### PR TITLE
project instead of gcloud_project

### DIFF
--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -33,7 +33,7 @@ func assertSaver() { func(ex state.Saver) {}(&S{}) }
 
 // Remove leading x to manually test DatastoreSaver.
 func xTestSaver(t *testing.T) {
-	os.Setenv("GCLOUD_PROJECT", "mlab-testing")
+	os.Setenv("PROJECT", "mlab-testing")
 
 	saver, err := state.NewDatastoreSaver()
 	if err != nil {
@@ -49,7 +49,7 @@ func xTestSaver(t *testing.T) {
 }
 
 func TestDispatcherLifeCycle(t *testing.T) {
-	os.Setenv("GCLOUD_PROJECT", "mlab-testing")
+	os.Setenv("PROJECT", "mlab-testing")
 	os.Setenv("UNIT_TEST_MODE", "true")
 	// Use a fake client so we intercept all the http ops.
 	client, counter := tq.DryRunQueuerClient()

--- a/state/state.go
+++ b/state/state.go
@@ -51,7 +51,7 @@ type DatastoreSaver struct {
 
 // NewDatastoreSaver creates and returns an appropriate saver.
 func NewDatastoreSaver() (*DatastoreSaver, error) {
-	project := os.Getenv("GCLOUD_PROJECT")
+	project := os.Getenv("PROJECT")
 	client, err := datastore.NewClient(context.Background(), project)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fix inconsistency between k8s config and code.
Verified working in sandbox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/49)
<!-- Reviewable:end -->
