### PR TITLE
Introduce cloud package, with common Config for cloud api clients.

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -1,7 +1,14 @@
+// Package cloud contains a generic cloud Config, and utilities like
+// DryRunClient.
 package cloud
 
 import (
+	"bytes"
+	"io"
+	"io/ioutil"
 	"net/http"
+	"strings"
+	"sync/atomic"
 
 	"google.golang.org/api/option"
 )
@@ -10,8 +17,73 @@ import (
 type Config struct {
 	Project string
 	Dataset string // TODO - do we want this here?  Only used for bigquery
+
+	// client to be used for cloud API calls.  Allows injection of fake for testing.
 	Client  *http.Client
 	Options []option.ClientOption
 
 	TestMode bool
+}
+
+// *******************************************************************
+// DryRunQueuerClient, that just returns status ok and empty body
+// For injection when we want Queuer to do nothing.
+// *******************************************************************
+
+// CountingTransport counts calls, and returns OK and empty body.
+type CountingTransport struct {
+	count int32
+	reqs  []*http.Request
+}
+
+// Count returns the client call count.
+func (ct *CountingTransport) Count() int32 {
+	return atomic.LoadInt32(&ct.count)
+}
+
+// Requests returns the entire req from the last request
+func (ct *CountingTransport) Requests() []*http.Request {
+	return ct.reqs
+}
+
+type nopCloser struct {
+	io.Reader
+}
+
+func (nc *nopCloser) Close() error { return nil }
+
+// RoundTrip implements the RoundTripper interface, logging the
+// request, and the response body, (which may be json).
+func (ct *CountingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	atomic.AddInt32(&ct.count, 1)
+
+	// Create an empty response with StatusOK
+	resp := &http.Response{}
+	resp.StatusCode = http.StatusOK
+	resp.Body = &nopCloser{strings.NewReader("")}
+
+	// Save the request for testing.
+	ct.reqs = append(ct.reqs, req)
+
+	return resp, nil
+}
+
+// DryRunClient returns a client that just counts calls.
+func DryRunClient() (*http.Client, *CountingTransport) {
+	client := &http.Client{}
+	tp := &CountingTransport{}
+	client.Transport = tp
+	return client, tp
+}
+
+// This is used to intercept Get requests to the queue_pusher when invoked
+// with -dry_run.
+type dryRunHTTP struct{}
+
+func (dr *dryRunHTTP) Get(url string) (resp *http.Response, err error) {
+	resp = &http.Response{}
+	resp.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
+	resp.Status = "200 OK"
+	resp.StatusCode = 200
+	return
 }

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -1,0 +1,17 @@
+package cloud
+
+import (
+	"net/http"
+
+	"google.golang.org/api/option"
+)
+
+// Config provides a generic config suitable for many cloud clients.
+type Config struct {
+	Project string
+	Dataset string // TODO - do we want this here?  Only used for bigquery
+	Client  *http.Client
+	Options []option.ClientOption
+
+	TestMode bool
+}

--- a/cloud/tq/queuehandler_test.go
+++ b/cloud/tq/queuehandler_test.go
@@ -16,7 +16,7 @@ func init() {
 }
 
 func TestChannelQueueHandler(t *testing.T) {
-	client, counter := tq.DryRunQueuerClient()
+	client, counter := cloud.DryRunClient()
 	config := cloud.Config{Project: "mlab-testing", Dataset: "", Client: client, Options: nil, TestMode: true}
 	cqh, err := tq.NewChannelQueueHandler(config, "test-queue", nil)
 	if err != nil {

--- a/cloud/tq/queuehandler_test.go
+++ b/cloud/tq/queuehandler_test.go
@@ -17,7 +17,7 @@ func init() {
 
 func TestChannelQueueHandler(t *testing.T) {
 	client, counter := tq.DryRunQueuerClient()
-	config := cloud.Config{"mlab-testing", "", client, nil, true}
+	config := cloud.Config{Project: "mlab-testing", Dataset: "", Client: client, Options: nil, TestMode: true}
 	cqh, err := tq.NewChannelQueueHandler(config, "test-queue", nil)
 	if err != nil {
 		t.Fatal(err)

--- a/cloud/tq/queuehandler_test.go
+++ b/cloud/tq/queuehandler_test.go
@@ -3,7 +3,6 @@ package tq_test
 import (
 	"fmt"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/m-lab/etl-gardener/cloud/tq"
@@ -16,10 +15,6 @@ func init() {
 }
 
 func TestChannelQueueHandler(t *testing.T) {
-	err := os.Setenv("UNIT_TEST_MODE", "true")
-	if err != nil {
-		t.Fatal("Unable to setenv")
-	}
 	client, counter := tq.DryRunQueuerClient()
 	cqh, err := tq.NewChannelQueueHandler(client, "mlab-testing", "test-queue", nil)
 	if err != nil {

--- a/cloud/tq/queuehandler_test.go
+++ b/cloud/tq/queuehandler_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/cloud/tq"
 	"github.com/m-lab/etl-gardener/state"
 )
@@ -16,7 +17,8 @@ func init() {
 
 func TestChannelQueueHandler(t *testing.T) {
 	client, counter := tq.DryRunQueuerClient()
-	cqh, err := tq.NewChannelQueueHandler(client, "mlab-testing", "test-queue", nil)
+	config := cloud.Config{"mlab-testing", "", client, nil, true}
+	cqh, err := tq.NewChannelQueueHandler(config, "test-queue", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cloud/tq/tq_integration_test.go
+++ b/cloud/tq/tq_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/cloud/tq"
 	"google.golang.org/api/iterator"
 )
@@ -74,7 +75,7 @@ func TestIsEmpty(t *testing.T) {
 // check that the bucket content has not been changed.
 func TestPostDay(t *testing.T) {
 	// Use a fake queue client.
-	client, counter := tq.DryRunQueuerClient()
+	client, counter := cloud.DryRunQueuerClient()
 	q, err := tq.NewQueueHandler(client, "fake-project", "test-queue")
 	if err != nil {
 		t.Fatal(err)

--- a/cloud/tq/tq_test.go
+++ b/cloud/tq/tq_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/cloud/tq"
 )
 
@@ -15,8 +16,9 @@ func init() {
 
 func TestPostOneTask(t *testing.T) {
 	os.Setenv("PROJECT", "mlab-testing")
-	client, counter := tq.DryRunQueuerClient()
-	q, err := tq.NewQueueHandler(client, "mlab-testing", "test-queue")
+	client, counter := cloud.DryRunClient()
+	config := cloud.Config{Client: client, Project: "mlab-testing"}
+	q, err := tq.NewQueueHandler(config, "test-queue")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -123,7 +123,7 @@ func dispatcherFromEnv(client *http.Client) (*dispatch.Dispatcher, error) {
 		return nil, err
 	}
 
-	config := cloud.Config{env.Project, env.Dataset, client, nil, false}
+	config := cloud.Config{Project: env.Project, Dataset: env.Dataset, Client: client, Options: nil, TestMode: false}
 	return dispatch.NewDispatcher(config, env.QueueBase, env.NumQueues, env.StartDate, ds)
 }
 

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/m-lab/etl-gardener/cloud"
+
 	"github.com/m-lab/etl-gardener/dispatch"
 	"github.com/m-lab/etl-gardener/state"
 
@@ -33,6 +35,7 @@ type environment struct {
 	// Vars for newDispatcher
 	Error     error
 	Project   string
+	Dataset   string
 	QueueBase string
 	NumQueues int
 	StartDate time.Time
@@ -90,6 +93,8 @@ func LoadEnv() {
 
 	env.Commit = os.Getenv("GIT_COMMIT")
 	env.Release = os.Getenv("RELEASE_TAG")
+
+	env.Dataset = os.Getenv("DATASET")
 }
 
 func init() {
@@ -118,7 +123,8 @@ func dispatcherFromEnv(client *http.Client) (*dispatch.Dispatcher, error) {
 		return nil, err
 	}
 
-	return dispatch.NewDispatcher(client, env.Project, env.QueueBase, env.NumQueues, env.StartDate, ds)
+	config := cloud.Config{env.Project, env.Dataset, client, nil, false}
+	return dispatch.NewDispatcher(config, env.QueueBase, env.NumQueues, env.StartDate, ds)
 }
 
 // StartDateRFC3339 is the date at which reprocessing will start when it catches

--- a/dispatch/deduphandler_test.go
+++ b/dispatch/deduphandler_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/m-lab/etl-gardener/api"
 	"github.com/m-lab/etl-gardener/cloud"
-	"github.com/m-lab/etl-gardener/cloud/tq"
 	"github.com/m-lab/etl-gardener/dispatch"
 	"github.com/m-lab/etl-gardener/state"
 	"google.golang.org/api/option"
@@ -21,7 +20,7 @@ func assertTaskPipe() {
 // This is much too whitebox.  Can we find better abstractions to improve testing?
 func TestDedupHandler(t *testing.T) {
 	// Use a fake client so we intercept all the http ops.
-	client, counter := tq.DryRunQueuerClient()
+	client, counter := cloud.DryRunClient()
 
 	config := cloud.Config{Project: "mlab-testing", Dataset: "batch", Client: client,
 		Options: []option.ClientOption{option.WithHTTPClient(client)}, TestMode: true}

--- a/dispatch/deduphandler_test.go
+++ b/dispatch/deduphandler_test.go
@@ -23,8 +23,8 @@ func TestDedupHandler(t *testing.T) {
 	// Use a fake client so we intercept all the http ops.
 	client, counter := tq.DryRunQueuerClient()
 
-	config := cloud.Config{"mlab-testing", "batch", client,
-		[]option.ClientOption{option.WithHTTPClient(client)}, true}
+	config := cloud.Config{Project: "mlab-testing", Dataset: "batch", Client: client,
+		Options: []option.ClientOption{option.WithHTTPClient(client)}, TestMode: true}
 
 	dedup := dispatch.NewDedupHandler(config)
 

--- a/dispatch/deduphandler_test.go
+++ b/dispatch/deduphandler_test.go
@@ -2,11 +2,11 @@ package dispatch_test
 
 import (
 	"log"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/m-lab/etl-gardener/api"
+	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/cloud/tq"
 	"github.com/m-lab/etl-gardener/dispatch"
 	"github.com/m-lab/etl-gardener/state"
@@ -23,10 +23,10 @@ func TestDedupHandler(t *testing.T) {
 	// Use a fake client so we intercept all the http ops.
 	client, counter := tq.DryRunQueuerClient()
 
-	os.Setenv("PROJECT", "mlab-testing")
-	os.Setenv("DATASET", "batch")
+	config := cloud.Config{"mlab-testing", "batch", client,
+		[]option.ClientOption{option.WithHTTPClient(client)}, true}
 
-	dedup := dispatch.NewDedupHandler(option.WithHTTPClient(client))
+	dedup := dispatch.NewDedupHandler(config)
 
 	// TODO - also test with inconsistent state.
 	dedup.Sink() <- state.Task{Name: "gs://gfr/sidestream/2001/01/01/", State: state.Stabilizing}

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -9,7 +9,6 @@ import (
 	"google.golang.org/api/option"
 
 	"github.com/m-lab/etl-gardener/cloud"
-	"github.com/m-lab/etl-gardener/cloud/tq"
 	"github.com/m-lab/etl-gardener/dispatch"
 	"github.com/m-lab/etl-gardener/state"
 )
@@ -51,7 +50,7 @@ func xTestSaver(t *testing.T) {
 
 func TestDispatcherLifeCycle(t *testing.T) {
 	// Use a fake client so we intercept all the http ops.
-	client, counter := tq.DryRunQueuerClient()
+	client, counter := cloud.DryRunClient()
 	config := cloud.Config{Project: "mlab-testing", Dataset: "dataset", Client: client, Options: nil, TestMode: true}
 
 	saver := S{tasks: make(map[string][]state.Task)}

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -8,6 +8,7 @@ import (
 
 	"google.golang.org/api/option"
 
+	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/cloud/tq"
 	"github.com/m-lab/etl-gardener/dispatch"
 	"github.com/m-lab/etl-gardener/state"
@@ -49,17 +50,16 @@ func xTestSaver(t *testing.T) {
 }
 
 func TestDispatcherLifeCycle(t *testing.T) {
-	os.Setenv("PROJECT", "mlab-testing")
-	os.Setenv("UNIT_TEST_MODE", "true")
 	// Use a fake client so we intercept all the http ops.
 	client, counter := tq.DryRunQueuerClient()
+	config := cloud.Config{"mlab-testing", "dataset", client, nil, true}
 
 	saver := S{tasks: make(map[string][]state.Task)}
 
 	// With time.Now(), this shouldn't send any requests.
 	// Inject fake client for bucket ops, so it doesn't hit the backends at all.
 	// Construction will trigger 4 HTTP calls, one to check that each queue is empty.
-	d, err := dispatch.NewDispatcher(client, "mlab-testing", "test-queue-", 3, time.Now(), &saver, option.WithHTTPClient(client))
+	d, err := dispatch.NewDispatcher(config, "test-queue-", 3, time.Now(), &saver, option.WithHTTPClient(client))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -52,7 +52,7 @@ func xTestSaver(t *testing.T) {
 func TestDispatcherLifeCycle(t *testing.T) {
 	// Use a fake client so we intercept all the http ops.
 	client, counter := tq.DryRunQueuerClient()
-	config := cloud.Config{"mlab-testing", "dataset", client, nil, true}
+	config := cloud.Config{Project: "mlab-testing", Dataset: "dataset", Client: client, Options: nil, TestMode: true}
 
 	saver := S{tasks: make(map[string][]state.Task)}
 

--- a/reproc/dispatch_test.go
+++ b/reproc/dispatch_test.go
@@ -1,6 +1,7 @@
 package reproc_test
 
 import (
+	"log"
 	"math/rand"
 	"testing"
 	"time"
@@ -8,6 +9,11 @@ import (
 	"github.com/m-lab/etl-gardener/reproc"
 	"github.com/m-lab/etl-gardener/state"
 )
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
 
 func assertTaskPipe(t state.Terminator) {
 	func(t state.Terminator) {}(&reproc.Terminator{})


### PR DESCRIPTION
This introduces a cloud package, and defines a Config struct, which specifies Project/Dataset, http client for communicating with services, ClientOptions, and TestMode, which may be used to control behavior for unit tests when fakes are infeasible, and emulator is not available.

