### PR TITLE
Update Sidestream start date and use standard DATASET names

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
@@ -46,13 +46,13 @@ spec:
         - name: TASKFILE_BUCKET
           value: "scraper-{{GCLOUD_PROJECT}}"  # NOTE: if we start deleting unembargoed files from scraper, this will no longer work.
         - name: START_DATE
-          value: "20170601"
+          value: "20160101"
         - name: EXPERIMENT
-          value: "sidestream"  # For example "ndt,sidestream,switch"
+          value: "sidestream"
         - name: DATASET
-          value: private
+          value: "batch"
         - name: FINAL_DATASET
-          value: ""  # e.g. base_tables
+          value: "base_tables"
         - name: QUEUE_BASE
           value: "etl-sidestream-batch-"
         - name: NUM_QUEUES


### PR DESCRIPTION
This change updates the sidestream gardener deployment to use standard DATASET names and to start processing at an earlier date to overlap with legacy tables and cover the full period where data should be unembargoed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/93)
<!-- Reviewable:end -->
