### PR TITLE
fix CopyConfig bug

### DIFF
--- a/cloud/bq/sanity.go
+++ b/cloud/bq/sanity.go
@@ -383,7 +383,7 @@ func SanityCheckAndCopy(ctx context.Context, src, dest *AnnotatedTable) error {
 	config := bqiface.CopyConfig{}
 	config.WriteDisposition = bigquery.WriteTruncate
 	config.Dst = dest.Table
-	copier.SetCopyConfig(bqiface.CopyConfig{})
+	copier.SetCopyConfig(config)
 	log.Println("Copying...", src.TableID())
 	job, err := copier.Run(ctx)
 	if err != nil {

--- a/cloud/bq/sanity.go
+++ b/cloud/bq/sanity.go
@@ -382,6 +382,7 @@ func SanityCheckAndCopy(ctx context.Context, src, dest *AnnotatedTable) error {
 	copier := dest.Table.CopierFrom(src.Table)
 	config := bqiface.CopyConfig{}
 	config.WriteDisposition = bigquery.WriteTruncate
+	config.Dst = dest.Table
 	copier.SetCopyConfig(bqiface.CopyConfig{})
 	log.Println("Copying...", src.TableID())
 	job, err := copier.Run(ctx)

--- a/cloud/bq/sanity_test.go
+++ b/cloud/bq/sanity_test.go
@@ -1,8 +1,12 @@
 package bq
 
 import (
+	"context"
 	"log"
+	"strings"
 	"testing"
+
+	"github.com/m-lab/go/dataset"
 )
 
 func init() {
@@ -46,5 +50,25 @@ func Test_getTableParts(t *testing.T) {
 	parts, err = getTableParts("table$20162102")
 	if err == nil {
 		t.Error("Should error when partition is invalid")
+	}
+}
+
+func TestSanityCheckAndCopy(t *testing.T) {
+	ctx := context.Background()
+	ds, err := dataset.NewDataset(ctx, "project", "dataset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := ds.Table("foo_19990101")
+	dest := ds.Table("foo$19990101")
+	srcAt := NewAnnotatedTable(src, &ds)
+	destAt := NewAnnotatedTable(dest, &ds)
+
+	err = SanityCheckAndCopy(ctx, srcAt, destAt)
+	if err == nil {
+		t.Fatal("Should have 404 error")
+	}
+	if !strings.HasPrefix(err.Error(), "googleapi: Error 404") {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
The SetCopyConfig requires non-nil Dst.  The copier already has this, so ideally the library should copy it, but it does not, so we copy it beforehand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/102)
<!-- Reviewable:end -->
