### PR TITLE
Adds timeouts for waitForStableTable

### DIFF
--- a/cloud/tq/queuehandler.go
+++ b/cloud/tq/queuehandler.go
@@ -105,6 +105,7 @@ func (qh *ChannelQueueHandler) processOneRequest(prefix string, bucketOpts ...op
 		log.Println(err)
 		metrics.FailCount.WithLabelValues("PostDayError").Inc()
 	}
+	log.Println("Added ", n, prefix, " tasks to ", qh.Queue)
 	return n, err
 }
 
@@ -121,6 +122,7 @@ func (qh *ChannelQueueHandler) handleLoop(next api.BasicPipe, bucketOpts ...opti
 		n, err := qh.processOneRequest(prefix, bucketOpts...)
 		if err != nil {
 			// TODO return error through Response()
+			// Currently, processOneRequest logs error and increments metric.
 		}
 
 		// Must wait for empty queue before proceeding with dedupping.

--- a/cloud/tq/tq.go
+++ b/cloud/tq/tq.go
@@ -225,10 +225,6 @@ func (qh *QueueHandler) postWithRetry(bucket, filepath string) error {
 // PostAll posts all normal file items in an ObjectIterator into the appropriate queue.
 func (qh *QueueHandler) PostAll(bucket string, it *storage.ObjectIterator) (int, error) {
 	fileCount := 0
-	defer func() {
-		log.Println("Added ", fileCount, " tasks to ", qh.Queue)
-	}()
-
 	qpErrCount := 0
 	gcsErrCount := 0
 	for o, err := it.Next(); err != iterator.Done; o, err = it.Next() {
@@ -270,7 +266,8 @@ func (qh *QueueHandler) PostDay(bucket *storage.BucketHandle, bucketName, prefix
 	}
 	// TODO - can this error?  Or do errors only occur on iterator ops?
 	it := bucket.Objects(context.Background(), &qry)
-	return qh.PostAll(bucketName, it)
+	fileCount, err := qh.PostAll(bucketName, it)
+	return fileCount, err
 }
 
 // *******************************************************************

--- a/cloud/tq/tq.go
+++ b/cloud/tq/tq.go
@@ -266,8 +266,7 @@ func (qh *QueueHandler) PostDay(bucket *storage.BucketHandle, bucketName, prefix
 	}
 	// TODO - can this error?  Or do errors only occur on iterator ops?
 	it := bucket.Objects(context.Background(), &qry)
-	fileCount, err := qh.PostAll(bucketName, it)
-	return fileCount, err
+	return qh.PostAll(bucketName, it)
 }
 
 // *******************************************************************


### PR DESCRIPTION
There are some conditions that are causing indefinite looping waiting for the table.  Looks like it just never is visible - not clear why.
* This adds a timeout, so that it doesn't loop forever, but generates an error.
* Reorganize the for loop to separate looping and error handling.
* Add more logging to improve debugging.

Also adds more logging to help debug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/35)
<!-- Reviewable:end -->
