### PR TITLE
Fix: Quote value for true

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
@@ -81,4 +81,4 @@ spec:
             cpu: "1"
 
       nodeSelector:
-        gardener-node: true
+        gardener-node: "true"


### PR DESCRIPTION
Evidently kubectl apply requires that the value be in quotes. Likely it is parsing the `true` value as a bool instead of a string.

This PR adds quotes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/84)
<!-- Reviewable:end -->
