### PR TITLE
cloud/bq test coverage improvements

### DIFF
--- a/cloud/bq/sanity_integration_test.go
+++ b/cloud/bq/sanity_integration_test.go
@@ -204,31 +204,11 @@ func TestAnnotatedTableGetPartitionInfo(t *testing.T) {
 
 	tbl := dsExt.Table("DedupTest$19990101")
 	at := bq.NewAnnotatedTable(tbl, &dsExt)
-	// Test nil context.
-	_, err = at.GetPartitionInfo(nil)
-	if err == nil {
-		t.Error("Should error on nil ctx")
-	}
-
-	// Test initial fetch
 	info, err := at.GetPartitionInfo(ctx)
 	if err != nil {
 		t.Error(err)
 	} else if info.PartitionID != "19990101" {
 		t.Error("wrong partitionID: " + info.PartitionID)
-	}
-	// Check cached code path
-	info, err = at.GetPartitionInfo(ctx)
-	if err != nil {
-		t.Error(err)
-	} else if info.PartitionID != "19990101" {
-		t.Error("wrong partitionID: " + info.PartitionID)
-	}
-
-	// Once cache is populated, also ok to send a nil ctx.
-	_, err = at.GetPartitionInfo(nil)
-	if err != nil {
-		t.Error(err)
 	}
 
 	// Check behavior for missing partition

--- a/cloud/bq/sanity_integration_test.go
+++ b/cloud/bq/sanity_integration_test.go
@@ -55,7 +55,7 @@ func TestGetTableDetail(t *testing.T) {
 	}
 }
 
-func TestAnnotationTableMeta(t *testing.T) {
+func TestCachedMeta(t *testing.T) {
 	// TODO - Make NewDataSet return a pointer, for consistency with bigquery.
 	ctx := context.Background()
 	dsExt, err := dataset.NewDataset(ctx, "mlab-testing", "src")
@@ -87,62 +87,7 @@ func TestAnnotationTableMeta(t *testing.T) {
 	}
 }
 
-func TestAnnotationDetail(t *testing.T) {
-	ctx := context.Background()
-	dsExt, err := dataset.NewDataset(ctx, "mlab-testing", "src")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tbl := dsExt.Table("DedupTest")
-
-	at := bq.NewAnnotatedTable(tbl, &dsExt)
-	// Fetch cache detail - which hits backend
-	_, err = at.CachedDetail(ctx)
-	if err != nil {
-		t.Error(err)
-	}
-	// Fetch again, exercising the cached code path.
-	_, err = at.CachedDetail(ctx)
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func TestAnnotationMeta(t *testing.T) {
-	ctx := context.Background()
-	dsExt, err := dataset.NewDataset(ctx, "mlab-testing", "src")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tbl := dsExt.Table("DedupTest")
-	meta, err := tbl.Metadata(ctx)
-	if err != nil {
-		t.Error(err)
-	} else if meta == nil {
-		t.Error("Meta should not be nil")
-	}
-
-	at := bq.NewAnnotatedTable(tbl, &dsExt)
-	// Fetch cache detail - which hits backend
-	meta, err = at.CachedMeta(ctx)
-	if err != nil {
-		t.Error(err)
-	} else if meta == nil {
-		t.Error("Meta should not be nil")
-	}
-	// Fetch again, exercising the cached code path.
-	meta, err = at.CachedMeta(ctx)
-	if err != nil {
-		t.Error(err)
-	} else if meta == nil {
-		t.Error("Meta should not be nil")
-	}
-
-}
-
-func TestAnnotationPartitionInfo(t *testing.T) {
+func TestCachedPartitionInfo(t *testing.T) {
 	ctx := context.Background()
 	dsExt, err := dataset.NewDataset(ctx, "mlab-testing", "src")
 	if err != nil {
@@ -223,7 +168,7 @@ func TestAnnotatedTableGetPartitionInfo(t *testing.T) {
 
 }
 
-func TestAnnotatedTable(t *testing.T) {
+func TestCachedDetail(t *testing.T) {
 	ctx := context.Background()
 	ds, err := dataset.NewDataset(ctx, "mlab-testing", "src")
 	if err != nil {

--- a/cloud/bq/sanity_integration_test.go
+++ b/cloud/bq/sanity_integration_test.go
@@ -149,7 +149,7 @@ func TestAnnotationPartitionInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tbl := dsExt.Table("DedupTest")
+	tbl := dsExt.Table("DedupTest$19990101")
 
 	at := bq.NewAnnotatedTable(tbl, &dsExt)
 	// Fetch cache detail - which hits backend
@@ -225,11 +225,11 @@ func TestAnnotatedTableGetPartitionInfo(t *testing.T) {
 
 func TestAnnotatedTable(t *testing.T) {
 	ctx := context.Background()
-	ds, err := dataset.NewDataset(ctx, "mlab-testing", "go")
+	ds, err := dataset.NewDataset(ctx, "mlab-testing", "src")
 	if err != nil {
 		t.Fatal(err)
 	}
-	src := ds.Table("TestGetTableStats")
+	src := ds.Table("DedupTest")
 	srcAt := bq.NewAnnotatedTable(src, &ds)
 	// Fetch detail.
 	_, err = srcAt.CachedDetail(ctx)


### PR DESCRIPTION
Minor improvements to sanity_integration_test.go, and introduction of a basic dataset fake in sanity_test.go

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/105)
<!-- Reviewable:end -->
