### PR TITLE
Preserve error states

### DIFF
--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -90,6 +90,7 @@ func NewTaskHandler(exec state.Executor, queues []string, saver state.Saver) *Ta
 var ErrTerminating = errors.New("TaskHandler is terminating")
 
 // StartTask starts a single task.  It should be properly initialized except for saver.
+// If the task had previously errored, this should clear the error from datastore.
 func (th *TaskHandler) StartTask(ctx context.Context, t state.Task) {
 	t.SetSaver(th.saver)
 

--- a/rex/rex_test.go
+++ b/rex/rex_test.go
@@ -98,10 +98,10 @@ func TestWithTaskQueue(t *testing.T) {
 	if counter.Count() != 9 {
 		t.Error("Wrong number of client calls", counter.Count())
 	}
-	if len(saver.GetDeletes()) != 3 {
-		// TODO - these are no longer deleted, because of change in error handling.
-		// t.Error("Wrong number of task deletes", len(saver.GetDeletes()))
-	}
+
+	// TODO: The tasks currently end in error, so there are no task
+	// deletes.  If we change this behavior, we might want to check the
+	// value of saver.Deletes() here.
 
 	tasks := saver.GetTasks()
 	for _, task := range tasks {

--- a/rex/rex_test.go
+++ b/rex/rex_test.go
@@ -99,7 +99,8 @@ func TestWithTaskQueue(t *testing.T) {
 		t.Error("Wrong number of client calls", counter.Count())
 	}
 	if len(saver.GetDeletes()) != 3 {
-		t.Error("Wrong number of task deletes", len(saver.GetDeletes()))
+		// TODO - these are no longer deleted, because of change in error handling.
+		// t.Error("Wrong number of task deletes", len(saver.GetDeletes()))
 	}
 
 	tasks := saver.GetTasks()

--- a/state/state.go
+++ b/state/state.go
@@ -288,8 +288,13 @@ loop:
 			}
 		}
 	}
-	metrics.CompletedCount.WithLabelValues("todo - add exp type").Inc()
-	t.Delete(ctx)
+	if t.ErrMsg == "" {
+		// Only delete the state entry if it completed without error.
+		t.Delete(ctx)
+		metrics.CompletedCount.WithLabelValues("todo - add exp type").Inc()
+	} else {
+		metrics.CompletedCount.WithLabelValues(StateNames[t.State] + " Error").Inc()
+	}
 	term.Done()
 }
 


### PR DESCRIPTION
This changes the state updates to preserve datastore tasks that end in an error state.  The task should be reprocessed the next time around, but the task state should persist until then.

This also fixes the "completed" metrics to include error state information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/128)
<!-- Reviewable:end -->
