### PR TITLE
delay deleting dedup source

### DIFF
--- a/rex/rex.go
+++ b/rex/rex.go
@@ -411,7 +411,7 @@ func (rex *ReprocessingExecutor) finish(ctx context.Context, t *state.Task, term
 	}
 
 	// Delete templated dedup source table.
-	log.Println("Completed deduplication, deleting dedup source", src.FullyQualifiedName())
+	log.Println("Deleting dedup source", src.FullyQualifiedName())
 	// If deduplication was successful, we should delete the source table.
 	delCtx, cf := context.WithTimeout(ctx, time.Minute)
 	defer cf()

--- a/rex/rex.go
+++ b/rex/rex.go
@@ -372,19 +372,7 @@ func (rex *ReprocessingExecutor) finish(ctx context.Context, t *state.Task, term
 		return err
 	}
 
-	// Delete dedup source table.
-
-	// Wait for JobID to complete, then delete the template table.
-	log.Println("Completed deduplication, deleting source", src.FullyQualifiedName())
-	// If deduplication was successful, we should delete the source table.
-	delCtx, cf := context.WithTimeout(ctx, time.Minute)
-	defer cf()
-	err = src.Delete(delCtx)
-	if err != nil {
-		log.Println(err)
-		t.SetError(ctx, err, "TableDelete")
-		return err
-	}
+	log.Println("Completed deduplication from", src.FullyQualifiedName())
 
 	// Sanity check and copy things to final DS.
 	// ==========================================================================
@@ -421,5 +409,18 @@ func (rex *ReprocessingExecutor) finish(ctx context.Context, t *state.Task, term
 		t.SetError(ctx, err, "SanityCheckAndCopy")
 		return err
 	}
+
+	// Delete templated dedup source table.
+	log.Println("Completed deduplication, deleting dedup source", src.FullyQualifiedName())
+	// If deduplication was successful, we should delete the source table.
+	delCtx, cf := context.WithTimeout(ctx, time.Minute)
+	defer cf()
+	err = src.Delete(delCtx)
+	if err != nil {
+		log.Println(err)
+		t.SetError(ctx, err, "TableDelete")
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
Keep dedup source until after sanity-check.
If sanity check fails, we want the source table available for debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/130)
<!-- Reviewable:end -->
