### PR TITLE
Queue check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,7 @@ deploy:
   on:
     repo: m-lab/etl-gardener
     all_branches: true
-    condition: $TRAVIS_BRANCH == staging-* && $TRAVIS_EVENT_TYPE == push
+    condition: $TRAVIS_BRANCH == master && $TRAVIS_EVENT_TYPE == push
 
 #########################################
 ## Production

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,7 @@ deploy:
   on:
     repo: m-lab/etl-gardener
     all_branches: true
-    condition: $TRAVIS_BRANCH == master && $TRAVIS_EVENT_TYPE == push
+    condition: $TRAVIS_BRANCH == staging-* && $TRAVIS_EVENT_TYPE == push
 
 #########################################
 ## Production
@@ -146,4 +146,5 @@ deploy:
   skip_cleanup: true
   on:
     repo: m-lab/etl-gardener
-    tags: true
+    all_branches: true
+    condition: $TRAVIS_TAG == prod-*

--- a/cloud/tq/queuehandler.go
+++ b/cloud/tq/queuehandler.go
@@ -2,6 +2,7 @@ package tq
 
 import (
 	"errors"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -81,6 +82,10 @@ func (qh *ChannelQueueHandler) waitForEmptyQueue() {
 	for {
 		stats, err := GetTaskqueueStats(qh.HTTPClient, qh.Project, qh.Queue)
 		if err != nil {
+			if err == io.EOF {
+				log.Println(err, "GetTaskqueueStats returned EOF - test client?")
+				return
+			}
 			// We don't expect errors here, so log and retry,
 			// in case there is some bad network condition, service failure,
 			// or perhaps the queue_pusher is down.

--- a/cloud/tq/queuehandler.go
+++ b/cloud/tq/queuehandler.go
@@ -77,7 +77,7 @@ func (qh *ChannelQueueHandler) waitForEmptyQueue() {
 	// Don't want to accept a date until we can actually queue it.
 	log.Println("Wait for empty queue ", qh.Queue)
 	var lastValid taskqueue.QueueStatistics
-	inactiveStartTime := time.Now()
+	inactiveStartTime := time.Now() // If the queue is actually empty, this allows timeout.
 	nullTime := time.Time{}
 	for {
 		stats, err := GetTaskqueueStats(qh.HTTPClient, qh.Project, qh.Queue)
@@ -109,7 +109,7 @@ func (qh *ChannelQueueHandler) waitForEmptyQueue() {
 				break
 			}
 			log.Printf("Suspicious (%s): %+v\n", qh.Queue, stats)
-			if time.Since(inactiveStartTime) > 120*time.Second {
+			if time.Since(inactiveStartTime) > 180*time.Second {
 				// It's been long enough to assume the queue is really empty.
 				log.Printf("Timeout. (%s) Last valid was: %+v", qh.Queue, lastValid)
 				break

--- a/cloud/tq/queuehandler.go
+++ b/cloud/tq/queuehandler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/m-lab/etl-gardener/api"
 	"github.com/m-lab/etl-gardener/metrics"
 	"google.golang.org/api/option"
+	"google.golang.org/appengine/taskqueue"
 )
 
 // ChannelQueueHandler is an autonomous queue handler running in a go
@@ -63,14 +64,23 @@ func ParsePrefix(prefix string) ([]string, error) {
 var ErrChannelClosed = errors.New("source channel closed")
 
 // waitForEmptyQueue loops checking queue until empty.
+// There is a bug in task queue status (from AppEngine) which causes it to
+// occasionally (a few times a day) return all zeros. This erronious report
+// seems to persist for a minute or more.  This is indistinguishable
+// from an actual empty queue, so we use a slightly different criteria:
+//  1. If queue was most recently 0 pending, >0 in flight, then we trust
+//     trust the empty queue state.
+//  2. If queue most recently had >0 pending, then we assume a zero state may
+//     be spurious, and check two more times over the next two minutes or so.
 func (qh *ChannelQueueHandler) waitForEmptyQueue() {
 	// Don't want to accept a date until we can actually queue it.
 	log.Println("Wait for empty queue ", qh.Queue)
-	for err := qh.IsEmpty(); err != nil; err = qh.IsEmpty() {
-		if err == ErrMoreTasks {
-			// Wait 5-15 seconds before checking again.
-			time.Sleep(time.Duration(5+rand.Intn(10)) * time.Second)
-		} else if err != nil {
+	var lastValid taskqueue.QueueStatistics
+	inactiveStartTime := time.Now()
+	nullTime := time.Time{}
+	for {
+		stats, err := GetTaskqueueStats(qh.HTTPClient, qh.Project, qh.Queue)
+		if err != nil {
 			// We don't expect errors here, so try logging, and a large backoff
 			// in case there is some bad network condition, service failure,
 			// or perhaps the queue_pusher is down.
@@ -78,7 +88,34 @@ func (qh *ChannelQueueHandler) waitForEmptyQueue() {
 			metrics.WarningCount.WithLabelValues("IsEmptyError").Inc()
 			// TODO update metric
 			time.Sleep(time.Duration(60+rand.Intn(120)) * time.Second)
+			continue
 		}
+		if stats.Tasks > 0 || stats.InFlight > 0 {
+			// Good data, queue is not empty...
+			lastValid = stats
+			inactiveStartTime = nullTime
+		} else if stats.Executed1Minute > 0 {
+			log.Printf("Looks good: %+v vs %+v", stats, lastValid)
+			break // Likely valid empty queue.
+		} else {
+			// Record the first time we see an apparently empty queue.
+			if inactiveStartTime == nullTime {
+				inactiveStartTime = time.Now()
+			}
+			if lastValid.Tasks == 0 {
+				// Most likely we really are done now.  Even if something is still
+				// in flight, we will just assume it is likely to finish.
+				break
+			}
+			log.Printf("Suspicious: %+v", stats)
+			if time.Since(inactiveStartTime) > 120*time.Second {
+				// It's been long enough to assume the queue is really empty.
+				log.Printf("Timeout.  Last valid was: %+v", lastValid)
+				break
+			}
+		}
+		// Check about once every minute.
+		time.Sleep(time.Duration(30+rand.Intn(60)) * time.Second)
 	}
 }
 

--- a/cloud/tq/queuehandler.go
+++ b/cloud/tq/queuehandler.go
@@ -96,7 +96,7 @@ func (qh *ChannelQueueHandler) waitForEmptyQueue() {
 			lastValid = stats
 			inactiveStartTime = nullTime
 		} else if stats.Executed1Minute > 0 {
-			log.Printf("Looks good: %+v vs %+v", stats, lastValid)
+			log.Printf("Looks good (%s): %+v vs %+v", qh.Queue, stats, lastValid)
 			break // Likely valid empty queue.
 		} else {
 			// Record the first time we see an apparently empty queue.
@@ -108,10 +108,10 @@ func (qh *ChannelQueueHandler) waitForEmptyQueue() {
 				// in flight, we will just assume it is likely to finish.
 				break
 			}
-			log.Printf("Suspicious: %+v", stats)
+			log.Printf("Suspicious (%s): %+v\n", qh.Queue, stats)
 			if time.Since(inactiveStartTime) > 120*time.Second {
 				// It's been long enough to assume the queue is really empty.
-				log.Printf("Timeout.  Last valid was: %+v", lastValid)
+				log.Printf("Timeout. (%s) Last valid was: %+v", qh.Queue, lastValid)
 				break
 			}
 		}

--- a/cloud/tq/tq.go
+++ b/cloud/tq/tq.go
@@ -152,10 +152,6 @@ func GetTaskqueueStats(client *http.Client, project string, name string) (stats 
 	var n int
 	n, err = io.ReadFull(resp.Body, data)
 	if err != io.ErrUnexpectedEOF {
-		if err == io.EOF {
-			log.Println(err, "No content from task queue request - test client?")
-			err = nil
-		}
 		return
 	}
 	var statsSlice []taskqueue.QueueStatistics


### PR DESCRIPTION
Adds a workaround for flaky QueueStatistics from task queues.
See large comment block in queuehandler.go for more info.

Also tweaks the prod deployment tag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/40)
<!-- Reviewable:end -->
