### PR TITLE
fix etl refs

### DIFF
--- a/dedup/dedup.go
+++ b/dedup/dedup.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/go/bqext"
 	"golang.org/x/net/context"
 	"google.golang.org/api/iterator"
@@ -210,7 +209,10 @@ func GetTablesMatching(ctx context.Context, dsExt *bqext.Dataset, filter string)
 	return alt, nil
 }
 
-var denseDateSuffix = regexp.MustCompile(`(.*)([_$])(` + etl.YYYYMMDD + `)$`)
+// YYYYMMDD matches valid dense year/month/date strings
+const YYYYMMDD = `\d{4}[01]\d[0123]\d`
+
+var denseDateSuffix = regexp.MustCompile(`(.*)([_$])(` + YYYYMMDD + `)$`)
 
 // tableNameParts is used to describe a templated table or table partition.
 type tableNameParts struct {

--- a/dedup/dedup_integration_test.go
+++ b/dedup/dedup_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-lab/etl/dedup"
+	"github.com/m-lab/etl-gardener/dedup"
 	"github.com/m-lab/go/bqext"
 )
 


### PR DESCRIPTION
Previously copied dedup code from etl repo.  This removes all references to the etl/dedup, which has been deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/16)
<!-- Reviewable:end -->
