### PR TITLE
Add Task, which will be basis for persistent state.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,25 +1,27 @@
 // Package api contains interfaces used in the project.
 package api
 
-// BasicPipe specifies an interface for sending jobs to a downstream handler.
-type BasicPipe interface {
-	Sink() chan<- string
+import "github.com/m-lab/etl-gardener/state"
+
+// TaskPipe specifies an interface for sending jobs to a downstream handler.
+type TaskPipe interface {
+	Sink() chan<- state.Task
 	Response() <-chan error
 }
 
-// NilBasicPipe is the trivial implementation of BasicPipe
-type NilBasicPipe struct{}
+// NilTaskPipe is the trivial implementation of TaskPipe
+type NilTaskPipe struct{}
 
 // Sink returns the sink channel, for use by the sender.
-func (nd *NilBasicPipe) Sink() chan<- string {
+func (nd *NilTaskPipe) Sink() chan<- state.Task {
 	return nil
 }
 
 // Response returns the response channel, that closes when all processing is complete.
-func (nd *NilBasicPipe) Response() <-chan error {
+func (nd *NilTaskPipe) Response() <-chan error {
 	return nil
 }
 
-func assertBasicPipe(ds BasicPipe) {
-	func(ds BasicPipe) {}(&NilBasicPipe{})
+func assertTaskPipe(ds TaskPipe) {
+	func(ds TaskPipe) {}(&NilTaskPipe{})
 }

--- a/cloud/tq/queuehandler.go
+++ b/cloud/tq/queuehandler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/m-lab/etl-gardener/api"
 	"github.com/m-lab/etl-gardener/metrics"
+	"github.com/m-lab/etl-gardener/state"
 	"google.golang.org/api/option"
 	"google.golang.org/appengine/taskqueue"
 )
@@ -20,12 +21,12 @@ import (
 type ChannelQueueHandler struct {
 	*QueueHandler
 	// Handler listens on this channel for prefixes.
-	MsgChan      chan string
+	MsgChan      chan state.Task
 	ResponseChan chan error
 }
 
 // Sink returns the sink channel, for use by the sender.
-func (qh *ChannelQueueHandler) Sink() chan<- string {
+func (qh *ChannelQueueHandler) Sink() chan<- state.Task {
 	return qh.MsgChan
 }
 
@@ -34,8 +35,8 @@ func (qh *ChannelQueueHandler) Response() <-chan error {
 	return qh.ResponseChan
 }
 
-func assertBasicPipe(ds api.BasicPipe) {
-	func(ds api.BasicPipe) {}(&ChannelQueueHandler{})
+func assertTaskPipe(ds api.TaskPipe) {
+	func(ds api.TaskPipe) {}(&ChannelQueueHandler{})
 }
 
 const start = `^gs://(?P<bucket>.*)/(?P<exp>[^/]*)/`
@@ -151,16 +152,16 @@ func (qh *ChannelQueueHandler) processOneRequest(prefix string, bucketOpts ...op
 }
 
 // handleLoop processes requests on input channel
-func (qh *ChannelQueueHandler) handleLoop(next api.BasicPipe, bucketOpts ...option.ClientOption) {
+func (qh *ChannelQueueHandler) handleLoop(next api.TaskPipe, bucketOpts ...option.ClientOption) {
 	log.Println("Starting handler for", qh.Queue)
 	qh.waitForEmptyQueue()
 	for {
-		prefix, more := <-qh.MsgChan
+		task, more := <-qh.MsgChan
 		if !more {
 			close(qh.ResponseChan)
 			break
 		}
-		n, err := qh.processOneRequest(prefix, bucketOpts...)
+		n, err := qh.processOneRequest(task.Name, bucketOpts...)
 		if err != nil {
 			// TODO return error through Response()
 			// Currently, processOneRequest logs error and increments metric.
@@ -170,10 +171,10 @@ func (qh *ChannelQueueHandler) handleLoop(next api.BasicPipe, bucketOpts ...opti
 		// This ensures that the data has actually been processed, rather
 		// than just sitting in the queue or in the pipeline.
 		qh.waitForEmptyQueue()
-		log.Println(qh.Queue, "sending", prefix, "to dedup handler")
+		log.Println(qh.Queue, "sending", task.Name, "to dedup handler")
 		// This may block if previous hasn't finished.  Should be rare.
 		if n > 0 && next != nil {
-			next.Sink() <- prefix
+			next.Sink() <- task
 		}
 	}
 	log.Println("Exiting handler for", qh.Queue)
@@ -182,7 +183,7 @@ func (qh *ChannelQueueHandler) handleLoop(next api.BasicPipe, bucketOpts ...opti
 // StartHandleLoop starts a go routine that waits for work on channel, and
 // processes it.
 // Returns a channel that closes when input channel is closed and final processing is complete.
-func (qh *ChannelQueueHandler) StartHandleLoop(next api.BasicPipe, bucketOpts ...option.ClientOption) {
+func (qh *ChannelQueueHandler) StartHandleLoop(next api.TaskPipe, bucketOpts ...option.ClientOption) {
 	go qh.handleLoop(next, bucketOpts...)
 }
 
@@ -190,12 +191,12 @@ func (qh *ChannelQueueHandler) StartHandleLoop(next api.BasicPipe, bucketOpts ..
 // from a channel.
 // Returns feeding channel, and done channel, which will return true when
 // feeding channel is closed, and processing is complete.
-func NewChannelQueueHandler(httpClient *http.Client, project, queue string, next api.BasicPipe, bucketOpts ...option.ClientOption) (*ChannelQueueHandler, error) {
+func NewChannelQueueHandler(httpClient *http.Client, project, queue string, next api.TaskPipe, bucketOpts ...option.ClientOption) (*ChannelQueueHandler, error) {
 	qh, err := NewQueueHandler(httpClient, project, queue)
 	if err != nil {
 		return nil, err
 	}
-	msg := make(chan string)
+	msg := make(chan state.Task)
 	rsp := make(chan error)
 	cqh := ChannelQueueHandler{qh, msg, rsp}
 

--- a/cloud/tq/queuehandler_test.go
+++ b/cloud/tq/queuehandler_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/m-lab/etl-gardener/cloud/tq"
+	"github.com/m-lab/etl-gardener/state"
 )
 
 func init() {
@@ -20,7 +21,7 @@ func TestChannelQueueHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 19; i < 29; i++ {
-		cqh.Sink() <- fmt.Sprintf("gs://archive-mlab-test/ndt/2017/09/%2d/", i)
+		cqh.Sink() <- state.Task{Name: fmt.Sprintf("gs://archive-mlab-test/ndt/2017/09/%2d/", i)}
 	}
 	close(cqh.Sink())
 	<-cqh.Response()

--- a/cloud/tq/queuehandler_test.go
+++ b/cloud/tq/queuehandler_test.go
@@ -21,7 +21,7 @@ func TestChannelQueueHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 19; i < 29; i++ {
-		cqh.Sink() <- state.Task{Name: fmt.Sprintf("gs://archive-mlab-test/ndt/2017/09/%2d/", i)}
+		cqh.Sink() <- state.Task{Name: fmt.Sprintf("gs://archive-mlab-testing/ndt/2017/09/%2d/", i)}
 	}
 	close(cqh.Sink())
 	<-cqh.Response()

--- a/cloud/tq/tq_integration_test.go
+++ b/cloud/tq/tq_integration_test.go
@@ -30,7 +30,7 @@ func TestGetTaskqueueStats(t *testing.T) {
 // NOTE: this test depends on actual bucket content.  If it starts failing,
 // check that the bucket content has not been changed.
 func TestGetBucket(t *testing.T) {
-	bucketName := "archive-mlab-test"
+	bucketName := "archive-mlab-testing"
 	bucket, err := tq.GetBucket(nil, "mlab-testing", bucketName, false)
 	if err != nil {
 		t.Fatal(err)
@@ -80,7 +80,7 @@ func TestPostDay(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Use a real storage bucket.
-	bucketName := "archive-mlab-test"
+	bucketName := "archive-mlab-testing"
 	bucket, err := tq.GetBucket(nil, "mlab-testing", bucketName, false)
 	if err != nil {
 		t.Fatal(err)

--- a/cloud/tq/tq_test.go
+++ b/cloud/tq/tq_test.go
@@ -20,7 +20,7 @@ func TestPostOneTask(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	q.PostOneTask("archive-mlab-test", "test-file")
+	q.PostOneTask("archive-mlab-testing", "test-file")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dispatch/deduphandler.go
+++ b/dispatch/deduphandler.go
@@ -166,6 +166,7 @@ func (dh *DedupHandler) handleLoop(opts ...option.ClientOption) {
 			if err != nil {
 				metrics.FailCount.WithLabelValues("NewDataset")
 				log.Println(err)
+				// TODO do we want to do any recovery here?
 				continue
 			}
 

--- a/dispatch/deduphandler.go
+++ b/dispatch/deduphandler.go
@@ -14,6 +14,7 @@ import (
 	"cloud.google.com/go/bigquery"
 	"github.com/m-lab/etl-gardener/cloud/tq"
 	"github.com/m-lab/etl-gardener/metrics"
+	"github.com/m-lab/etl-gardener/state"
 	"github.com/m-lab/go/bqext"
 	"google.golang.org/api/option"
 )
@@ -27,12 +28,12 @@ var (
 type DedupHandler struct {
 	Project      string
 	Dataset      string
-	MsgChan      chan string
+	MsgChan      chan state.Task
 	ResponseChan chan error
 }
 
 // Sink returns the sink channel, for use by the sender.
-func (dh *DedupHandler) Sink() chan<- string {
+func (dh *DedupHandler) Sink() chan<- state.Task {
 	return dh.MsgChan
 }
 
@@ -96,8 +97,8 @@ ErrorTimeout:
 }
 
 // processOneRequest waits on the channel for a new request, and handles it.
-func (dh *DedupHandler) waitAndDedup(ds *bqext.Dataset, prefix string, clientOpts ...option.ClientOption) error {
-	parts, err := tq.ParsePrefix(prefix)
+func (dh *DedupHandler) waitAndDedup(ds *bqext.Dataset, task state.Task, clientOpts ...option.ClientOption) error {
+	parts, err := tq.ParsePrefix(task.Name)
 	if err != nil {
 		// If there is a parse error, log and skip request.
 		log.Println(err)
@@ -159,7 +160,7 @@ func (dh *DedupHandler) handleLoop(opts ...option.ClientOption) {
 	log.Println("Starting handler for ...")
 
 	for {
-		req, more := <-dh.MsgChan
+		task, more := <-dh.MsgChan
 		if more {
 			ds, err := bqext.NewDataset(dh.Project, dh.Dataset, opts...)
 			if err != nil {
@@ -168,7 +169,8 @@ func (dh *DedupHandler) handleLoop(opts ...option.ClientOption) {
 				continue
 			}
 
-			dh.waitAndDedup(&ds, req, opts...)
+			dh.waitAndDedup(&ds, task, opts...)
+			// TODO - delete the task??
 		} else {
 			log.Println("Exiting handler for ...")
 			close(dh.ResponseChan)
@@ -189,7 +191,7 @@ func NewDedupHandler(opts ...option.ClientOption) *DedupHandler {
 		project = "measurement-lab" // destination for production tables.
 	}
 	dataset := os.Getenv("DATASET")
-	msg := make(chan string)
+	msg := make(chan state.Task)
 	rsp := make(chan error)
 	dh := DedupHandler{project, dataset, msg, rsp}
 

--- a/dispatch/deduphandler_test.go
+++ b/dispatch/deduphandler_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/m-lab/etl-gardener/api"
 	"github.com/m-lab/etl-gardener/cloud/tq"
 	"github.com/m-lab/etl-gardener/dispatch"
+	"github.com/m-lab/etl-gardener/state"
 	"google.golang.org/api/option"
 )
 
 // This just asserts that DedupHandler satisfies the Downstream interface.
-func assertBasicPipe() {
-	func(ds api.BasicPipe) {}(&dispatch.DedupHandler{})
+func assertTaskPipe() {
+	func(ds api.TaskPipe) {}(&dispatch.DedupHandler{})
 }
 
 // This is much too whitebox.  Can we find better abstractions to improve testing?
@@ -27,7 +28,8 @@ func TestDedupHandler(t *testing.T) {
 
 	dedup := dispatch.NewDedupHandler(option.WithHTTPClient(client))
 
-	dedup.Sink() <- "gs://gfr/sidestream/2001/01/01/"
+	// TODO - also test with inconsistent state.
+	dedup.Sink() <- state.Task{Name: "gs://gfr/sidestream/2001/01/01/", State: state.Stabilizing}
 	close(dedup.Sink())
 	<-dedup.Response()
 

--- a/state/state.go
+++ b/state/state.go
@@ -12,7 +12,7 @@ type State int
 // State definitions
 const (
 	Initializing  State = iota
-	Queuing             // Queuing all tasks for the task.
+	Queuing             // Queuing all task files for the task (date/experiment).
 	Processing          // Done queuing, waiting for the queue to empty.
 	Stabilizing         // Waiting for streaming buffer to be empty
 	Deduplicating       // Bigquery deduplication query in process.
@@ -26,7 +26,7 @@ type Saver interface {
 	DeleteTask(t Task) error
 }
 
-// DatastoreSaver will implement a Saver that stores Task state in DataStore.
+// DatastoreSaver will implement a Saver that stores Task state in Datastore.
 type DatastoreSaver struct {
 	// TODO - add datastore stuff
 }
@@ -40,13 +40,13 @@ func (s *DatastoreSaver) DeleteTask(t Task) error { return nil }
 // Task contains the state of a single Task.
 // These will be stored and retrieved from DataStore
 type Task struct {
-	Name    string // e.g. gs://archive-mlab-oti/ndt/2017/06/01/
-	Suffix  string // e.g. 20170601
-	State   State
-	Queue   string // The queue the tasks were submitted to, or empty.
-	JobID   string // JobID, when the state is Deduplicating
-	Err     error  // Processing error, if any
-	ErrInfo string // More context about any error, if any
+	Name        string // e.g. gs://archive-mlab-oti/ndt/2017/06/01/
+	TableSuffix string // e.g. 20170601
+	State       State
+	Queue       string // The queue the task files are submitted to, or "".
+	JobID       string // BigQuery JobID, when the state is Deduplicating
+	Err         error  // Processing error, if any
+	ErrInfo     string // More context about any error, if any
 
 	saver Saver // Saver is used for Save operations. Stored locally, but not persisted.
 }

--- a/state/state.go
+++ b/state/state.go
@@ -1,0 +1,95 @@
+// Package state handles persistent state required across instances.
+package state
+
+// NOTE: Avoid dependencies on any other m-lab code.
+import (
+	"errors"
+)
+
+// State indicates the state of a single Task in flight.
+type State int
+
+// State definitions
+const (
+	Initializing  State = iota
+	Queuing             // Queuing all tasks for the task.
+	Processing          // Done queuing, waiting for the queue to empty.
+	Stabilizing         // Waiting for streaming buffer to be empty
+	Deduplicating       // Bigquery deduplication query in process.
+	Finishing           // Deleting template table, copying to final table, deleting partition.
+	Done                // Done all processing, ok to delete state.
+)
+
+// Saver provides API for saving Task state.
+type Saver interface {
+	SaveTask(t Task) error
+	DeleteTask(t Task) error
+}
+
+// DatastoreSaver will implement a Saver that stores Task state in DataStore.
+type DatastoreSaver struct {
+	// TODO - add datastore stuff
+}
+
+// SaveTask implements Saver.SaveTask using Datastore.
+func (s *DatastoreSaver) SaveTask(t Task) error { return nil }
+
+// DeleteTask implements Saver.DeleteTask using Datastore.
+func (s *DatastoreSaver) DeleteTask(t Task) error { return nil }
+
+// Task contains the state of a single Task.
+// These will be stored and retrieved from DataStore
+type Task struct {
+	Name    string // e.g. gs://archive-mlab-oti/ndt/2017/06/01/
+	Suffix  string // e.g. 20170601
+	State   State
+	Queue   string // The queue the tasks were submitted to, or empty.
+	JobID   string // JobID, when the state is Deduplicating
+	Err     error  // Processing error, if any
+	ErrInfo string // More context about any error, if any
+
+	saver Saver // Saver is used for Save operations. Stored locally, but not persisted.
+}
+
+// ErrNoSaver is returned when saver has not been set.
+var ErrNoSaver = errors.New("Task.saver is nil")
+
+// Save saves the task state to the "saver".
+func (t *Task) Save() error {
+	if t.saver == nil {
+		return ErrNoSaver
+	}
+	return t.saver.SaveTask(*t)
+}
+
+// Update updates the task state, and saves to the "saver".
+func (t *Task) Update(st State) error {
+	if t.saver == nil {
+		return ErrNoSaver
+	}
+	t.State = st
+	return t.saver.SaveTask(*t)
+}
+
+// Delete removes by calling saver.DeleteTask.
+func (t *Task) Delete() error {
+	if t.saver == nil {
+		return ErrNoSaver
+	}
+	return t.saver.DeleteTask(*t)
+}
+
+// SetError adds error information and saves to the "saver"
+func (t *Task) SetError(err error, info string) error {
+	if t.saver == nil {
+		return ErrNoSaver
+	}
+	t.Err = err
+	t.ErrInfo = info
+	return t.saver.SaveTask(*t)
+}
+
+// SetSaver sets the value of the saver to be used for all other calls.
+func (t *Task) SetSaver(saver Saver) {
+	t.saver = saver
+}

--- a/state/state.go
+++ b/state/state.go
@@ -11,7 +11,8 @@ type State int
 
 // State definitions
 const (
-	Initializing  State = iota
+	Invalid       State = iota
+	Initializing        // Task is being initialized.
 	Queuing             // Queuing all task files for the task (date/experiment).
 	Processing          // Done queuing, waiting for the queue to empty.
 	Stabilizing         // Waiting for streaming buffer to be empty
@@ -45,7 +46,7 @@ type Task struct {
 	State       State
 	Queue       string // The queue the task files are submitted to, or "".
 	JobID       string // BigQuery JobID, when the state is Deduplicating
-	Err         error  // Processing error, if any
+	Err         error  // Task handling error, if any
 	ErrInfo     string // More context about any error, if any
 
 	saver Saver // Saver is used for Save operations. Stored locally, but not persisted.

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -8,27 +8,27 @@ import (
 	"github.com/m-lab/etl-gardener/state"
 )
 
-type saver struct {
+type testSaver struct {
 	tasks  map[string][]state.Task
 	delete map[string]struct{}
 }
 
-func (s *saver) SaveTask(t state.Task) error {
+func (s *testSaver) SaveTask(t state.Task) error {
 	s.tasks[t.Name] = append(s.tasks[t.Name], t)
 	return nil
 }
 
-func (s *saver) DeleteTask(t state.Task) error {
+func (s *testSaver) DeleteTask(t state.Task) error {
 	log.Println(t.Name)
 	s.delete[t.Name] = struct{}{}
 	return nil
 }
 
-func assertSaver() { func(ex state.Saver) {}(&saver{}) }
+func assertSaver() { func(ex state.Saver) {}(&testSaver{}) }
 
 func TestTaskBasics(t *testing.T) {
 	task := state.Task{Name: "foobar"}
-	saver := saver{make(map[string][]state.Task), make(map[string]struct{})}
+	saver := testSaver{make(map[string][]state.Task), make(map[string]struct{})}
 	task.SetSaver(&saver)
 
 	task.Update(state.Initializing)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1,0 +1,74 @@
+package state_test
+
+import (
+	"errors"
+	"log"
+	"testing"
+
+	"github.com/m-lab/etl-gardener/state"
+)
+
+type saver struct {
+	tasks  map[string][]state.Task
+	delete map[string]struct{}
+}
+
+func (s *saver) SaveTask(t state.Task) error {
+	s.tasks[t.Name] = append(s.tasks[t.Name], t)
+	return nil
+}
+
+func (s *saver) DeleteTask(t state.Task) error {
+	log.Println(t.Name)
+	s.delete[t.Name] = struct{}{}
+	return nil
+}
+
+func assertSaver() { func(ex state.Saver) {}(&saver{}) }
+
+func TestTaskBasics(t *testing.T) {
+	task := state.Task{Name: "foobar"}
+	saver := saver{make(map[string][]state.Task), make(map[string]struct{})}
+	task.SetSaver(&saver)
+
+	task.Update(state.Initializing)
+
+	task.Queue = "queue"
+	task.Update(state.Queuing)
+
+	tasks, ok := saver.tasks["foobar"]
+	if !ok {
+		t.Fatal("Should have an entry for foobar")
+	}
+	if len(tasks) != 2 {
+		t.Fatal("Something very wrong")
+	}
+	if tasks[1].State != state.Queuing {
+		t.Error("Should be queuing", tasks[1])
+	}
+
+	task.SetError(errors.New("test error"), "test")
+	tasks, ok = saver.tasks["foobar"]
+	if !ok {
+		t.Fatal("Should have an entry for foobar")
+	}
+	if len(tasks) != 3 {
+		t.Fatal("Something very wrong")
+	}
+	if tasks[2].State != state.Queuing {
+		t.Error("Should be queuing", tasks[2])
+	}
+	if tasks[2].Err.Error() != "test error" {
+		t.Error("Should have error", tasks[2])
+	}
+	if tasks[2].ErrInfo != "test" {
+		t.Error("Should have error", tasks[2])
+	}
+
+	task.Delete()
+	_, ok = saver.delete["foobar"]
+	if !ok {
+		t.Fatal("Should have called delete")
+	}
+
+}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -27,7 +27,7 @@ func (s *testSaver) DeleteTask(t state.Task) error {
 func assertSaver() { func(ex state.Saver) {}(&testSaver{}) }
 
 func TestTaskBasics(t *testing.T) {
-	task := state.Task{Name: "foobar"}
+	task := state.Task{Name: "foobar", State: state.Initializing}
 	saver := testSaver{make(map[string][]state.Task), make(map[string]struct{})}
 	task.SetSaver(&saver)
 


### PR DESCRIPTION
This introduces "Task", which stores info about the state of a single gardener reprocess/dedup task.  It also changes the channels between GoRoutines to handle Tasks instead of strings.

Future PRs will add more functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/46)
<!-- Reviewable:end -->
