### PR TITLE
update dedup query and table detail query

### DIFF
--- a/cloud/bq/sanity.go
+++ b/cloud/bq/sanity.go
@@ -168,22 +168,22 @@ func GetTableDetail(ctx context.Context, dsExt *dataset.Dataset, table bqiface.T
 	detail := Detail{}
 	queryString := fmt.Sprintf(`
 		#standardSQL
-		SELECT SUM(tests) AS TestCount, COUNT(DISTINCT task)-1 AS TaskFileCount
-		FROM (
-			-- This avoids null counts when the partition doesn't exist or is empty.
-  		    SELECT 0 AS tests, "fake-task" AS task
-  		    UNION ALL
-		  	SELECT COUNT(DISTINCT test_id) AS tests, task_filename AS task
-		  	FROM `+"`%s.%s`"+`
-		  	%s  -- where clause
-		  	GROUP BY task
-		)`, dataset, tableName, where)
+        SELECT SUM(tests) AS TestCount, COUNT(DISTINCT task)-1 AS TaskFileCount
+        FROM (
+            -- This avoids null counts when the partition doesn't exist or is empty.
+            SELECT 0 AS tests, "fake-task" AS task
+            UNION ALL
+            SELECT COUNT(DISTINCT test_id) AS tests, task_filename AS task
+            FROM `+"`%s.%s`"+`
+            %s  -- where clause
+            GROUP BY task
+        )`, dataset, tableName, where)
 
 	// TODO - this should take a context?
 	err := dsExt.QueryAndParse(ctx, queryString, &detail)
 	if err != nil {
 		log.Println(err)
-		log.Println("Query error:", queryString)
+		log.Println("Query:", queryString)
 	}
 	return &detail, err
 }

--- a/cloud/bq/sanity_integration_test.go
+++ b/cloud/bq/sanity_integration_test.go
@@ -37,7 +37,7 @@ func TestGetTableDetail(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	} else if detail.TaskFileCount != 2 || detail.TestCount != 4 {
-		t.Error("Wrong number of tasks or tests")
+		t.Errorf("Wrong number of tasks or tests %v\n", detail)
 	}
 
 	srcDS, err := dataset.NewDataset(ctx, "mlab-testing", "src")
@@ -50,8 +50,8 @@ func TestGetTableDetail(t *testing.T) {
 	detail, err = bq.GetTableDetail(ctx, &srcDS, srcDS.Table("DedupTest_19990101"))
 	if err != nil {
 		t.Error(err)
-	} else if detail.TaskFileCount != 2 || detail.TestCount != 6 {
-		t.Error("Wrong number of tasks or tests")
+	} else if detail.TaskFileCount != 2 || detail.TestCount != 4 {
+		t.Errorf("Wrong number of tasks or tests %v\n", detail)
 	}
 }
 


### PR DESCRIPTION
Story #138 
This also tightens the test count sanity check, and ignores the task count sanity check, so that we can clear the previously un-deduped dates in 2009 and 2012.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/140)
<!-- Reviewable:end -->
