### PR TITLE
Update TASKFILE_BUCKET source and START_DATE

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
@@ -43,10 +43,11 @@ spec:
           value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
+        # NOTE: We read archives from the public archive for all projects.
         - name: TASKFILE_BUCKET
-          value: "archive-{{GCLOUD_PROJECT}}"
+          value: "archive-measurement-lab"
         - name: START_DATE
-          value: "20160501"
+          value: "20160501"  # Actual start date of switch data.
         - name: EXPERIMENT
           value: "switch"
         - name: DATASET

--- a/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
@@ -43,10 +43,11 @@ spec:
           value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
+        # NOTE: We read archives from the public archive for all projects.
         - name: TASKFILE_BUCKET
-          value: "archive-{{GCLOUD_PROJECT}}"
+          value: "archive-measurement-lab"
         - name: START_DATE
-          value: "20170101"  # Provide 6-month overlap with legacy tables.
+          value: "20150101"
         - name: EXPERIMENT
           value: "ndt"
         - name: DATASET

--- a/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
@@ -43,10 +43,11 @@ spec:
           value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: {{GCLOUD_PROJECT}}
+        # NOTE: We read archives from the public archive for all projects.
         - name: TASKFILE_BUCKET
-          value: "archive-{{GCLOUD_PROJECT}}"
+          value: "archive-measurement-lab"
         - name: START_DATE
-          value: "20160101"
+          value: "20150101"
         - name: EXPERIMENT
           value: "sidestream"
         - name: DATASET

--- a/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
@@ -43,10 +43,11 @@ spec:
           value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
+        # NOTE: We read archives from the public archive for all projects.
         - name: TASKFILE_BUCKET
-          value: "archive-{{GCLOUD_PROJECT}}"
+          value: "archive-measurement-lab"
         - name: START_DATE
-          value: "20170101"  # Provide 6-month overlap with legacy tables.
+          value: "20150101"
         - name: EXPERIMENT
           value: "paris-traceroute"
         - name: DATASET


### PR DESCRIPTION
This change update the TASKFILE bucket source to archive-measurement-lab so that all projects process the same data set and that the generated data comes from the same public archives accessible to the public.

This change updates the START_TIME to 20150101 to split partition dataset tables between pre2015 and post2015 to respect the 2500 partition limit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/111)
<!-- Reviewable:end -->
