### PR TITLE
add config.Srcs

### DIFF
--- a/cloud/bq/sanity.go
+++ b/cloud/bq/sanity.go
@@ -383,6 +383,7 @@ func SanityCheckAndCopy(ctx context.Context, src, dest *AnnotatedTable) error {
 	config := bqiface.CopyConfig{}
 	config.WriteDisposition = bigquery.WriteTruncate
 	config.Dst = dest.Table
+	config.Srcs = append(config.Srcs, src.Table)
 	copier.SetCopyConfig(config)
 	log.Println("Copying...", src.TableID())
 	job, err := copier.Run(ctx)


### PR DESCRIPTION
bqiface doesn't expose the various bigquery Configs.  This means that the configs have to be fully specified in order to change any field.

This PR fixes the missing Srcs from the CopyConfig.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/109)
<!-- Reviewable:end -->
