### PR TITLE
Start plumbing Task state changes

### DIFF
--- a/cloud/tq/queuehandler.go
+++ b/cloud/tq/queuehandler.go
@@ -191,8 +191,8 @@ func (qh *ChannelQueueHandler) handleLoop(next api.TaskPipe, bucketOpts ...optio
 			task.Update(state.Stabilizing)
 
 			log.Println(qh.Queue, "sending", task.Name, "to dedup handler")
-			// This may block if previous hasn't finished.  Should be rare.
 			if next != nil {
+				// This may block if previous hasn't finished.  Should be rare.
 				next.Sink() <- task
 			} else {
 				// TODO - or error?

--- a/cloud/tq/queuehandler_test.go
+++ b/cloud/tq/queuehandler_test.go
@@ -3,6 +3,7 @@ package tq_test
 import (
 	"fmt"
 	"log"
+	"os"
 	"testing"
 
 	"github.com/m-lab/etl-gardener/cloud/tq"
@@ -15,6 +16,10 @@ func init() {
 }
 
 func TestChannelQueueHandler(t *testing.T) {
+	err := os.Setenv("UNIT_TEST_MODE", "true")
+	if err != nil {
+		t.Fatal("Unable to setenv")
+	}
 	client, counter := tq.DryRunQueuerClient()
 	cqh, err := tq.NewChannelQueueHandler(client, "mlab-testing", "test-queue", nil)
 	if err != nil {
@@ -25,9 +30,9 @@ func TestChannelQueueHandler(t *testing.T) {
 	}
 	close(cqh.Sink())
 	<-cqh.Response()
-	// There will be one http request for each IsEmpty() call (10), and one for each task file (76).
+	// There will be one http request for each GetTaskqueueStatistics() call (10), and one for each task file (76).
 	if counter.Count() != 87 {
 		log.Println(counter.Count())
-		t.Error("Count != 87")
+		t.Errorf("Count = %d, expected 87", counter.Count())
 	}
 }

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -56,7 +56,13 @@ func dispatcherFromEnv(client *http.Client) (*dispatch.Dispatcher, error) {
 		return nil, errors.New("START_DATE not set")
 	}
 
-	return dispatch.NewDispatcher(client, project, queueBase, numQueues, startDate, &state.DatastoreSaver{})
+	ds, err := state.NewDatastoreSaver()
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
+
+	return dispatch.NewDispatcher(client, project, queueBase, numQueues, startDate, ds)
 }
 
 // StartDateRFC3339 is the date at which reprocessing will start when it catches

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/m-lab/etl-gardener/dispatch"
+	"github.com/m-lab/etl-gardener/state"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -55,7 +56,7 @@ func dispatcherFromEnv(client *http.Client) (*dispatch.Dispatcher, error) {
 		return nil, errors.New("START_DATE not set")
 	}
 
-	return dispatch.NewDispatcher(client, project, queueBase, numQueues, startDate)
+	return dispatch.NewDispatcher(client, project, queueBase, numQueues, startDate, &state.DatastoreSaver{})
 }
 
 // StartDateRFC3339 is the date at which reprocessing will start when it catches

--- a/dedup/dedup.go
+++ b/dedup/dedup.go
@@ -5,7 +5,6 @@
 //  2. It expects destination table to be partitioned.
 //  3. It does not explicitly check for schema compatibility,
 //      though it will fail if they are incompatible.
-
 package dedup
 
 import (

--- a/dispatch/deduphandler.go
+++ b/dispatch/deduphandler.go
@@ -127,11 +127,12 @@ func (dh *DedupHandler) waitAndDedup(ds *bqext.Dataset, task state.Task, clientO
 	// if it still exists.
 	dest := ds.Table(parts[2] + "$" + strings.Join(strings.Split(parts[3], "/"), ""))
 	log.Println("Dedupping", tt.FullyQualifiedName())
-	//status, err := DedupAndWait(ds, tt.TableID, dest)
 	job, err := Dedup(ds, tt.TableID, dest)
-	// TODO - improve on this testing hack.
 	if err != nil {
 		if err == io.EOF {
+			// TODO - improve on this testing hack.
+			// It would be nice to use a fake Job, but that seems impossible.
+			// Could instead return our own Job interface object??
 			log.Println("EOF error - is this a test client?")
 			task.JobID = "fake jobID"
 			task.Save()
@@ -312,12 +313,3 @@ func Dedup(dsExt *bqext.Dataset, src string, destTable *bigquery.Table) (*bigque
 	return job, nil
 }
 
-// DedupAndWait executes a query that dedups and writes to destination partition.
-// Waits for query completion and returns JobStatus
-func DedupAndWait(dsExt *bqext.Dataset, src string, destTable *bigquery.Table) (*bigquery.JobStatus, error) {
-	job, err := Dedup(dsExt, src, destTable)
-	if err != nil {
-		return nil, err
-	}
-	return job.Wait(context.Background())
-}

--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/m-lab/etl-gardener/api"
 	"github.com/m-lab/etl-gardener/cloud/tq"
 	"github.com/m-lab/etl-gardener/state"
+
 	"google.golang.org/api/option"
 )
 
@@ -28,6 +29,7 @@ type Dispatcher struct {
 	Handlers    []api.TaskPipe
 	StartDate   time.Time
 	Terminating bool // Indicates when Terminate has been called.
+	Saver       state.Saver
 	lock        sync.Mutex
 }
 
@@ -39,7 +41,9 @@ var (
 // NewDispatcher creates a dispatcher that will spread requests across multiple
 // QueueHandlers.
 // bucketOpts may be used to provide a fake client for bucket operations.
-func NewDispatcher(httpClient *http.Client, project, queueBase string, numQueues int, startDate time.Time, bucketOpts ...option.ClientOption) (*Dispatcher, error) {
+func NewDispatcher(httpClient *http.Client, project, queueBase string, numQueues int,
+	startDate time.Time, saver state.Saver, bucketOpts ...option.ClientOption) (*Dispatcher, error) {
+
 	handlers := make([]api.TaskPipe, 0, numQueues)
 	for i := 0; i < numQueues; i++ {
 		queue := fmt.Sprintf("%s%d", queueBase, i)
@@ -55,7 +59,7 @@ func NewDispatcher(httpClient *http.Client, project, queueBase string, numQueues
 		handlers = append(handlers, cqh)
 	}
 
-	return &Dispatcher{Handlers: handlers, StartDate: startDate, Terminating: false}, nil
+	return &Dispatcher{Handlers: handlers, StartDate: startDate, Terminating: false, Saver: saver}, nil
 }
 
 // Terminate closes all the channels, and waits for all the dones.
@@ -86,6 +90,12 @@ func (disp *Dispatcher) Add(prefix string) error {
 	}
 	// TODO - create Task entry in persistent store, in Initializing state.
 	task := state.Task{Name: prefix, State: state.Initializing}
+	task.SetSaver(disp.Saver)
+	err := task.Save()
+	if err != nil {
+		// We don't expect errors here.  What should we do?
+		// TODO - ???
+	}
 
 	// Easiest to do this on the fly, since it requires the prefix in the cases.
 	cases := make([]reflect.SelectCase, 0, len(disp.Handlers))

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/m-lab/etl-gardener/cloud/tq"
 	"github.com/m-lab/etl-gardener/dispatch"
+	"github.com/m-lab/etl-gardener/state"
 )
 
 func init() {
@@ -16,14 +17,29 @@ func init() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
 
+type S struct {
+	tasks map[string][]state.Task
+}
+
+func (s *S) SaveTask(t state.Task) error {
+	s.tasks[t.Name] = append(s.tasks[t.Name], t)
+	return nil
+}
+
+func (s *S) DeleteTask(t state.Task) error { return nil }
+
+func assertSaver() { func(ex state.Saver) {}(&S{}) }
+
 func TestDispatcherLifeCycle(t *testing.T) {
 	// Use a fake client so we intercept all the http ops.
 	client, counter := tq.DryRunQueuerClient()
 
+	saver := S{tasks: make(map[string][]state.Task)}
+
 	// With time.Now(), this shouldn't send any requests.
 	// Inject fake client for bucket ops, so it doesn't hit the backends at all.
 	// Construction will trigger 4 HTTP calls, one to check that each queue is empty.
-	d, err := dispatch.NewDispatcher(client, "project", "queue-base-", 4, time.Now(), option.WithHTTPClient(client))
+	d, err := dispatch.NewDispatcher(client, "project", "queue-base-", 4, time.Now(), &saver, option.WithHTTPClient(client))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,8 +57,30 @@ func TestDispatcherLifeCycle(t *testing.T) {
 		t.Errorf("Count was %d instead of 6", counter.Count())
 	}
 
-	err = d.Add("gs://foobar/ndt/2001/01/01/")
+	err = d.Add("gs://foobar/ndt/2001/01/02/")
 	if err != dispatch.ErrTerminating {
 		t.Error("Should get", dispatch.ErrTerminating)
 	}
+
+	taskStates, ok := saver.tasks["gs://foobar/ndt/2001/01/01/"]
+	if !ok {
+		t.Fatal("Task not saved")
+	}
+	// For now, state should have progressed to Stabilizing.
+	if len(taskStates) != 4 {
+		t.Fatal("Wrong number of states:", len(taskStates))
+	}
+
+	if taskStates[1].State != state.Queuing {
+		t.Errorf("Wrong state %+v\n", taskStates[1])
+	}
+
+	if taskStates[2].State != state.Processing {
+		t.Errorf("Wrong state %+v\n", taskStates[2])
+	}
+
+	if taskStates[3].State != state.Stabilizing {
+		t.Errorf("Wrong state %+v\n", taskStates[3])
+	}
+
 }

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -31,6 +31,22 @@ func (s *S) DeleteTask(t state.Task) error { return nil }
 
 func assertSaver() { func(ex state.Saver) {}(&S{}) }
 
+func TestSaver(t *testing.T) {
+	os.Setenv("GCLOUD_PROJECT", "mlab-testing")
+
+	saver, err := state.NewDatastoreSaver()
+	if err != nil {
+		t.Fatal(err)
+	}
+	task := state.Task{Name: "gs://foobar/test-task"}
+	task.SetSaver(saver)
+
+	err = task.Update(state.Queuing)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDispatcherLifeCycle(t *testing.T) {
 	os.Setenv("GCLOUD_PROJECT", "mlab-testing")
 	os.Setenv("UNIT_TEST_MODE", "true")

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -31,7 +31,8 @@ func (s *S) DeleteTask(t state.Task) error { return nil }
 
 func assertSaver() { func(ex state.Saver) {}(&S{}) }
 
-func TestSaver(t *testing.T) {
+// Remove leading x to manually test DatastoreSaver.
+func xTestSaver(t *testing.T) {
 	os.Setenv("GCLOUD_PROJECT", "mlab-testing")
 
 	saver, err := state.NewDatastoreSaver()

--- a/go-pre-commit
+++ b/go-pre-commit
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Intended for use with m-lab/git-hooks.
+# Clone or use submodule, and link .git/hooks to git-hooks,
+#  e.g.
+#    mv .git/hooks .git/hooks.orig
+#    ln -s ../../git-hooks .git/hooks
+#
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+
+set -x
+set -u
+# travis lint -x # Now done by git-hooks/pre-commit
+
+golint ./...
+go vet ./...

--- a/state/state.go
+++ b/state/state.go
@@ -23,7 +23,7 @@ const (
 )
 
 // StateNames maps from State to string, for use in String()
-var StateNames map[State]string = map[State]string{
+var StateNames = map[State]string{
 	Initializing:  "Initializing",
 	Queuing:       "Queuing",
 	Processing:    "Processing",

--- a/state/state.go
+++ b/state/state.go
@@ -4,6 +4,7 @@ package state
 // NOTE: Avoid dependencies on any other m-lab code.
 import (
 	"errors"
+	"fmt"
 )
 
 // State indicates the state of a single Task in flight.
@@ -20,6 +21,17 @@ const (
 	Finishing           // Deleting template table, copying to final table, deleting partition.
 	Done                // Done all processing, ok to delete state.
 )
+
+// StateNames maps from State to string, for use in String()
+var StateNames map[State]string = map[State]string{
+	Initializing:  "Initializing",
+	Queuing:       "Queuing",
+	Processing:    "Processing",
+	Stabilizing:   "Stabilizing",
+	Deduplicating: "Deduplicating",
+	Finishing:     "Finishing",
+	Done:          "Done",
+}
 
 // Saver provides API for saving Task state.
 type Saver interface {
@@ -50,6 +62,10 @@ type Task struct {
 	ErrInfo     string // More context about any error, if any
 
 	saver Saver // Saver is used for Save operations. Stored locally, but not persisted.
+}
+
+func (t Task) String() string {
+	return fmt.Sprintf("{%s: %s, Q:%s, J:%s, E:%v (%s)}", t.Name, StateNames[t.State], t.Queue, t.JobID, t.Err, t.ErrInfo)
 }
 
 // ErrNoSaver is returned when saver has not been set.

--- a/state/state.go
+++ b/state/state.go
@@ -83,14 +83,14 @@ type Task struct {
 	State       State
 	Queue       string // The queue the task files are submitted to, or "".
 	JobID       string // BigQuery JobID, when the state is Deduplicating
-	Err         error  // Task handling error, if any
+	ErrMsg      string // Task handling error, if any
 	ErrInfo     string // More context about any error, if any
 
 	saver Saver // Saver is used for Save operations. Stored locally, but not persisted.
 }
 
 func (t Task) String() string {
-	return fmt.Sprintf("{%s: %s, Q:%s, J:%s, E:%v (%s)}", t.Name, StateNames[t.State], t.Queue, t.JobID, t.Err, t.ErrInfo)
+	return fmt.Sprintf("{%s: %s, Q:%s, J:%s, E:%s (%s)}", t.Name, StateNames[t.State], t.Queue, t.JobID, t.ErrMsg, t.ErrInfo)
 }
 
 // ErrNoSaver is returned when saver has not been set.
@@ -126,7 +126,7 @@ func (t *Task) SetError(err error, info string) error {
 	if t.saver == nil {
 		return ErrNoSaver
 	}
-	t.Err = err
+	t.ErrMsg = err.Error()
 	t.ErrInfo = info
 	return t.saver.SaveTask(*t)
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/m-lab/etl-gardener/state"
 )
 
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
 type testSaver struct {
 	tasks  map[string][]state.Task
 	delete map[string]struct{}
@@ -19,7 +24,6 @@ func (s *testSaver) SaveTask(t state.Task) error {
 }
 
 func (s *testSaver) DeleteTask(t state.Task) error {
-	log.Println(t.Name)
 	s.delete[t.Name] = struct{}{}
 	return nil
 }
@@ -70,5 +74,4 @@ func TestTaskBasics(t *testing.T) {
 	if !ok {
 		t.Fatal("Should have called delete")
 	}
-
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -62,7 +62,7 @@ func TestTaskBasics(t *testing.T) {
 	if tasks[2].State != state.Queuing {
 		t.Error("Should be queuing", tasks[2])
 	}
-	if tasks[2].Err.Error() != "test error" {
+	if tasks[2].ErrMsg != "test error" {
 		t.Error("Should have error", tasks[2])
 	}
 	if tasks[2].ErrInfo != "test" {


### PR DESCRIPTION
1. Fleshes out state.Saver implementation.
2. Adds Tasks state change actions in Dispatch, QueueHandler, DedupHandler, including tracking of most errors.

ALSO:
3. splits Dedup into two phases, one to launch the Dedup, and one to monitor whether it has finished successfully.  This allows tracking the JobID in the Task.
4. Improves queuehandler corner cases.
5. Improves unit tests.
6. Add git precommit for go files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/47)
<!-- Reviewable:end -->
