### PR TITLE
Add task date of most recent datastore update, per state

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -10,6 +10,7 @@ func init() {
 	prometheus.MustRegister(StartedCount)
 	prometheus.MustRegister(CompletedCount)
 	prometheus.MustRegister(StateTimeSummary)
+	prometheus.MustRegister(StateDate)
 }
 
 var (
@@ -76,12 +77,26 @@ var (
 	// Provides metrics:
 	//   gardener_tasks_in_flight
 	// Example usage:
-	// metrics.TasksInFlight.Inc()
+	// metrics.TasksInFlight.Add(1)
 	TasksInFlight = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "gardener_tasks_in_flight",
 			Help: "Number of tasks in flight",
 		},
+	)
+
+	// StateDate identifies the date of the most recent update to each state.
+	//
+	// Provides metrics:
+	//   gardener_state_date
+	// Example usage:
+	// metrics.StateDate.WithLabelValues(StateNames[t.State]).Observe(time.Now())
+	StateDate = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gardener_state_date",
+			Help: "Most recent date for each state.",
+		},
+		[]string{"state"},
 	)
 
 	// StateTimeSummary measures the time spent in different task states.

--- a/state/state.go
+++ b/state/state.go
@@ -210,7 +210,7 @@ func (t *Task) Save(ctx context.Context) error {
 		return ErrNoSaver
 	}
 	t.UpdateTime = time.Now()
-	metrics.StateDate.WithLabelValues(StateNames[t.State]).SetToCurrentTime()
+	metrics.StateDate.WithLabelValues(StateNames[t.State]).Set(float64(t.Date.Unix()))
 	return t.saver.SaveTask(ctx, *t)
 }
 
@@ -220,7 +220,7 @@ func (t *Task) Update(ctx context.Context, st State) error {
 	metrics.StateTimeSummary.WithLabelValues(StateNames[t.State]).Observe(duration.Seconds())
 	t.State = st
 	t.UpdateTime = time.Now()
-	metrics.StateDate.WithLabelValues(StateNames[t.State]).SetToCurrentTime()
+	metrics.StateDate.WithLabelValues(StateNames[t.State]).Set(float64(t.Date.Unix()))
 	if t.saver == nil {
 		return ErrNoSaver
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -210,6 +210,7 @@ func (t *Task) Save(ctx context.Context) error {
 		return ErrNoSaver
 	}
 	t.UpdateTime = time.Now()
+	metrics.StateDate.WithLabelValues(StateNames[t.State]).SetToCurrentTime()
 	return t.saver.SaveTask(ctx, *t)
 }
 
@@ -219,6 +220,7 @@ func (t *Task) Update(ctx context.Context, st State) error {
 	metrics.StateTimeSummary.WithLabelValues(StateNames[t.State]).Observe(duration.Seconds())
 	t.State = st
 	t.UpdateTime = time.Now()
+	metrics.StateDate.WithLabelValues(StateNames[t.State]).SetToCurrentTime()
 	if t.saver == nil {
 		return ErrNoSaver
 	}


### PR DESCRIPTION
This should produce a sawtooth date pattern for each state, allowing insight into the progress for each data type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/108)
<!-- Reviewable:end -->
