### PR TITLE
Fairly nasty ownership control code, through datastore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,12 @@ before_install:
 - source "${HOME}/google-cloud-sdk/path.bash.inc"
 
 # Install test credentials.
-# These are uploaded to travis by doing this from within the repository
-# $ gcloud --project mlab-testing iam service-accounts keys create --iam-account go-travis-testing@mlab-testing.iam.gserviceaccount.com go_travis_testing.json
-# $ KEY="$(base64 go_travis_testing.json)"
-# $ travis env set TEST_SERVICE_ACCOUNT_mlab_testing "${KEY}"
+# These are uploaded to travis by invoking setup_service_accounts_for_travis.sh (from
+# the m-lab/travis repo), from a directory within *this* repo.
 #
+# New mechanism for setting up testing service account.
 # Note that anyone with github ACLs to push to a branch can hack .travis.yml
 # and discover these credentials in the travis logs.
-- if [[ -n "$TEST_SERVICE_ACCOUNT_mlab_testing" ]] ; then
-  echo "$TEST_SERVICE_ACCOUNT_mlab_testing" | base64 -d > travis-testing.key ;
-  fi
-# New mechanism for setting up testing service account.
 # TODO use version in travis directory.
 - if [[ -n "$SERVICE_ACCOUNT_mlab_testing" ]] ; then
   $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_testing ;
@@ -48,6 +43,7 @@ script:
   done
 - COVER_PKGS=${COVER_PKGS::-1}  # Trim the trailing comma
 - EC=0
+# Note that for modules in subdirectories, this replaces separating slashes with _.
 - for module in $MODULES; do
     go test -v -coverpkg=$COVER_PKGS -coverprofile=${module//\//_}.cov github.com/m-lab/etl-gardener/$module ;
     EC=$[ $EC || $? ] ;
@@ -61,7 +57,7 @@ script:
 # the non-integration tests are repeated.  If we change the unit tests to NOT run when integration
 # test tag is set, then we would need to have separate cov files.
 # Note: we do not run integration tests from forked PRs b/c the SA is unavailable.
-- EC=0
+# Note that for modules in subdirectories, this replaces separating slashes with _.
 - if [[ -n "$TEST_SERVICE_ACCOUNT_mlab_testing" ]] ; then
   for module in cloud/tq cmd/gardener ; do
     go test -v -coverpkg=$COVER_PKGS -coverprofile=${module//\//_}.cov github.com/m-lab/etl-gardener/$module -tags=integration ;

--- a/cloud/tq/tq_integration_test.go
+++ b/cloud/tq/tq_integration_test.go
@@ -23,9 +23,9 @@ func init() {
 func TestGetTaskqueueStats(t *testing.T) {
 	os.Setenv("PROJECT", "mlab-testing")
 	// TODO - use mlab-testing instead of mlab-sandbox??
-	//bucket, err := tq.GetBucket(Options(), "mlab-sandbox", "archive-mlab-test", true)
+	//bucket, err := tq.GetBucket(MLabTestAuth(), "mlab-sandbox", "archive-mlab-test", true)
 
-	q, err := tq.CreateQueuer(http.DefaultClient, Options(), "test-", 8, "mlab-sandbox", "archive-mlab-test", true)
+	q, err := tq.CreateQueuer(http.DefaultClient, MLabTestAuth(), "test-", 8, "mlab-sandbox", "archive-mlab-test", true)
 	stats, err := q.GetTaskqueueStats()
 	if err != nil {
 		t.Fatal(err)
@@ -40,7 +40,7 @@ func TestGetTaskqueueStats(t *testing.T) {
 // check that the bucket content has not been changed.
 func TestGetBucket(t *testing.T) {
 	bucketName := "archive-mlab-test"
-	bucket, err := tq.GetBucket(Options(), "mlab-testing", bucketName, false)
+	bucket, err := tq.GetBucket(MLabTestAuth(), "mlab-testing", bucketName, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,12 +72,12 @@ func TestGetBucket(t *testing.T) {
 // check that the bucket content has not been changed.
 func TestPostDay(t *testing.T) {
 	client, counter := tq.DryRunQueuerClient()
-	q, err := tq.CreateQueuer(client, Options(), "test-", 8, "fake-project", "archive-mlab-test", true)
+	q, err := tq.CreateQueuer(client, MLabTestAuth(), "test-", 8, "fake-project", "archive-mlab-test", true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	bucketName := "archive-mlab-test"
-	bucket, err := tq.GetBucket(Options(), "mlab-testing", bucketName, false)
+	bucket, err := tq.GetBucket(MLabTestAuth(), "mlab-testing", bucketName, false)
 	q.PostDay(nil, bucket, bucketName, "ndt/2017/09/24/")
 	if counter.Count() != 76 {
 		t.Errorf("Should have made 76 http requests: %d\n", counter.Count())

--- a/cloud/tq/tq_test.go
+++ b/cloud/tq/tq_test.go
@@ -14,10 +14,10 @@ func init() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
 
-func Options() []option.ClientOption {
+func MLabTestAuth() []option.ClientOption {
 	opts := []option.ClientOption{}
 	if os.Getenv("TRAVIS") != "" {
-		authOpt := option.WithCredentialsFile("../../travis-testing.key")
+		authOpt := option.WithAPIKey(os.Getenv("SERVICE_ACCOUNT_mlab_testing"))
 		opts = append(opts, authOpt)
 	}
 
@@ -28,7 +28,7 @@ func TestPostOneTask(t *testing.T) {
 	os.Setenv("PROJECT", "mlab-testing")
 	// TODO - use mlab-testing instead of mlab-sandbox??
 	client, counter := tq.DryRunQueuerClient()
-	q, err := tq.CreateQueuer(client, Options(), "test-", 8, "mlab-sandbox", "archive-mlab-test", true)
+	q, err := tq.CreateQueuer(client, MLabTestAuth(), "test-", 8, "mlab-sandbox", "archive-mlab-test", true)
 	q.PostOneTask("test-queue", "archive-mlab-test", "test-file")
 	if err != nil {
 		t.Fatal(err)

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -1,0 +1,241 @@
+// Package dispatch identifies dates to reprocess, and feeds them into
+// the reprocessing network.
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"log"
+	"math/rand"
+	"os"
+	"time"
+
+	"cloud.google.com/go/datastore"
+	"google.golang.org/api/option"
+)
+
+// ###############################################################################
+//  Ownership related code
+// ###############################################################################
+
+const (
+	// DSNamespace is the namespace for all gardener related DataStore entities.
+	DSNamespace = "Gardener"
+
+	// DSOwnerLeaseName is the name of the single OwnerLease object.
+	DSOwnerLeaseName = "OwnerLease"
+)
+
+var (
+	// TestMode controls datastore retry delays to allow faster testing.
+	TestMode = false
+)
+
+// Errors for leases
+var (
+	ErrLostLease          = errors.New("lost ownership lease")
+	ErrNotOwner           = errors.New("owner does not match instance")
+	ErrOwnershipRequested = errors.New("another instance has requested ownership")
+	ErrInvalidState       = errors.New("invalid owner lease state")
+	ErrNoSuchLease        = errors.New("lease does not exist")
+	ErrNotAvailable       = errors.New("lease not available")
+
+	ErrNoProject = errors.New("PROJECT environment variable not set")
+)
+
+// OwnerLease is a DataStore record that controls ownership of the reprocessing task.
+// An instance must own this before doing any reprocessing / dedupping operations.
+// It should be periodically renewed to avoid another instance taking ownership
+// without a handshake.
+// TODO - should this have a mutex?
+type OwnerLease struct {
+	InstanceID      string    // instance ID of the owner.
+	LeaseExpiration time.Time // Time that the lease will expire.
+	NewInstanceID   string    // ID of instance trying to assume ownership.
+
+	// These are not saved or retrieved from DataStore
+	namespace string
+	kind      string
+	client    *datastore.Client
+}
+
+// NewOwnerLease returns a properly initialized OwnerLease object.
+// Note this creates a datastore client, which may do network operations.
+func NewOwnerLease(instance, namespace, kind string, opts ...option.ClientOption) (*OwnerLease, error) {
+	var err error
+	var client *datastore.Client
+	project, ok := os.LookupEnv("PROJECT")
+	if !ok {
+		return nil, ErrNoProject
+	}
+	log.Println(project)
+	client, err = datastore.NewClient(context.Background(), project, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OwnerLease{instance, time.Now().Add(5 * time.Minute), "", namespace, kind, client}, nil
+}
+
+// NameKey creates a full key using the Saver settings.
+func (ol *OwnerLease) nameKey(name string) *datastore.Key {
+	k := datastore.NameKey(ol.kind, name, nil)
+	k.Namespace = ol.namespace
+	return k
+}
+
+// Validate checks that fields have been initialized.
+func (ol *OwnerLease) validate() error {
+	if ol.NewInstanceID != "" {
+		return ErrOwnershipRequested
+	}
+	if ol.InstanceID == "" {
+		log.Printf("%+v\n", ol)
+		return ErrInvalidState
+	}
+	return nil
+}
+
+// Renew renews the ownership lease for interval.
+// The receiver must have InstanceID already set.
+// TODO - should this run on a timer, or in a go routine?
+func (ol *OwnerLease) Renew(interval time.Duration) error {
+	err := ol.validate()
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+	k := ol.nameKey(DSOwnerLeaseName)
+	ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cf()
+	_, err = ol.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
+		var lease OwnerLease
+		err := tx.Get(k, &lease)
+		if err != nil {
+			return err
+		}
+		if lease.InstanceID != ol.InstanceID {
+			log.Println(ol.InstanceID, "lost lease to", lease.InstanceID)
+			return ErrLostLease
+		}
+
+		if lease.NewInstanceID != "" {
+			log.Println(lease.InstanceID, "relinquishing ownership to", lease.NewInstanceID)
+			if lease.LeaseExpiration.After(time.Now()) {
+				lease.LeaseExpiration = time.Now()
+				_, err = tx.Put(k, &lease)
+				if err != nil {
+					return err
+				}
+			}
+			return ErrOwnershipRequested
+		}
+
+		lease.LeaseExpiration = time.Now().Add(interval)
+		_, err = tx.Put(k, &lease)
+		return err
+	})
+	return err
+}
+
+// TakeOwnershipIfAvailable assumes ownership if no-one else owns it.
+func (ol *OwnerLease) takeOwnershipIfAvailable(interval time.Duration) error {
+	k := ol.nameKey(DSOwnerLeaseName)
+	ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cf()
+	_, err := ol.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
+		var lease OwnerLease
+		err := tx.Get(k, &lease)
+		// If lease is expired, or doesn't exist, go ahead and try to take it.
+		if err == datastore.ErrNoSuchEntity || lease.LeaseExpiration.Before(time.Now()) {
+			ol.LeaseExpiration = time.Now().Add(interval)
+			ol.NewInstanceID = ""
+			tx.Put(k, ol)
+			return nil
+		}
+		return ErrNotAvailable
+	})
+	return err
+}
+
+// RequestLease sets the NewInstanceID field to indicate that we want ownership.
+func (ol *OwnerLease) requestLease() error {
+	k := ol.nameKey(DSOwnerLeaseName)
+	ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cf()
+	_, err := ol.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
+		var lease OwnerLease
+		err := tx.Get(k, &lease)
+		if err != nil {
+			return err
+		}
+		if lease.NewInstanceID == "" {
+			lease.NewInstanceID = ol.InstanceID
+			log.Println(ol.InstanceID, "requesting lease from", lease.InstanceID)
+			_, err = tx.Put(k, &lease)
+		}
+		return err
+	})
+	return err
+}
+
+// WaitForOwnership retries TakeOwnershipIfAvailable until timeout or success.
+func (ol *OwnerLease) waitForOwnership(interval time.Duration) error {
+	for timeout := time.Now().Add(2 * time.Minute); time.Now().Before(timeout); {
+		log.Println("Trying again to get ownership", ol.InstanceID)
+		err := ol.takeOwnershipIfAvailable(interval)
+		if err != ErrNotAvailable {
+			return err
+		}
+		if TestMode {
+			time.Sleep(time.Duration(1) * time.Second)
+		} else {
+			time.Sleep(time.Duration(5+rand.Intn(10)) * time.Second)
+		}
+	}
+
+	return ErrNotAvailable
+}
+
+// Lease attempts to take ownership of the lease.
+// Expected to be attempted at startup, and process should fail health check
+// if this fails repeatedly.
+func (ol *OwnerLease) Lease(interval time.Duration) error {
+	if ol.validate() != nil {
+		return ol.validate()
+	}
+	err := ol.takeOwnershipIfAvailable(interval)
+	if err == nil {
+		return err
+	}
+	err = ol.requestLease()
+	if err != nil {
+		return err
+	}
+	err = ol.waitForOwnership(interval)
+	return err
+}
+
+// Delete deletes the lease iff held by ol.
+func (ol *OwnerLease) Delete() error {
+	k := ol.nameKey(DSOwnerLeaseName)
+	ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cf()
+	_, err := ol.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
+		var lease OwnerLease
+		err := tx.Get(k, &lease)
+		if err != nil {
+			return err
+		}
+		if lease.InstanceID == ol.InstanceID {
+			err = tx.Delete(k)
+			return err
+		}
+		return ErrNotOwner
+	})
+	return err
+}
+
+// ###############################################################################
+//  Dispatch interface and related code
+// ###############################################################################

--- a/dispatch/dispatch_integration_test.go
+++ b/dispatch/dispatch_integration_test.go
@@ -1,0 +1,81 @@
+package dispatch_test
+
+import (
+	"log"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m-lab/etl-gardener/dispatch"
+	"google.golang.org/api/option"
+)
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	dispatch.TestMode = true
+}
+
+func MLabTestAuth() []option.ClientOption {
+	opts := []option.ClientOption{}
+	if os.Getenv("TRAVIS") != "" {
+		authOpt := option.WithAPIKey(os.Getenv("SERVICE_ACCOUNT_mlab_testing"))
+		opts = append(opts, authOpt)
+	}
+	return opts
+}
+
+// TODO - use random saver namespace to avoid collisions between multiple testers.
+// TODO - use datastore emulator
+func TestOwnerLease_Lease(t *testing.T) {
+	os.Setenv("PROJECT", "mlab-testing")
+	// TODO - should use emulator
+	ol1, err := dispatch.NewOwnerLease("instance1", "gardener", "test", MLabTestAuth()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ol2, err := dispatch.NewOwnerLease("instance2", "gardener", "test", MLabTestAuth()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ol1.Lease(10 * time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Println("instance1 has ownership")
+
+	var ol2err error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		ol2err = ol2.Lease(10 * time.Second)
+		wg.Done()
+	}()
+
+	time.Sleep(2 * 2 * time.Second)
+	// This should notice the request, and relinquish ownership.
+	err = ol1.Renew(2 * time.Second)
+	if err != dispatch.ErrOwnershipRequested {
+		log.Println(err)
+	}
+
+	wg.Wait()
+	if ol2err != nil {
+		t.Fatal(ol2err)
+	}
+
+	err = ol1.Renew(2 * time.Second)
+	if err != dispatch.ErrLostLease {
+		t.Fatal("Should have lost lease:", err)
+	}
+	err = ol1.Delete()
+	if err != dispatch.ErrNotOwner {
+		t.Error(err)
+	}
+	err = ol2.Delete()
+	if err != err {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
RETARGET and SUBMIT AFTER basic-2a
This is a bit of messy code for handling ownership reservations, yielding, taking over, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/7)
<!-- Reviewable:end -->
