### PR TITLE
For production, override project for BQ tables

### DIFF
--- a/dispatch/deduphandler.go
+++ b/dispatch/deduphandler.go
@@ -183,6 +183,11 @@ func (dh *DedupHandler) handleLoop(opts ...option.ClientOption) {
 // feeding channel is closed, and processing is complete.
 func NewDedupHandler(opts ...option.ClientOption) *DedupHandler {
 	project := os.Getenv("PROJECT")
+	// When running in prod, the task files and queues are in mlab-oti, but the destination
+	// BigQuery tables are in measurement-lab.
+	if project == "mlab-oti" {
+		project = "measurement-lab" // destination for production tables.
+	}
 	dataset := os.Getenv("DATASET")
 	msg := make(chan string)
 	rsp := make(chan error)


### PR DESCRIPTION
When project is mlab-oti, the source task files and queues are mlab-oti, but the destination tables are in measurement-lab.  This adjusts the BQ table specification accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/43)
<!-- Reviewable:end -->
