### PR TITLE
More queuehandler stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
 
 script:
 # To start, run all the non-integration tests.
-- MODULES="cloud/tq cmd/gardener"
+- MODULES="dispatch cloud/tq cmd/gardener"
 - for module in $MODULES; do
     COVER_PKGS=${COVER_PKGS}./$module/..., ;
   done
@@ -72,7 +72,7 @@ script:
 # Note: we do not run integration tests from forked PRs b/c the SA is unavailable.
 # Note that for modules in subdirectories, this replaces separating slashes with _.
 - if [[ -n "$SERVICE_ACCOUNT_mlab_testing" ]] ; then
-  for module in cloud/tq cmd/gardener ; do
+  for module in dispatch cloud/tq cmd/gardener ; do
     go test -v -coverpkg=$COVER_PKGS -coverprofile=${module//\//_}.cov github.com/m-lab/etl-gardener/$module -tags=integration ;
     EC=$[ $EC || $? ] ;
   done ;

--- a/cloud/tq/tq_integration_test.go
+++ b/cloud/tq/tq_integration_test.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 func TestGetTaskqueueStats(t *testing.T) {
-	stats, err := tq.GetTaskqueueStats("mlab-sandbox", "test-queue")
+	stats, err := tq.GetTaskqueueStats(http.DefaultClient, "mlab-sandbox", "test-queue")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -118,13 +118,13 @@ func runService() {
 	http.HandleFunc("/alive", healthCheck)
 	http.HandleFunc("/ready", healthCheck)
 
-	q, err := queuerFromEnv()
+	disp, err := dispatch.NewDispatcher()
 	if err != nil {
 		log.Println(err)
 		// leaving healthy = false should eventually lead to rollback.
 	} else {
 		// TODO - add termination channel.
-		go dispatch.DoDispatchLoop(q)
+		go disp.DoDispatchLoop()
 
 		healthy = true
 	}

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -3,11 +3,12 @@
 package dispatch
 
 import (
+	"fmt"
 	"log"
 	"math/rand"
+	"net/http"
+	"reflect"
 	"time"
-
-	"github.com/m-lab/etl-gardener/cloud/tq"
 )
 
 // DESIGN:
@@ -17,19 +18,64 @@ import (
 // We don't care which queue a date goes to.  Only reason for multiple queues is to rate
 // limit each individual day.
 
+// Dispatcher globals
+type Dispatcher struct {
+	Queues []chan<- string
+	Done   []<-chan bool
+
+	StartDate time.Time
+}
+
+// HACK
+func NewDispatcher() (*Dispatcher, error) {
+	queues := make([]chan<- string, 0, 4)
+	done := make([]<-chan bool, 0, 4)
+	for i := 0; i < 4; i++ {
+		q, d, err := NewChannelQueueHandler(http.DefaultClient, "mlab-testing",
+			fmt.Sprintf("test-queue-%d", i))
+		if err != nil {
+			return nil, err
+		}
+		queues = append(queues, q)
+		done = append(done, d)
+	}
+
+	return &Dispatcher{queues, done,
+		time.Now().AddDate(0, 0, -10)}, nil
+}
+
+// Kill closes all the channels, and waits for all the dones.
+func (disp *Dispatcher) Kill() {
+	for i := range disp.Queues {
+		close(disp.Queues[i])
+	}
+	// Wait for all of the done events.
+	for i := range disp.Done {
+		<-disp.Done[i]
+	}
+}
+
+// Add will post the request to next available queue.
+func (disp *Dispatcher) Add(prefix string) {
+	// Easiest to do this on the fly, since it requires the prefix in the cases.
+	cases := make([]reflect.SelectCase, 0, len(disp.Queues))
+	for i := range disp.Queues {
+		cases = append(cases, reflect.SelectCase{reflect.SelectSend,
+			reflect.ValueOf(disp.Queues[i]), reflect.ValueOf(prefix)})
+	}
+	reflect.Select(cases)
+}
+
 // DoDispatchLoop looks for next work to do.
+// It should generally be blocked on the queues.
 // TODO - Just for proof of concept. Replace with more useful code.
-func DoDispatchLoop(queuer *tq.QueueHandler) {
+func (disp *Dispatcher) DoDispatchLoop() {
 	for {
 		log.Println("Dispatch Loop")
 		// TODO - add content.
 
-		stats, err := tq.GetTaskqueueStats(queuer.Project, queuer.Queue)
-		if err != nil {
-			log.Println(err)
-		}
-		log.Println(stats)
+		disp.Add("gs://bucket/foobar/2017/01/02/")
 
-		time.Sleep(time.Duration(30+rand.Intn(60)) * time.Second)
+		time.Sleep(time.Duration(10+rand.Intn(20)) * time.Second)
 	}
 }

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -10,6 +10,13 @@ import (
 	"github.com/m-lab/etl-gardener/cloud/tq"
 )
 
+// DESIGN:
+// There will be N channels that will handle posting to queue, waiting for queue drain,
+// and deduplication and cleanup.
+// The dispatch loop will simply step through days, submitting dates to the input queue.
+// We don't care which queue a date goes to.  Only reason for multiple queues is to rate
+// limit each individual day.
+
 // DoDispatchLoop looks for next work to do.
 // TODO - Just for proof of concept. Replace with more useful code.
 func DoDispatchLoop(queuer *tq.QueueHandler) {

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -1,1 +1,0 @@
-package dispatch_test

--- a/dispatch/queuehandler.go
+++ b/dispatch/queuehandler.go
@@ -1,0 +1,89 @@
+package dispatch
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"regexp"
+
+	"github.com/m-lab/etl-gardener/cloud/tq"
+)
+
+// ChannelQueueHandler is an autonomous queue handler running in a go
+// routine, fed by a channel.
+type ChannelQueueHandler struct {
+	*tq.QueueHandler
+	Channel chan string
+}
+
+const start = `^gs://(?P<bucket>.*)/(?P<exp>[^/]*)/`
+const datePath = `(?P<datepath>\d{4}/[01]\d/[0123]\d)/`
+
+// These are here to facilitate use across queue-pusher and parsing components.
+var (
+	// This matches any valid test file name, and some invalid ones.
+	prefixPattern = regexp.MustCompile(start + // #1 #2
+		datePath) // #3 - YYYY/MM/DD
+)
+
+// Parses prefix, returning {bucket, experiment, date string}, error
+func parsePrefix(prefix string) ([]string, error) {
+	fields := prefixPattern.FindStringSubmatch(prefix)
+
+	if fields == nil {
+		return nil, errors.New("Invalid test path: " + prefix)
+	}
+	if len(fields) < 4 {
+		return nil, errors.New("Path does not include all fields: " + prefix)
+	}
+	return fields, nil
+}
+
+// StartHandleLoop starts a go routine that waits for work on channel, and
+// processes it.  Returns a channel that will send true when input channel is closed.
+func (chq *ChannelQueueHandler) StartHandleLoop() <-chan bool {
+	done := make(chan bool)
+	go func() {
+		for {
+			// TODO - should block here until queue is empty
+			prefix, more := <-chq.Channel
+			if more {
+				// Use proper storage bucket.
+				parts, err := parsePrefix(prefix)
+				if err != nil {
+					log.Println(err)
+					continue
+				}
+				bucketName := parts[1]
+				bucket, err := tq.GetBucket(nil, chq.Project, bucketName, false)
+				//bucket, err := chq.getBucket(bucketName)
+				if err != nil {
+					log.Println(err)
+					continue
+				}
+				log.Println(parts)
+				chq.PostDay(bucket, bucketName, parts[2]+"/"+parts[3]+"/")
+			} else {
+				done <- true
+				break
+			}
+		}
+	}()
+	return done
+}
+
+// NewChannelQueueHandler creates a new QueueHandler, sets up a go routine to feed it
+// from a channel.
+// Returns feeding channel, and done channel, which will return true when
+// feeding channel is closed, and processing is complete.
+func NewChannelQueueHandler(httpClient *http.Client, project, queue string) (chan<- string, <-chan bool, error) {
+	qh, err := tq.NewQueueHandler(httpClient, project, queue)
+	if err != nil {
+		return nil, nil, err
+	}
+	ch := make(chan string)
+	cqh := ChannelQueueHandler{qh, ch}
+
+	done := cqh.StartHandleLoop()
+	return ch, done, nil
+}

--- a/dispatch/queuehandler.go
+++ b/dispatch/queuehandler.go
@@ -63,20 +63,22 @@ func (chq *ChannelQueueHandler) StartHandleLoop() <-chan bool {
 						// Wait 5 seconds before checking again.
 						time.Sleep(time.Duration(5+rand.Intn(10)) * time.Second)
 					} else if err != nil {
+						// We don't expect errors here, so try logging, and a large backoff
+						// in case there is some bad network condition, service failure,
+						// or perhaps the queue_pusher is down.
 						log.Println(err)
 						time.Sleep(time.Duration(60+rand.Intn(120)) * time.Second)
 					}
 				}
 
 				log.Println(parts)
-				time.Sleep(time.Duration(10) * time.Minute)
-				// bucketName := parts[1]
-				// bucket, err := tq.GetBucket(nil, chq.Project, bucketName, false)
-				// if err != nil {
-				//	 log.Println(err)
-				//	 continue
-				// }
-				// chq.PostDay(bucket, bucketName, parts[2]+"/"+parts[3]+"/")
+				bucketName := parts[1]
+				bucket, err := tq.GetBucket(nil, chq.Project, bucketName, false)
+				if err != nil {
+					log.Println(err)
+					continue
+				}
+				chq.PostDay(bucket, bucketName, parts[2]+"/"+parts[3]+"/")
 			} else {
 				done <- true
 				break

--- a/dispatch/queuehandler_test.go
+++ b/dispatch/queuehandler_test.go
@@ -25,7 +25,9 @@ func TestChannelQueueHandler(t *testing.T) {
 	}
 	close(c)
 	<-d
-	if counter.Count() != 76 {
+	// There will be one http request for each IsEmpty() call, and one for each task file.
+	if counter.Count() != 86 {
+		log.Println(counter.Count())
 		t.Error("Count != 76")
 	}
 }

--- a/dispatch/queuehandler_test.go
+++ b/dispatch/queuehandler_test.go
@@ -1,0 +1,31 @@
+package dispatch_test
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/m-lab/etl-gardener/cloud/tq"
+	"github.com/m-lab/etl-gardener/dispatch"
+)
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+func TestChannelQueueHandler(t *testing.T) {
+	client, counter := tq.DryRunQueuerClient()
+	c, d, err := dispatch.NewChannelQueueHandler(client, "mlab-testing", "test-queue")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 19; i < 29; i++ {
+		c <- fmt.Sprintf("gs://archive-mlab-test/ndt/2017/09/%2d/", i)
+	}
+	close(c)
+	<-d
+	if counter.Count() != 76 {
+		t.Error("Count != 76")
+	}
+}


### PR DESCRIPTION
Adds a channel driven wrapper around QueueHandler.  It includes a processing loop that runs indefinitely, waiting on requests channel, and delaying submission to queue until queue is empty.

Implements Dispatcher, that wraps a slice of queues, and sends requests to any queue that is currently empty.  Currently just prints job name instead of actually queuing.

Prototype driver in gardener, that demos use of queue.