### PR TITLE
Switch to task based dispatching/processing

### DIFF
--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -129,7 +129,7 @@ func (th *TaskHandler) AddTask(prefix string) error {
 	}
 }
 
-// RestartTasks queries the status, and restarts all the tasks.
+// RestartTasks restarts all the tasks, allocating queues as needed.
 // SHOULD ONLY be called at startup.
 // Returns date of next jobs to process.
 func (th *TaskHandler) RestartTasks(tasks []state.Task) (time.Time, error) {

--- a/rex/rex.go
+++ b/rex/rex.go
@@ -277,8 +277,6 @@ func waitForJob(ctx context.Context, job *bigquery.Job, maxBackoff time.Duration
 		}
 		if status.Done() {
 			break
-		} else {
-			log.Println(status.State)
 		}
 		if backoff+previous < maxBackoff {
 			tmp := previous

--- a/rex/rex.go
+++ b/rex/rex.go
@@ -151,7 +151,6 @@ func (rex *ReprocessingExecutor) waitForParsing(t *state.Task, terminate <-chan 
 		default:
 		}
 		if err == tq.ErrMoreTasks {
-			log.Println(err)
 			// Wait 5-15 seconds before checking again.
 			time.Sleep(time.Duration(5+rand.Intn(10)) * time.Second)
 		} else if err != nil {

--- a/state/state.go
+++ b/state/state.go
@@ -141,7 +141,6 @@ func NewTask(name string, queue string, saver Saver) (*Task, error) {
 	return &t, nil
 }
 
-// HACK - remove from tq package?
 const start = `^gs://(?P<bucket>.*)/(?P<exp>[^/]*)/`
 const datePath = `(?P<datepath>\d{4}/[01]\d/[0123]\d)/`
 
@@ -248,7 +247,6 @@ func nop() {}
 
 // Process handles all steps of processing a task.
 func (t Task) Process(ex Executor, doneWithQueue func(), term Terminator) {
-	log.Println("Starting:", t.Name)
 loop:
 	for t.State != Done { //&& t.ErrMsg == "" {
 		select {
@@ -256,7 +254,6 @@ loop:
 			t.SetError(ErrTaskSuspended, "Terminating")
 			break loop
 		default:
-			log.Println("Doing ", StateNames[t.State], t.Name)
 			switch t.State {
 			case Processing:
 				ex.Next(&t, term.GetNotifyChannel())


### PR DESCRIPTION
This enables the task based dispatching scheme.
1.  Uses go-routine per date.
2.  On startup, restarts all tasks tracked in datastore.
3.  Reduces some log spam.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/68)
<!-- Reviewable:end -->
