### PR TITLE
Remove references to measurement-lab

### DIFF
--- a/cloud/bq/README.md
+++ b/cloud/bq/README.md
@@ -6,7 +6,7 @@ the table into the corresponding partition in __destination_table__.
 
 ## Useful bits:
 
-1. bq show --format=prettyjson measurement-lab.batch.ndt_* will give
+1. bq show --format=prettyjson mlab-oti.batch.ndt_* will give
  the summary for the whole set.  Using HTTP, this would be a get request:
  ```
 GET https://www.googleapis.com/bigquery/v2/projects/projectId/datasets/datasetId/tables/tableId

--- a/cloud/bq/dedup.go
+++ b/cloud/bq/dedup.go
@@ -90,7 +90,7 @@ ErrorTimeout:
 }
 
 // This template expects to be executed on a table containing a single day's data, such
-// as measurement-lab:batch.ndt_20170601.
+// as mlab-oti:batch.ndt_20170601.
 //
 // Some tests are collected as both uncompressed and compressed files. In some historical
 // archives (June 2017), files for a single test appear in different tar files, which

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -26,8 +26,8 @@ type Config struct {
 type BQConfig struct {
 	Config
 
-	// In prod, most services are from mlab-oti, but BQ tables may be in measurement-lab.
-	// So we provide a separate BQProject
+	// Services should run in and write to tables in the same project.
+	// TODO: deprecate BQProject in favor of Config.Project.
 	BQProject string // Project for BigQuery tables
 
 	// TODO: Consider generalizing BQConfig structure & moving to m-lab/go/cloud.

--- a/cmd/gardener/README.md
+++ b/cmd/gardener/README.md
@@ -10,8 +10,4 @@ For example:
 go run cmd/gardener/gardener.go -project mlab-oti -day 2017/10/01
 ```
 
-The pipeline job runs in mlab-oti, so I've granted bigquery.dataeditor
-permissions to measurement-lab for mlab-oti@appspot.gserviceaccount.com,
-but this is more permissive that I would like.  We should use a service-account
-instead.  One already exists called etl-pipeline that would
-probably make most sense.
+The batch pipeline job also runs in and writes to mlab-oti.


### PR DESCRIPTION
This change updates docstrings through out gardener source to not refer to measurement-lab.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/96)
<!-- Reviewable:end -->
