### PR TITLE
Use archive-mlab-oti instead of scraper-mlab-oti

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
@@ -44,7 +44,7 @@ spec:
         - name: PROJECT
           value: {{GCLOUD_PROJECT}}
         - name: TASKFILE_BUCKET
-          value: "scraper-{{GCLOUD_PROJECT}}"  # NOTE: if we start deleting unembargoed files from scraper, this will no longer work.
+          value: "archive-{{GCLOUD_PROJECT}}"
         - name: START_DATE
           value: "20160101"
         - name: EXPERIMENT


### PR DESCRIPTION
Found the problem with sidestream - still reading from the wrong bucket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/110)
<!-- Reviewable:end -->
