### PR TITLE
scopes: gardener

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener.yml
@@ -83,6 +83,8 @@ spec:
         - mountPath: /etl-gardener
           name: etl-gardener-storage
 
+      nodeSelector:
+        scopes: gardener
 
       # Disks created manually, can be named here explicitly using
       # gcePersistentDisk instead of the persistentVolumeClaim.


### PR DESCRIPTION
Adds nodeSelector, so that gardener runs on pods with the appropriate scopes.  Recently added datastore to the gardener pools, and this ensures that we run on those pools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/59)
<!-- Reviewable:end -->
