### PR TITLE
Implement dedup as second goroutine

### DIFF
--- a/cloud/tq/queuehandler.go
+++ b/cloud/tq/queuehandler.go
@@ -90,7 +90,6 @@ func (qh *ChannelQueueHandler) processOneRequest(prefix string, bucketOpts ...op
 	if err != nil {
 		// If there is a parse error, log and skip request.
 		log.Println(err)
-		// TODO update metric
 		metrics.FailCount.WithLabelValues("BadPrefix").Inc()
 		return 0, err
 	}

--- a/cloud/tq/queuehandler.go
+++ b/cloud/tq/queuehandler.go
@@ -83,7 +83,8 @@ func (qh *ChannelQueueHandler) waitForEmptyQueue() {
 }
 
 // processOneRequest waits on the channel for a new request, and handles it.
-func (qh *ChannelQueueHandler) processOneRequest(prefix string, bucketOpts ...option.ClientOption) error {
+// Returns number of items posted, or error
+func (qh *ChannelQueueHandler) processOneRequest(prefix string, bucketOpts ...option.ClientOption) (int, error) {
 	// Use proper storage bucket.
 	parts, err := ParsePrefix(prefix)
 	if err != nil {
@@ -91,38 +92,45 @@ func (qh *ChannelQueueHandler) processOneRequest(prefix string, bucketOpts ...op
 		log.Println(err)
 		// TODO update metric
 		metrics.FailCount.WithLabelValues("BadPrefix").Inc()
-		return err
+		return 0, err
 	}
 	bucketName := parts[1]
 	bucket, err := GetBucket(bucketOpts, qh.Project, bucketName, false)
 	if err != nil {
 		log.Println(err)
 		metrics.FailCount.WithLabelValues("BucketError").Inc()
-		return err
+		return 0, err
 	}
-	qh.PostDay(bucket, bucketName, parts[2]+"/"+parts[3]+"/")
-	return nil
+	n, err := qh.PostDay(bucket, bucketName, parts[2]+"/"+parts[3]+"/")
+	if err != nil {
+		log.Println(err)
+		metrics.FailCount.WithLabelValues("PostDayError").Inc()
+	}
+	return n, err
 }
 
 // handleLoop processes requests on input channel
 func (qh *ChannelQueueHandler) handleLoop(next api.BasicPipe, bucketOpts ...option.ClientOption) {
 	log.Println("Starting handler for", qh.Queue)
+	qh.waitForEmptyQueue()
 	for {
-		qh.waitForEmptyQueue()
-
 		prefix, more := <-qh.MsgChan
 		if !more {
 			close(qh.ResponseChan)
 			break
 		}
-		err := qh.processOneRequest(prefix, bucketOpts...)
-		if err == nil {
-			// This may block if previous hasn't finished.  Should be rare.
-			if next != nil {
-				next.Sink() <- prefix
-			}
-		} else {
+		n, err := qh.processOneRequest(prefix, bucketOpts...)
+		if err != nil {
 			// TODO return error through Response()
+		}
+
+		// Must wait for empty queue before proceeding with dedupping.
+		// This ensures that the data has actually been processed, rather
+		// than just sitting in the queue or in the pipeline.
+		qh.waitForEmptyQueue()
+		// This may block if previous hasn't finished.  Should be rare.
+		if n > 0 && next != nil {
+			next.Sink() <- prefix
 		}
 	}
 	log.Println("Exiting handler for", qh.Queue)

--- a/cloud/tq/tq.go
+++ b/cloud/tq/tq.go
@@ -262,7 +262,6 @@ func (qh *QueueHandler) PostAll(bucket string, it *storage.ObjectIterator) (int,
 // PostDay fetches an iterator over the objects with ndt/YYYY/MM/DD prefix,
 // and passes the iterator to postDay with appropriate queue.
 // This typically takes about 10 minutes for a 20K task NDT day.
-// TODO return the count of items posted.
 func (qh *QueueHandler) PostDay(bucket *storage.BucketHandle, bucketName, prefix string) (int, error) {
 	log.Println("Adding ", prefix, " to ", qh.Queue)
 	qry := storage.Query{

--- a/cloud/tq/tq.go
+++ b/cloud/tq/tq.go
@@ -223,7 +223,7 @@ func (qh *QueueHandler) postWithRetry(bucket, filepath string) error {
 }
 
 // PostAll posts all normal file items in an ObjectIterator into the appropriate queue.
-func (qh *QueueHandler) PostAll(bucket string, it *storage.ObjectIterator) error {
+func (qh *QueueHandler) PostAll(bucket string, it *storage.ObjectIterator) (int, error) {
 	fileCount := 0
 	defer func() {
 		log.Println("Added ", fileCount, " tasks to ", qh.Queue)
@@ -239,7 +239,7 @@ func (qh *QueueHandler) PostAll(bucket string, it *storage.ObjectIterator) error
 			gcsErrCount++
 			if gcsErrCount > 5 {
 				log.Printf("Failed after %d files to %s.\n", fileCount, qh.Queue)
-				return err
+				return 0, err
 			}
 			continue
 		}
@@ -250,20 +250,20 @@ func (qh *QueueHandler) PostAll(bucket string, it *storage.ObjectIterator) error
 			qpErrCount++
 			if qpErrCount > 5 {
 				log.Printf("Failed after %d files to %s (on %s).\n", fileCount, qh.Queue, o.Name)
-				return err
+				return 0, err
 			}
 		} else {
 			fileCount++
 		}
 	}
-	return nil
+	return fileCount, nil
 }
 
 // PostDay fetches an iterator over the objects with ndt/YYYY/MM/DD prefix,
 // and passes the iterator to postDay with appropriate queue.
 // This typically takes about 10 minutes for a 20K task NDT day.
 // TODO return the count of items posted.
-func (qh *QueueHandler) PostDay(bucket *storage.BucketHandle, bucketName, prefix string) error {
+func (qh *QueueHandler) PostDay(bucket *storage.BucketHandle, bucketName, prefix string) (int, error) {
 	log.Println("Adding ", prefix, " to ", qh.Queue)
 	qry := storage.Query{
 		Delimiter: "/",

--- a/cloud/tq/tq_integration_test.go
+++ b/cloud/tq/tq_integration_test.go
@@ -85,7 +85,13 @@ func TestPostDay(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	q.PostDay(bucket, bucketName, "ndt/2017/09/24/")
+	n, err := q.PostDay(bucket, bucketName, "ndt/2017/09/24/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 76 {
+		t.Errorf("Should have posted 76 items")
+	}
 	if counter.Count() != 76 {
 		t.Errorf("Should have made 76 http requests: %d\n", counter.Count())
 	}

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -95,8 +95,8 @@ func (disp *Dispatcher) Add(prefix string) error {
 	return nil
 }
 
-// DoDispatchLoop looks for next work to do.
-// It should generally be blocked on the queues.
+// DoDispatchLoop just sequences through archives in date order.
+// It will generally be blocked on the queues.
 func (disp *Dispatcher) DoDispatchLoop(bucket string, experiments []string) {
 	next := disp.StartDate
 

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -42,8 +42,12 @@ func NewDispatcher(httpClient *http.Client, project, queueBase string, numQueues
 	handlers := make([]api.BasicPipe, 0, numQueues)
 	for i := 0; i < numQueues; i++ {
 		queue := fmt.Sprintf("%s%d", queueBase, i)
+		// First build the dedup handler.
+		dedup := NewDedupHandler()
+		// Build QueueHandler that chains to dedup handler.
+
 		cqh, err := tq.NewChannelQueueHandler(httpClient, project,
-			queue, nil, bucketOpts...)
+			queue, dedup, bucketOpts...)
 		if err != nil {
 			return nil, err
 		}

--- a/k8s/data-processing-cluster/deployments/etl-gardener.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener.yml
@@ -41,12 +41,14 @@ spec:
           value: "true"
         - name:  GIT_COMMIT
           value: "{{GIT_COMMIT}}"
-        - name: TASKFILE_BUCKET
-          value: "archive-{{GCLOUD_PROJECT}}"
-        - name: EXPERIMENTS
-          value: "ndt,sidestream"  # For example "ndt,sidestream,switch"
         - name: PROJECT
           value: {{GCLOUD_PROJECT}}
+        - name: TASKFILE_BUCKET
+          value: "archive-{{GCLOUD_PROJECT}}"
+        - name: START_DATE
+          value: "20170501"
+        - name: EXPERIMENTS
+          value: "ndt,sidestream"  # For example "ndt,sidestream,switch"
         - name: DATASET
           value: batch
         - name: QUEUE_BASE

--- a/k8s/data-processing-cluster/deployments/etl-gardener.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener.yml
@@ -44,7 +44,7 @@ spec:
         - name: TASKFILE_BUCKET
           value: "gfr"  # "archive-{{GCLOUD_PROJECT}}"
         - name: EXPERIMENTS
-          value: "sidestream"  # For example "ndt,sidestream,disco"
+          value: "ndt,sidestream"  # For example "ndt,sidestream,disco"
         - name: PROJECT
           value: {{GCLOUD_PROJECT}}
         - name: DATASET

--- a/k8s/data-processing-cluster/deployments/etl-gardener.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener.yml
@@ -42,13 +42,13 @@ spec:
         - name:  GIT_COMMIT
           value: "{{GIT_COMMIT}}"
         - name: TASKFILE_BUCKET
-          value: "gfr"  # "archive-{{GCLOUD_PROJECT}}"
+          value: "archive-{{GCLOUD_PROJECT}}"
         - name: EXPERIMENTS
-          value: "ndt,sidestream"  # For example "ndt,sidestream,disco"
+          value: "ndt,sidestream"  # For example "ndt,sidestream,switch"
         - name: PROJECT
           value: {{GCLOUD_PROJECT}}
         - name: DATASET
-          value: gfr
+          value: batch
         - name: QUEUE_BASE
           value: etl-ndt-batch-
         - name: NUM_QUEUES

--- a/k8s/data-processing-cluster/deployments/etl-gardener.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener.yml
@@ -48,7 +48,7 @@ spec:
         - name: PROJECT
           value: {{GCLOUD_PROJECT}}
         - name: DATASET
-          value: batch
+          value: gfr
         - name: QUEUE_BASE
           value: etl-ndt-batch-
         - name: NUM_QUEUES

--- a/k8s/data-processing-cluster/deployments/etl-gardener.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener.yml
@@ -42,9 +42,9 @@ spec:
         - name:  GIT_COMMIT
           value: "{{GIT_COMMIT}}"
         - name: TASKFILE_BUCKET
-          value: "archive-{{GCLOUD_PROJECT}}"
+          value: "gfr"  # "archive-{{GCLOUD_PROJECT}}"
         - name: EXPERIMENTS
-          value: "ndt"  # For example "ndt,sidestream,switch"
+          value: "sidestream"  # For example "ndt,sidestream,disco"
         - name: PROJECT
           value: {{GCLOUD_PROJECT}}
         - name: DATASET


### PR DESCRIPTION
1.  Add counter to PostDay result so we know whether any tasks were posted.
2.  Wait for empty queue before accepting new prefix
3.  Chain dedup handler to queue handler.
4.  Conditionally forward prefix to dedup after successfully processing a day.
5.  Get start/restart date from environment instead of hard-coding.  Eventually this will come from datastore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/33)
<!-- Reviewable:end -->
