### PR TITLE
use only 2 queues for PT

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
@@ -57,7 +57,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-traceroute-batch-"
         - name: NUM_QUEUES
-          value: "16"
+          value: "2"
 
         ports:
         - name: prometheus-port


### PR DESCRIPTION
Reduce the number of queues to limit PT throughput until we switch to the new schema.

We could alternatively just kill the PT instance of gardener, but would need to remove the deployments from travis.  This seems less disruptive in the long run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/118)
<!-- Reviewable:end -->
