### PR TITLE
promauto and prometheusx

### DIFF
--- a/cloud/tq/tq.go
+++ b/cloud/tq/tq.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/google-cloud-go-testing/storage/stiface"
 	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/api/iterator"
 	"google.golang.org/appengine/taskqueue"
 )
@@ -35,7 +36,7 @@ var (
 	ErrTerminated       = errors.New("terminated early")
 	ErrInvalidQueueName = errors.New("invalid queue name")
 
-	EmptyStatsRecoveryTimeHistogramSecs = prometheus.NewHistogramVec(
+	EmptyStatsRecoveryTimeHistogramSecs = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "gardener_empty_stats_recovery_sec",
 			Help: "empty stats recovery time distributions.",
@@ -48,10 +49,6 @@ var (
 		[]string{"status"},
 	)
 )
-
-func init() {
-	prometheus.MustRegister(EmptyStatsRecoveryTimeHistogramSecs)
-}
 
 // QueueHandler is much like tq.Queuer, but for a single queue.  We want
 // independent single queue handlers to avoid thread safety issues, among

--- a/cloud/tq/tq_test.go
+++ b/cloud/tq/tq_test.go
@@ -4,6 +4,8 @@ import (
 	"log"
 	"testing"
 
+	"github.com/m-lab/go/prometheusx"
+
 	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/cloud/tq"
 )
@@ -27,4 +29,9 @@ func TestPostOneTask(t *testing.T) {
 	if counter.Count() != 1 {
 		t.Error("Should have count of 1")
 	}
+}
+
+func TestMetrics(t *testing.T) {
+	tq.EmptyStatsRecoveryTimeHistogramSecs.WithLabelValues("x")
+	prometheusx.LintMetrics(t)
 }

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -273,7 +273,9 @@ func setupService(ctx context.Context) error {
 	// Enable block profiling
 	runtime.SetBlockProfileRate(1000000) // One event per msec.
 
+	// Expose prometheus and pprof metrics on a separate port.
 	prometheusx.MustStartPrometheus(":9090")
+
 	// We also setup another prometheus handler on a non-standard path. This
 	// path name will be accessible through the AppEngine service address,
 	// however it will be served by a random instance.

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -12,12 +12,13 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/http/pprof"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/m-lab/go/prometheusx"
 
 	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/reproc"
@@ -228,23 +229,6 @@ const StartDateRFC3339 = "2017-05-01T00:00:00Z"
 //  Top level service control code.
 // ###############################################################################
 
-func setupPrometheus() {
-	// Define a custom serve mux for prometheus to listen on a separate port.
-	// We listen on a separate port so we can forward this port on the host VM.
-	// We cannot forward port 8080 because it is used by AppEngine.
-	mux := http.NewServeMux()
-	// Assign the default prometheus handler to the standard exporter path.
-	mux.Handle("/metrics", promhttp.Handler())
-	// Assign the pprof handling paths to the external port to access individual
-	// instances.
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-	go http.ListenAndServe(":9090", mux)
-}
-
 // Status provides basic information about the service.  For now, it is just
 // configuration and version info.  In future it will likely include more
 // dynamic information.
@@ -289,7 +273,7 @@ func setupService(ctx context.Context) error {
 	// Enable block profiling
 	runtime.SetBlockProfileRate(1000000) // One event per msec.
 
-	setupPrometheus()
+	prometheusx.MustStartPrometheus(":9090")
 	// We also setup another prometheus handler on a non-standard path. This
 	// path name will be accessible through the AppEngine service address,
 	// however it will be served by a random instance.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,20 +1,9 @@
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
-
-func init() {
-	// Register the metrics defined with Prometheus's default registry.
-	prometheus.MustRegister(FailCount)
-	prometheus.MustRegister(WarningCount)
-	prometheus.MustRegister(TasksInFlight)
-	prometheus.MustRegister(StartedCount)
-	prometheus.MustRegister(CompletedCount)
-	prometheus.MustRegister(StateTimeSummary)
-	prometheus.MustRegister(StateTimeHistogram)
-	prometheus.MustRegister(StateDate)
-	prometheus.MustRegister(FilesPerDateHistogram)
-	prometheus.MustRegister(BytesPerDateHistogram)
-}
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
 
 var (
 	// StartedCount counts the number of date tasks started.  This does not include
@@ -24,7 +13,7 @@ var (
 	//   gardener_started_total{experiment}
 	// Example usage:
 	// metrics.StartedCount.WithLabelValues("sidestream").Inc()
-	StartedCount = prometheus.NewCounterVec(
+	StartedCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "gardener_started_total",
 			Help: "Number of date tasks started.",
@@ -38,7 +27,7 @@ var (
 	//   gardener_completed_total{experiment}
 	// Example usage:
 	// metrics.CompletedCount.WithLabelValues("sidestream").Inc()
-	CompletedCount = prometheus.NewCounterVec(
+	CompletedCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "gardener_completed_total",
 			Help: "Number of date tasks completed.",
@@ -53,7 +42,7 @@ var (
 	//   gardener_fail_total{status}
 	// Example usage:
 	// metrics.FailCount.WithLabelValues("BadTableName").Inc()
-	FailCount = prometheus.NewCounterVec(
+	FailCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "gardener_fail_total",
 			Help: "Number of processing failures.",
@@ -67,7 +56,7 @@ var (
 	//   gardener_warning_total{status}
 	// Example usage:
 	// metrics.WarningCount.WithLabelValues("funny xyz").Inc()
-	WarningCount = prometheus.NewCounterVec(
+	WarningCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "gardener_warning_total",
 			Help: "Number of processing warnings.",
@@ -81,7 +70,7 @@ var (
 	//   gardener_tasks_in_flight
 	// Example usage:
 	// metrics.TasksInFlight.Add(1)
-	TasksInFlight = prometheus.NewGauge(
+	TasksInFlight = promauto.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "gardener_tasks_in_flight",
 			Help: "Number of tasks in flight",
@@ -94,7 +83,7 @@ var (
 	//   gardener_state_date
 	// Example usage:
 	// metrics.StateDate.WithLabelValues(StateNames[t.State]).Observe(time.Now())
-	StateDate = prometheus.NewGaugeVec(
+	StateDate = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gardener_state_date",
 			Help: "Most recent date for each state.",
@@ -108,7 +97,7 @@ var (
 	//    gardener_state_time_summary
 	// Example usage:
 	//    metrics.StateTimeSummary.WithLabelValues("Queuing").observe(float64)
-	StateTimeSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+	StateTimeSummary = promauto.NewSummaryVec(prometheus.SummaryOpts{
 		Name:       "gardener_state_time_summary",
 		Help:       "The time spent in each state.",
 		Objectives: map[float64]float64{0.01: 0.001, 0.1: 0.01, 0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
@@ -120,7 +109,7 @@ var (
 	// Usage example:
 	//   metrics.StateTimeHistogram.WithLabelValues(
 	//           StateName[state]).Observe(time.Since(start).Seconds())
-	StateTimeHistogram = prometheus.NewHistogramVec(
+	StateTimeHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "gardener_state_time_histogram",
 			Help: "time-in-state distributions.",
@@ -142,7 +131,7 @@ var (
 	// Usage example:
 	//   metrics.FilesPerDateHistogram.WithLabelValues(
 	//           "2011").Observe(files)
-	FilesPerDateHistogram = prometheus.NewHistogramVec(
+	FilesPerDateHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "gardener_files",
 			Help: "Histogram of number of files submitted per date",
@@ -167,7 +156,7 @@ var (
 	// Usage example:
 	//   metrics.BytesPerDateHistogram.WithLabelValues(
 	//           "2011").Observe(bytes)
-	BytesPerDateHistogram = prometheus.NewHistogramVec(
+	BytesPerDateHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "gardener_bytes",
 			Help: "Histogram of number of bytes submitted per date",

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/m-lab/go/prometheusx"
+)
+
+func TestLintMetrics(t *testing.T) {
+	StartedCount.WithLabelValues("x")
+	CompletedCount.WithLabelValues("x")
+	FailCount.WithLabelValues("x")
+	WarningCount.WithLabelValues("x")
+	StateDate.WithLabelValues("x")
+	StateTimeSummary.WithLabelValues("x")
+	StateTimeHistogram.WithLabelValues("x")
+	FilesPerDateHistogram.WithLabelValues("x")
+	BytesPerDateHistogram.WithLabelValues("x")
+	prometheusx.LintMetrics(t)
+}


### PR DESCRIPTION
Lints the metrics, starts the prometheus server in a standard manner, eliminated the need to register metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/142)
<!-- Reviewable:end -->
