### PR TITLE
Temporary gardener config for reprocessing sidestream

### DIFF
--- a/cloud/tq/queuehandler.go
+++ b/cloud/tq/queuehandler.go
@@ -201,6 +201,9 @@ func (qh *ChannelQueueHandler) handleLoop(next api.TaskPipe, bucketOpts ...optio
 			}
 		} else {
 			log.Println("No task files")
+			task.Queue = ""
+			task.Update(state.Done)
+			task.Delete()
 		}
 	}
 	log.Println(qh.Queue, "waiting for deduper to close")

--- a/dispatch/deduphandler.go
+++ b/dispatch/deduphandler.go
@@ -222,12 +222,13 @@ func (dh *DedupHandler) handleLoop(opts ...option.ClientOption) {
 // feeding channel is closed, and processing is complete.
 func NewDedupHandler(opts ...option.ClientOption) *DedupHandler {
 	project := os.Getenv("PROJECT")
+	dataset := os.Getenv("DATASET")
 	// When running in prod, the task files and queues are in mlab-oti, but the destination
 	// BigQuery tables are in measurement-lab.
-	if project == "mlab-oti" {
+	// However, for sidestream private tables, we leave them in mlab-oti
+	if project == "mlab-oti" && dataset != "private" {
 		project = "measurement-lab" // destination for production tables.
 	}
-	dataset := os.Getenv("DATASET")
 	msg := make(chan state.Task)
 	rsp := make(chan error)
 	dh := DedupHandler{project, dataset, msg, rsp}
@@ -312,4 +313,3 @@ func Dedup(dsExt *bqext.Dataset, src string, destTable *bigquery.Table) (*bigque
 	}
 	return job, nil
 }
-

--- a/k8s/data-processing-cluster/deployments/etl-gardener.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener.yml
@@ -44,13 +44,13 @@ spec:
         - name: PROJECT
           value: {{GCLOUD_PROJECT}}
         - name: TASKFILE_BUCKET
-          value: "archive-{{GCLOUD_PROJECT}}"
+          value: "scraper-{{GCLOUD_PROJECT}}"
         - name: START_DATE
-          value: "20180301"
+          value: "20170601"
         - name: EXPERIMENTS
-          value: "sidestream,ndt"  # For example "ndt,sidestream,switch"
+          value: "sidestream"  # For example "ndt,sidestream,switch"
         - name: DATASET
-          value: batch
+          value: private
         - name: FINAL_DATASET
           value: ""  # e.g. base_tables
         - name: QUEUE_BASE

--- a/k8s/data-processing-cluster/deployments/etl-gardener.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener.yml
@@ -44,7 +44,7 @@ spec:
         - name: PROJECT
           value: {{GCLOUD_PROJECT}}
         - name: TASKFILE_BUCKET
-          value: "scraper-{{GCLOUD_PROJECT}}"
+          value: "scraper-{{GCLOUD_PROJECT}}"  # NOTE: if we start deleting unembargoed files from scraper, this will no longer work.
         - name: START_DATE
           value: "20170601"
         - name: EXPERIMENTS


### PR DESCRIPTION
This modifies a small bit of code and config to set up gardener to reprocess the past year's sidestream data.  

The code overrides the BQ table placement from measurement-lab to mlab-oti for sidestream tables.

Additionally, I've configured private datasets in all mlab-* repositories for tables containing embargoed data, using the dataset.get and dataset.update functions.  These datasets have ACLs allowing Owner and Writer to have any access to the tables.  There is no access allowed for Readers.

etl batch pipeline is already modified to always use the private dataset for sidestream data, and to continue using the "batch" dataset for other data types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/58)
<!-- Reviewable:end -->
