### PR TITLE
Error metrics

### DIFF
--- a/cloud/bq/dedup.go
+++ b/cloud/bq/dedup.go
@@ -138,8 +138,6 @@ func Dedup(dsExt *bqext.Dataset, src string, destTable *bigquery.Table) (*bigque
 	if !strings.Contains(destTable.TableID, "$") {
 		meta, err := destTable.Metadata(context.Background())
 		if err == nil && meta.TimePartitioning != nil {
-			log.Println(err)
-			metrics.FailCount.WithLabelValues("BadDestTable")
 			return nil, errors.New("Destination table must specify partition")
 		}
 	}
@@ -152,8 +150,8 @@ func Dedup(dsExt *bqext.Dataset, src string, destTable *bigquery.Table) (*bigque
 	case strings.HasPrefix(destTable.TableID, "ndt"):
 		queryString = fmt.Sprintf(dedupTemplateNDT, src)
 	default:
-		metrics.FailCount.WithLabelValues("UnknownTableType")
-		return nil, errors.New("Only handles sidestream, ndt, not " + destTable.TableID)
+		log.Println("Only handles sidestream, ndt, not " + destTable.TableID)
+		return nil, errors.New("Unknown table type")
 	}
 	query := dsExt.DestQuery(queryString, destTable, bigquery.WriteTruncate)
 

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -164,6 +164,7 @@ queueLoop:
 			if strings.TrimSpace(t.Queue) != t.Queue {
 				log.Println("invalid queue name", t)
 				metrics.FailCount.WithLabelValues("bad queue name").Inc()
+				// Skip updating task date, as this entry is somehow corrupted.
 				continue
 			}
 			_, ok := queues[t.Queue]

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -172,8 +172,9 @@ queueLoop:
 				log.Println("Restarting", t)
 				th.StartTask(t)
 			} else {
-				// TODO - add metric
 				log.Println("Queue", t.Queue, "already in use.  Skipping", t)
+				metrics.FailCount.WithLabelValues("queue not available").Inc()
+				continue
 			}
 		} else {
 			// No queue, just restart...

--- a/rex/rex.go
+++ b/rex/rex.go
@@ -303,6 +303,9 @@ func waitForJob(ctx context.Context, job *bigquery.Job, maxBackoff time.Duration
 			if strings.Contains(status.Err().Error(), "Not found: Table") {
 				return state.ErrTableNotFound
 			}
+			if strings.Contains(status.Err().Error(), "rows belong to different partitions") {
+				return state.ErrRowsFromOtherPartition
+			}
 		} else if status.Done() {
 			break
 		}

--- a/rex/rex.go
+++ b/rex/rex.go
@@ -298,16 +298,12 @@ func waitForJob(ctx context.Context, job *bigquery.Job, maxBackoff time.Duration
 		status, err := job.Status(ctx)
 		if err != nil {
 			log.Println(err)
-			continue
-		}
-		if status.Err() != nil {
+		} else if status.Err() != nil {
 			log.Println(job.ID(), status.Err())
 			if strings.Contains(status.Err().Error(), "Not found: Table") {
 				return state.ErrTableNotFound
 			}
-			continue
-		}
-		if status.Done() {
+		} else if status.Done() {
 			break
 		}
 		if backoff+previous < maxBackoff {

--- a/rex/rex.go
+++ b/rex/rex.go
@@ -297,6 +297,9 @@ func waitForJob(ctx context.Context, job *bigquery.Job, maxBackoff time.Duration
 			if strings.Contains(status.Err().Error(), "rows belong to different partitions") {
 				return state.ErrRowsFromOtherPartition
 			}
+			if backoff == maxBackoff {
+				return status.Err()
+			}
 		} else if status.Done() {
 			break
 		}

--- a/rex/rex.go
+++ b/rex/rex.go
@@ -117,7 +117,7 @@ func (rex *ReprocessingExecutor) Next(t *state.Task, terminate <-chan struct{}) 
 	case state.Deduplicating:
 		if err := rex.dedup(t); err != nil {
 			// SetError also pushes to datastore, like Update()
-			t.SetError(err, "rex.Dedup")
+			t.SetError(err, "rex.dedup")
 			return err
 		}
 		t.Update(state.Finishing)
@@ -161,8 +161,7 @@ func (rex *ReprocessingExecutor) waitForParsing(t *state.Task, terminate <-chan 
 	// Don't want to accept a date until we can actually queue it.
 	qh, err := tq.NewQueueHandler(rex.Config, t.Queue)
 	if err != nil {
-		metrics.FailCount.WithLabelValues("NewQueueHandler")
-		t.SetError(err, "NewQueueHandler: "+t.Name)
+		t.SetError(err, "NewQueueHandler")
 		return err
 	}
 	log.Println("Wait for empty queue ", qh.Queue)
@@ -199,7 +198,6 @@ func (rex *ReprocessingExecutor) queue(t *state.Task) (int, error) {
 	//func (qh *ChannelQueueHandler) handleLoop(next api.BasicPipe, bucketOpts ...option.ClientOption) {
 	qh, err := tq.NewQueueHandler(rex.Config, t.Queue)
 	if err != nil {
-		metrics.FailCount.WithLabelValues("NewQueueHandler")
 		t.SetError(err, "NewQueueHandler")
 		return 0, err
 	}
@@ -207,7 +205,6 @@ func (rex *ReprocessingExecutor) queue(t *state.Task) (int, error) {
 	if err != nil {
 		// If there is a parse error, log and skip request.
 		log.Println(err)
-		metrics.FailCount.WithLabelValues("BadPrefix").Inc()
 		t.SetError(err, "BadPrefix")
 		return 0, err
 	}
@@ -218,7 +215,6 @@ func (rex *ReprocessingExecutor) queue(t *state.Task) (int, error) {
 	storageClient, err := storage.NewClient(context.Background(), rex.BucketOpts...)
 	if err != nil {
 		log.Println(err)
-		metrics.FailCount.WithLabelValues("StorageClientError").Inc()
 		t.SetError(err, "StorageClientError")
 		return 0, err
 	}
@@ -230,7 +226,6 @@ func (rex *ReprocessingExecutor) queue(t *state.Task) (int, error) {
 			return 0, nil
 		}
 		log.Println(err)
-		metrics.FailCount.WithLabelValues("BucketError").Inc()
 		t.SetError(err, "BucketError")
 		return 0, err
 	}
@@ -239,7 +234,6 @@ func (rex *ReprocessingExecutor) queue(t *state.Task) (int, error) {
 	n, err := qh.PostDay(bucket, bucketName, parts[1]+"/"+parts[2]+"/")
 	if err != nil {
 		log.Println(err)
-		metrics.FailCount.WithLabelValues("PostDayError").Inc()
 		t.SetError(err, "PostDayError")
 		return n, nil
 	}
@@ -251,13 +245,11 @@ func (rex *ReprocessingExecutor) dedup(t *state.Task) error {
 	// Launch the dedup request, and save the JobID
 	ds, err := rex.GetDS()
 	if err != nil {
-		metrics.FailCount.WithLabelValues("NewDataset")
 		t.SetError(err, "GetDS")
 		return err
 	}
 	src, dest, err := t.SourceAndDest(&ds)
 	if err != nil {
-		metrics.FailCount.WithLabelValues("SourceAndDest")
 		t.SetError(err, "SourceAndDest")
 		return err
 	}
@@ -273,7 +265,6 @@ func (rex *ReprocessingExecutor) dedup(t *state.Task) error {
 			}
 		} else {
 			log.Println(err, src.FullyQualifiedName())
-			metrics.FailCount.WithLabelValues("DedupFailed")
 			t.SetError(err, "DedupFailed")
 			return err
 		}
@@ -326,19 +317,16 @@ func (rex *ReprocessingExecutor) finish(t *state.Task, terminate <-chan struct{}
 	// TODO use a simple client instead of creating dataset?
 	ds, err := bqext.NewDataset(rex.Project, rex.BQDataset, rex.Options...)
 	if err != nil {
-		metrics.FailCount.WithLabelValues("NewDataset")
 		t.SetError(err, "NewDataset")
 		return err
 	}
 	src, _, err := t.SourceAndDest(&ds)
 	if err != nil {
-		metrics.FailCount.WithLabelValues("SourceAndDest")
 		t.SetError(err, "SourceAndDest")
 		return err
 	}
 	job, err := ds.BqClient.JobFromID(context.Background(), t.JobID)
 	if err != nil {
-		metrics.FailCount.WithLabelValues("JobFromID")
 		t.SetError(err, "JobFromID")
 		return err
 	}
@@ -346,16 +334,14 @@ func (rex *ReprocessingExecutor) finish(t *state.Task, terminate <-chan struct{}
 	err = waitForJob(context.Background(), job, 10*time.Second, terminate)
 	if err != nil {
 		log.Println(err, src.FullyQualifiedName())
-		metrics.FailCount.WithLabelValues("JobTableNotFound")
-		t.SetError(err, "JobTableNotFound")
+		t.SetError(err, "waitForJob")
 		return err
 	}
 	status, err := job.Wait(context.Background())
 	if err != nil {
 		if err != state.ErrTaskSuspended {
 			log.Println(status.Err(), src.FullyQualifiedName())
-			metrics.FailCount.WithLabelValues("DedupJobWait")
-			t.SetError(err, "DedupJobWait")
+			t.SetError(err, "job.Wait")
 		}
 		return err
 	}
@@ -368,8 +354,7 @@ func (rex *ReprocessingExecutor) finish(t *state.Task, terminate <-chan struct{}
 	err = src.Delete(ctx)
 	if err != nil {
 		log.Println(err)
-		metrics.FailCount.WithLabelValues("TableDeleteErr")
-		t.SetError(err, "TableDeleteErr")
+		t.SetError(err, "TableDelete")
 		return err
 	}
 

--- a/state/state.go
+++ b/state/state.go
@@ -47,9 +47,10 @@ var StateNames = map[State]string{
 
 // Task Errors
 var (
-	ErrInvalidQueue  = errors.New("invalid queue")
-	ErrTaskSuspended = errors.New("task suspended")
-	ErrTableNotFound = errors.New("Not found: Table")
+	ErrInvalidQueue           = errors.New("invalid queue")
+	ErrTaskSuspended          = errors.New("task suspended")
+	ErrTableNotFound          = errors.New("Not found: Table")
+	ErrRowsFromOtherPartition = errors.New("Rows belong to different partition")
 )
 
 // Executor describes an object that can do all the required steps to execute a Task.

--- a/state/state.go
+++ b/state/state.go
@@ -221,6 +221,7 @@ func (t *Task) Delete() error {
 
 // SetError adds error information and saves to the "saver"
 func (t *Task) SetError(err error, info string) error {
+	metrics.FailCount.WithLabelValues(info)
 	if t.saver == nil {
 		return ErrNoSaver
 	}


### PR DESCRIPTION
Cleans up FailCount metric, and adds explicit handling of "rows belong to different partitions"

Also fixes a small bug where we were continuing retry loop, without doubling the backoff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/86)
<!-- Reviewable:end -->
