### PR TITLE
fix bug

### DIFF
--- a/cloud/tq/queuehandler.go
+++ b/cloud/tq/queuehandler.go
@@ -112,7 +112,7 @@ func (qh *ChannelQueueHandler) waitForEmptyQueue() {
 			}
 			log.Printf("Suspicious (%s): %+v\n", qh.Queue, stats)
 		}
-		if time.Since(inactiveStartTime) > 180*time.Second {
+		if inactiveStartTime != nullTime && time.Since(inactiveStartTime) > 180*time.Second {
 			// It's been long enough to assume the queue is really empty.
 			// Or possibly we've just been getting errors all this time.
 			log.Printf("Timeout. (%s) Last trusted was: %+v", qh.Queue, lastTrusted)


### PR DESCRIPTION
Last minute code change to address a potential bug introduced a real bug.
Timeout was happening almost immediately, because timeout check was happening even if we were getting non-zero queue data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/42)
<!-- Reviewable:end -->
