### PR TITLE
write error msgs to status

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -291,11 +291,14 @@ func WriteHTMLStatusTo(w io.Writer, project string) error {
 	defer cancel()
 	tasks, err := ds.GetStatus(ctx)
 	if err != nil {
-		log.Println(err)
+		fmt.Fprintln(w, "Error executing Datastore query:", err)
+		fmt.Fprintln(w, "Project:", project)
+		log.Println(project, err)
 		return err
 	}
 
 	if ctx.Err() != nil {
+		fmt.Fprintln(w, "Context error executing Datastore query:", err)
 		return err
 	}
 	fmt.Fprintf(w, "<div>\nTask State</br>\n")


### PR DESCRIPTION
Seeing errors when fetching tasks from datastore.  This improves error propagation to status page, and improves debug message in log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/70)
<!-- Reviewable:end -->
