### PR TITLE
Add tcpinfo config

### DIFF
--- a/cloud/bq/dedup.go
+++ b/cloud/bq/dedup.go
@@ -186,6 +186,21 @@ var dedupTemplateTraceroute = `
 	    FROM ` + "`%s`" + `)
 	WHERE row_number = 1`
 
+var dedupTemplateTCPInfo = `
+	#standardSQL
+	# Delete all duplicate rows based on uuid, preferring "later" task filename, later parse_time
+	SELECT * except (row_number)
+    from (
+		select *,
+		# Prefer more snapshots, earlier task names, later parse time
+		ROW_NUMBER() OVER (PARTITION BY uuid ORDER BY ARRAY_LENGTH(Snapshots) DESC, ParseInfo.TaskFileName, ParseInfo.ParseTime DESC) row_number
+        FROM (
+			SELECT *
+    		FROM ` + "`%s`" + `
+        )
+    )
+	WHERE row_number = 1`
+
 // Dedup executes a query that dedups and writes to destination partition.
 // This function is alpha status.  The interface may change without notice
 // or major version number change.
@@ -217,6 +232,8 @@ func Dedup(ctx context.Context, dsExt *dataset.Dataset, src string, destTable bq
 		queryString = fmt.Sprintf(dedupTemplateSwitch, src)
 	case strings.HasPrefix(destTable.TableID(), "traceroute"):
 		queryString = fmt.Sprintf(dedupTemplateTraceroute, src)
+	case strings.HasPrefix(destTable.TableID(), "tcpinfo"):
+		queryString = fmt.Sprintf(dedupTemplateTCPInfo, src)
 	default:
 		log.Println("Only handles sidestream, ndt, switch, traceroute, not " + destTable.TableID())
 		return nil, errors.New("Unknown table type")

--- a/cloud/bq/dedup.go
+++ b/cloud/bq/dedup.go
@@ -189,9 +189,9 @@ var dedupTemplateTraceroute = `
 var dedupTemplateTCPInfo = `
 	#standardSQL
 	# Delete all duplicate rows based on uuid, preferring "later" task filename, later parse_time
-	SELECT * except (row_number)
-    from (
-		select *,
+	SELECT * EXCEPT (row_number)
+    FROM (
+		SELECT *,
 		# Prefer more snapshots, earlier task names, later parse time
 		ROW_NUMBER() OVER (PARTITION BY uuid ORDER BY ARRAY_LENGTH(Snapshots) DESC, ParseInfo.TaskFileName, ParseInfo.ParseTime DESC) row_number
         FROM (

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -186,7 +186,7 @@ func taskHandlerFromEnv(ctx context.Context, client *http.Client) (*reproc.TaskH
 	if err != nil {
 		return nil, err
 	}
-	return reproc.NewTaskHandler(exec, queues, saver), nil
+	return reproc.NewTaskHandler(env.Experiment, exec, queues, saver), nil
 }
 
 // doDispatchLoop just sequences through archives in date order.

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -1,0 +1,88 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: etl-gardener-tcpinfo
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      # Used to match pre-existing pods that may be affected during updates.
+      run: etl-gardener-tcpinfo
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  # Pod template.
+  template:
+    metadata:
+      labels:
+        # Note: run=etl-gardener-server should match a service config with a
+        # public IP and port so that it is publicly accessible.
+        run: etl-gardener-tcpinfo
+      annotations:
+        # Tell prometheus service discovery to collect metrics from the containers.
+        prometheus.io/scrape: 'true'
+    spec:
+      # When container receives SIGTERM, it begins a new checkpoint. This can
+      # take longer than the default grace period of 30s.
+      terminationGracePeriodSeconds: 300
+
+      # Place the pod into the Guaranteed QoS by setting equal resource
+      # requests and limits for *all* containers in the pod.
+      # For more background, see:
+      # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md
+      containers:
+      - image: gcr.io/{{GCLOUD_PROJECT}}/github-m-lab-etl-gardener:{{GIT_COMMIT}}
+        name: etl-gardener
+        env:
+        - name: GARDENER_SERVICE
+          value: "true"
+        - name: GIT_COMMIT
+          value: "{{GIT_COMMIT}}"
+        - name: PROJECT
+          value: "{{GCLOUD_PROJECT}}"
+        # NOTE: We read archives from the public archive for all projects.
+        - name: TASKFILE_BUCKET
+          value: "pusher-{{GCLOUD_PROJECT}}"
+        - name: START_DATE
+          value: "20190501"
+        - name: DATE_SKIP  # Should be 0 for normal operation
+          value: "{{DATE_SKIP}}"
+        - name: TASK_FILE_SKIP # Should be 0 for normal operation
+          value: "{{TASK_FILE_SKIP}}"
+        - name: EXPERIMENT
+          value: "tcpinfo"
+        - name: DATASET
+          value: "batch"
+        - name: FINAL_DATASET
+          value: "ndt"
+        - name: QUEUE_BASE
+          value: "etl-tcpinfo-batch-"
+        - name: NUM_QUEUES
+          value: "2"
+
+        ports:
+        - name: prometheus-port
+          containerPort: 9090
+        - name: service-port
+          containerPort: 8080
+
+        livenessProbe:
+          httpGet:
+            path: /alive
+            port: service-port
+          initialDelaySeconds: 30
+          periodSeconds: 60
+
+        resources:
+          requests:
+            memory: "3Gi"
+            cpu: "1"
+          limits:
+            memory: "3Gi"
+            cpu: "1"
+
+      nodeSelector:
+        gardener-node: "true"

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -58,7 +58,7 @@ spec:
         - name: DATASET
           value: "batch"
         - name: FINAL_DATASET
-          value: "base-tables"
+          value: "base_tables"
         - name: QUEUE_BASE
           value: "etl-tcpinfo-batch-"
         - name: NUM_QUEUES

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -93,7 +93,7 @@ spec:
         gardener-node: "true"
 
       volumes:
-      - name: ndt-storage
+      - name: tcpinfo-storage
         persistentVolumeClaim:
           claimName: gardener-tcpinfo-disk0
 

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -45,9 +45,9 @@ spec:
           value: "{{GCLOUD_PROJECT}}"
         # NOTE: We read archives from the public archive for all projects.
         - name: TASKFILE_BUCKET
-          value: "pusher-{{GCLOUD_PROJECT}}"
+          value: "pusher-{{GCLOUD_PROJECT}}"  # This will work for staging, but prod should use archive-measurement-lab.
         - name: START_DATE
-          value: "20190501"
+          value: "20190329"
         - name: DATE_SKIP  # Should be 0 for normal operation
           value: "{{DATE_SKIP}}"
         - name: TASK_FILE_SKIP # Should be 0 for normal operation

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -58,7 +58,7 @@ spec:
         - name: DATASET
           value: "batch"
         - name: FINAL_DATASET
-          value: "ndt"
+          value: "base-tables"
         - name: QUEUE_BASE
           value: "etl-tcpinfo-batch-"
         - name: NUM_QUEUES
@@ -85,5 +85,15 @@ spec:
             memory: "3Gi"
             cpu: "1"
 
+        volumeMounts:
+        - mountPath: /volume-claim
+          name: tcpinfo-storage
+
       nodeSelector:
         gardener-node: "true"
+
+      volumes:
+      - name: ndt-storage
+        persistentVolumeClaim:
+          claimName: gardener-tcpinfo-disk0
+

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -44,8 +44,9 @@ spec:
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
         # NOTE: We read archives from the public archive for all projects.
+        # TODO: Update when we address https://github.com/m-lab/dev-tracker/issues/369
         - name: TASKFILE_BUCKET
-          value: "pusher-{{GCLOUD_PROJECT}}"  # This will work for staging, but prod should use archive-measurement-lab.
+          value: "pusher-{{GCLOUD_PROJECT}}"  # This will work for sandbox/staging, but prod should use archive-measurement-lab.
         - name: START_DATE
           value: "20190329"
         - name: DATE_SKIP  # Should be 0 for normal operation
@@ -53,7 +54,7 @@ spec:
         - name: TASK_FILE_SKIP # Should be 0 for normal operation
           value: "{{TASK_FILE_SKIP}}"
         - name: EXPERIMENT
-          value: "tcpinfo"
+          value: "ndt/tcpinfo"
         - name: DATASET
           value: "batch"
         - name: FINAL_DATASET

--- a/k8s/data-processing-cluster/services/etl-gardener-tcpinfo-service.yml
+++ b/k8s/data-processing-cluster/services/etl-gardener-tcpinfo-service.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etl-gardener-tcpinfo-service
+  namespace: default
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: etl-gardener-tcpinfo
+  sessionAffinity: None
+  type: LoadBalancer

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -67,7 +67,7 @@ func NewTerminator() *Terminator {
 // It is responsible for starting tasks, recycling queues, and handling the
 // termination signal.
 type TaskHandler struct {
-	expKey     string         // The key used for task.Experiment
+	expName    string         // The string used for task.Experiment, which is used in Datastore queries.
 	exec       state.Executor // Executor passed to new tasks
 	taskQueues chan string    // Channel through which queues recycled.
 	saver      state.Saver    // The Saver used to save task states.
@@ -121,7 +121,7 @@ func (th *TaskHandler) AddTask(ctx context.Context, prefix string) error {
 	select {
 	// Wait until there is an available task queue.
 	case queue := <-th.taskQueues:
-		t, err := state.NewTask(th.expKey, prefix, queue, th.saver)
+		t, err := state.NewTask(th.expName, prefix, queue, th.saver)
 		if err != nil {
 			log.Println(err)
 			return err

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -67,6 +67,7 @@ func NewTerminator() *Terminator {
 // It is responsible for starting tasks, recycling queues, and handling the
 // termination signal.
 type TaskHandler struct {
+	expKey     string         // The key used for task.Experiment
 	exec       state.Executor // Executor passed to new tasks
 	taskQueues chan string    // Channel through which queues recycled.
 	saver      state.Saver    // The Saver used to save task states.
@@ -76,14 +77,14 @@ type TaskHandler struct {
 }
 
 // NewTaskHandler creates a new TaskHandler.
-func NewTaskHandler(exec state.Executor, queues []string, saver state.Saver) *TaskHandler {
+func NewTaskHandler(expKey string, exec state.Executor, queues []string, saver state.Saver) *TaskHandler {
 	// Create taskQueue channel, and preload with queues.
 	taskQueues := make(chan string, len(queues))
 	for _, q := range queues {
 		taskQueues <- q
 	}
 
-	return &TaskHandler{exec, taskQueues, saver, NewTerminator()}
+	return &TaskHandler{expKey, exec, taskQueues, saver, NewTerminator()}
 }
 
 // ErrTerminating is returned e.g. by AddTask, when tracker is terminating.
@@ -120,7 +121,7 @@ func (th *TaskHandler) AddTask(ctx context.Context, prefix string) error {
 	select {
 	// Wait until there is an available task queue.
 	case queue := <-th.taskQueues:
-		t, err := state.NewTask(prefix, queue, th.saver)
+		t, err := state.NewTask(th.expKey, prefix, queue, th.saver)
 		if err != nil {
 			log.Println(err)
 			return err

--- a/reproc/dispatch_test.go
+++ b/reproc/dispatch_test.go
@@ -115,7 +115,7 @@ func TestBasic(t *testing.T) {
 	// Start tracker with no queues.
 	exec := Exec{}
 	saver := NewTestSaver()
-	th := reproc.NewTaskHandler(&exec, []string{}, saver)
+	th := reproc.NewTaskHandler("exp", &exec, []string{}, saver)
 
 	// This will block because there are no queues.
 	go th.AddTask(ctx, "foobar")
@@ -135,7 +135,7 @@ func TestWithTaskQueue(t *testing.T) {
 	// Start tracker with one queue.
 	exec := Exec{}
 	saver := NewTestSaver()
-	th := reproc.NewTaskHandler(&exec, []string{"queue-1"}, saver)
+	th := reproc.NewTaskHandler("exp", &exec, []string{"queue-1"}, saver)
 
 	th.AddTask(ctx, "gs://fake/ndt/2017/09/22/")
 
@@ -151,10 +151,10 @@ func TestRestart(t *testing.T) {
 	ctx := context.Background()
 	exec := Exec{}
 	saver := NewTestSaver()
-	th := reproc.NewTaskHandler(&exec, []string{"queue-1", "queue-2"}, saver)
+	th := reproc.NewTaskHandler("exp", &exec, []string{"queue-1", "queue-2"}, saver)
 
 	taskName := "gs://foobar/exp/2001/02/03/"
-	t1, err := state.NewTask(taskName, "queue-1", nil)
+	t1, err := state.NewTask("exp", taskName, "queue-1", nil)
 	t1.State = state.Processing
 	if err != nil {
 		t.Fatal(err)

--- a/rex/rex_bb_test.go
+++ b/rex/rex_bb_test.go
@@ -29,7 +29,7 @@ func TestRealBucket(t *testing.T) {
 	}
 	defer exec.StorageClient.Close()
 	saver := newTestSaver()
-	th := reproc.NewTaskHandler(exec, []string{"queue-1"}, saver)
+	th := reproc.NewTaskHandler("exp", exec, []string{"queue-1"}, saver)
 
 	// We submit tasks corresponding to real buckets...
 	th.AddTask(ctx, "gs://archive-mlab-testing/ndt/2017/09/22/")

--- a/rex/rex_test.go
+++ b/rex/rex_test.go
@@ -81,7 +81,7 @@ func TestWithTaskQueue(t *testing.T) {
 	exec := &rex.ReprocessingExecutor{BQConfig: bqConfig, StorageClient: fc}
 	defer exec.StorageClient.Close()
 	saver := newTestSaver()
-	th := reproc.NewTaskHandler(exec, []string{"queue-1"}, saver)
+	th := reproc.NewTaskHandler("exp", exec, []string{"queue-1"}, saver)
 
 	th.AddTask(ctx, "gs://foo/bar/2001/01/01/")
 
@@ -179,7 +179,7 @@ func TestBadPrefix(t *testing.T) {
 	defer exec.StorageClient.Close()
 
 	saver := newTestSaver()
-	th := reproc.NewTaskHandler(exec, []string{"queue-1"}, saver)
+	th := reproc.NewTaskHandler("exp", exec, []string{"queue-1"}, saver)
 
 	err := th.AddTask(ctx, "gs://foo/bar/badprefix/01/01/")
 	if err == nil {
@@ -203,7 +203,7 @@ func TestZeroFiles(t *testing.T) {
 	defer exec.StorageClient.Close()
 
 	saver := newTestSaver()
-	th := reproc.NewTaskHandler(exec, []string{"queue-1"}, saver)
+	th := reproc.NewTaskHandler("exp", exec, []string{"queue-1"}, saver)
 
 	err := th.AddTask(ctx, "gs://foo/bar/2001/01/01/")
 	if err != nil {

--- a/state/state.go
+++ b/state/state.go
@@ -141,12 +141,8 @@ func GetExperiment(name string) (string, error) {
 }
 
 // NewTask properly initializes a new task, complete with saver.
-func NewTask(name string, queue string, saver Saver) (*Task, error) {
-	expt, err := GetExperiment(name)
-	if err != nil {
-		return nil, err
-	}
-	t := Task{Name: name, Experiment: expt, State: Initializing, Queue: queue, saver: saver}
+func NewTask(expKey string, name string, queue string, saver Saver) (*Task, error) {
+	t := Task{Name: name, Experiment: expKey, State: Initializing, Queue: queue, saver: saver}
 	t.UpdateTime = time.Now()
 	prefix, err := t.ParsePrefix()
 	if err != nil {

--- a/state/state.go
+++ b/state/state.go
@@ -187,9 +187,9 @@ type Prefix struct {
 // Path returns the path within the bucket, not including the leading gs://bucket/
 func (p Prefix) Path() string {
 	if p.ExpDir == "" {
-		return p.DataTypeString + "/" + p.DatePath
+		return p.DataTypeString + "/" + p.DatePath + "/"
 	}
-	return p.ExpDir + "/" + p.DataTypeString + "/" + p.DatePath
+	return p.ExpDir + "/" + p.DataTypeString + "/" + p.DatePath + "/"
 }
 
 // ParsePrefix Parses prefix, returning {bucket, experiment, date string}, error

--- a/state/state.go
+++ b/state/state.go
@@ -116,7 +116,7 @@ func (ds *DatastoreSaver) DeleteTask(ctx context.Context, t Task) error {
 // is written to datastore means that it can not be an interface and instead
 // must be a struct.
 type Task struct {
-	Name       string // e.g. gs://archive-mlab-oti/ndt/2017/06/01/
+	Name       string // e.g. gs://archive-mlab-oti/ndt/2017/06/01/ or gs://pusher-mlab-sandbox/ndt/tcpinfo/2019/04/01/
 	Experiment string // e.g. ndt, sidestream, etc.
 	Date       time.Time
 	State      State
@@ -148,11 +148,11 @@ func NewTask(name string, queue string, saver Saver) (*Task, error) {
 	}
 	t := Task{Name: name, Experiment: expt, State: Initializing, Queue: queue, saver: saver}
 	t.UpdateTime = time.Now()
-	parts, err := t.ParsePrefix()
+	prefix, err := t.ParsePrefix()
 	if err != nil {
 		return nil, err
 	}
-	date, err := time.Parse("2006/01/02", parts[2])
+	date, err := time.Parse("2006/01/02", prefix.DatePath)
 	if err != nil {
 		return nil, err
 	}
@@ -160,42 +160,77 @@ func NewTask(name string, queue string, saver Saver) (*Task, error) {
 	return &t, nil
 }
 
-const start = `^gs://(?P<bucket>.*)/(?P<exp>[^/]*)/`
-const datePath = `(?P<datepath>\d{4}/[01]\d/[0123]\d)/`
+// These are common with code in etl/etl/globals.go
+const (
+	bucket   = `gs://([^/]*)/`
+	expType  = `(?:([a-z-]+)/)?([a-z-]+)/` // experiment OR experiment/type
+	datePath = `(\d{4}/[01]\d/[0123]\d)/`
+)
 
 // These are here to facilitate use across queue-pusher and parsing components.
 var (
 	// This matches any valid test file name, and some invalid ones.
-	prefixPattern = regexp.MustCompile(start + // #1 #2
-		datePath) // #3 - YYYY/MM/DD
+	prefixPattern = regexp.MustCompile(bucket + // #1
+		expType + // #2 #3
+		datePath) // #4 - YYYY/MM/DD
 )
+
+// Prefix is a valid gs:// prefix for either legacy or new platform data.
+type Prefix struct {
+	Bucket         string    // the GCS bucket name.
+	ExpDir         string    // the experiment directory.
+	DataTypeString string    // if empty, this is legacy, and DataType is same as ExpDir
+	DatePath       string    // the YYYY/MM/DD date path.
+	Date           time.Time // the time.Time corresponding to the datepath.
+}
+
+// Path returns the path within the bucket, not including the leading gs://bucket/
+func (p Prefix) Path() string {
+	if p.ExpDir == "" {
+		return p.DataTypeString + "/" + p.DatePath
+	}
+	return p.ExpDir + "/" + p.DataTypeString + "/" + p.DatePath
+}
 
 // ParsePrefix Parses prefix, returning {bucket, experiment, date string}, error
 // Unless it returns error, the result will be exactly length 3.
-func (t *Task) ParsePrefix() ([]string, error) {
+func (t *Task) ParsePrefix() (*Prefix, error) {
 	fields := prefixPattern.FindStringSubmatch(t.Name)
 
 	if fields == nil {
 		return nil, errors.New("Invalid test path: " + t.Name)
 	}
-	// If fields is not nil, then there was a match, and all matches contain 4 fields.
-	return fields[1:], nil
+
+	date, err := time.Parse("2006/01/02", fields[4])
+	if err != nil {
+		return nil, err
+	}
+	p := Prefix{
+		Bucket:         fields[1],
+		ExpDir:         fields[2],
+		DataTypeString: fields[3],
+		DatePath:       fields[4],
+		Date:           date,
+	}
+	// If fields is not nil, then there was a match, and all matches contain 5 fields.
+
+	return &p, nil
 }
 
 // SourceAndDest creates BQ Table entities for the source templated table, and destination partition.
 func (t *Task) SourceAndDest(ds *dataset.Dataset) (bqiface.Table, bqiface.Table, error) {
 	// Launch the dedup request, and save the JobID
-	parts, err := t.ParsePrefix()
+	prefix, err := t.ParsePrefix()
 	if err != nil {
 		// If there is a parse error, log and skip request.
 		metrics.FailCount.WithLabelValues("BadDedupPrefix")
 		return nil, nil, err
 	}
 
-	tableName := etl.DirToTablename(parts[1])
+	tableName := etl.DirToTablename(prefix.DataTypeString)
 
-	src := ds.Table(tableName + "_" + strings.Join(strings.Split(parts[2], "/"), ""))
-	dest := ds.Table(tableName + "$" + strings.Join(strings.Split(parts[2], "/"), ""))
+	src := ds.Table(tableName + "_" + strings.Join(strings.Split(prefix.DatePath, "/"), ""))
+	dest := ds.Table(tableName + "$" + strings.Join(strings.Split(prefix.DatePath, "/"), ""))
 	return src, dest, nil
 }
 

--- a/state/state_bb_test.go
+++ b/state/state_bb_test.go
@@ -16,13 +16,13 @@ import (
 func waitForNTasks(t *testing.T, saver *state.DatastoreSaver, expectedTaskCount int, expt string) []state.Task {
 	var tasks []state.Task
 	var err error
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 50; i++ {
 		// Real datastore takes about 100 msec or more before consistency.
 		// In travis, we use the emulator, which should provide consistency
 		// much more quickly.  We use a modest number here that usually
 		// is sufficient for running on workstation, and rarely fail with emulator.
-		// Then we retry up to 10 times, before actually failing.
-		time.Sleep(200 * time.Millisecond)
+		// Then we retry up to 50 times, before actually failing.
+		time.Sleep(100 * time.Millisecond)
 		ctx := context.Background()
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
@@ -33,7 +33,7 @@ func waitForNTasks(t *testing.T, saver *state.DatastoreSaver, expectedTaskCount 
 		if ctx.Err() != nil {
 			t.Fatal(ctx.Err())
 		}
-		if len(tasks) == expectedTaskCount {
+		if len(tasks) >= expectedTaskCount {
 			break
 		}
 	}

--- a/state/state_bb_test.go
+++ b/state/state_bb_test.go
@@ -47,7 +47,7 @@ func TestStatus(t *testing.T) {
 		log.Println(saver)
 		t.Fatal(err)
 	}
-	task, err := state.NewTask("gs://foo/bar/2000/01/01/task1", "Q1", saver)
+	task, err := state.NewTask("exp", "gs://foo/bar/2000/01/01/task1", "Q1", saver)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func TestStatus(t *testing.T) {
 	}
 
 	ExpectedTasks := 2
-	tasks := waitForNTasks(t, saver, ExpectedTasks, "bar")
+	tasks := waitForNTasks(t, saver, ExpectedTasks, "exp")
 	if len(tasks) != ExpectedTasks {
 		t.Errorf("Saw %d tasks instead of %d (see notes on consistency)", len(tasks), ExpectedTasks)
 		for _, t := range tasks {
@@ -86,7 +86,7 @@ func TestWriteStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	task, err := state.NewTask("gs://foo/bar/2000/01/01/task1", "Q1", saver)
+	task, err := state.NewTask("bar", "gs://foo/bar/2000/01/01/task1", "Q1", saver)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -151,18 +151,18 @@ func TestTaskBasics(t *testing.T) {
 }
 
 func TestSourceAndDest(t *testing.T) {
-	if _, err := state.NewTask("gs://task1", "Q1", nil); err == nil {
+	if _, err := state.NewTask("exp", "gs://task1", "Q1", nil); err == nil {
 		t.Fatal("Should have had an error here")
 	}
-	if _, err := state.NewTask("gs://foo/ndt/2000/ab/01/task1", "Q1", nil); err == nil {
+	if _, err := state.NewTask("exp", "gs://foo/ndt/2000/ab/01/task1", "Q1", nil); err == nil {
 		t.Fatal("Should have had an error here")
 	}
-	if _, err := state.NewTask("gs://foo/ndt/2000/13/01/task1", "Q1", nil); err == nil {
+	if _, err := state.NewTask("exp", "gs://foo/ndt/2000/13/01/task1", "Q1", nil); err == nil {
 		t.Fatal("Should have had an error here")
 	}
 
 	ctx := context.Background()
-	task, err := state.NewTask("gs://foo/ndt/2000/01/01/task1", "Q1", nil)
+	task, err := state.NewTask("exp", "gs://foo/ndt/2000/01/01/task1", "Q1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -60,7 +60,7 @@ func TestNewPlatformPrefix(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if pp.DataTypeString != "tcpinfo" {
+	if pp.DataType != "tcpinfo" {
 		t.Error(pp)
 	}
 
@@ -76,7 +76,7 @@ func TestLegacyPrefix(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if pp.DataTypeString != "ndt" {
+	if pp.DataType != "ndt" {
 		t.Error(pp)
 	}
 

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -50,6 +50,38 @@ func (s *testSaver) GetDeletes(t state.Task) map[string]struct{} {
 
 func assertSaver() { func(ex state.Saver) {}(&testSaver{}) }
 
+func TestNewPlatformPrefix(t *testing.T) {
+	task := state.Task{Name: "gs://pusher-mlab-sandbox/ndt/tcpinfo/2019/04/01/", State: state.Initializing}
+	saver := testSaver{tasks: make(map[string][]state.Task), delete: make(map[string]struct{})}
+	task.SetSaver(&saver)
+
+	pp, err := task.ParsePrefix()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pp.DataTypeString != "tcpinfo" {
+		t.Error(pp)
+	}
+
+}
+
+func TestLegacyPrefix(t *testing.T) {
+	task := state.Task{Name: "gs://archive-mlab-sandbox/ndt/2019/04/01/", State: state.Initializing}
+	saver := testSaver{tasks: make(map[string][]state.Task), delete: make(map[string]struct{})}
+	task.SetSaver(&saver)
+
+	pp, err := task.ParsePrefix()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pp.DataTypeString != "ndt" {
+		t.Error(pp)
+	}
+
+}
+
 func TestTaskBasics(t *testing.T) {
 	ctx := context.Background()
 	task := state.Task{Name: "foobar", State: state.Initializing}


### PR DESCRIPTION
Adds a gardener config for tcpinfo.

TODO:  Need to ensure there are enough nodes available in all three projects for the new pod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/156)
<!-- Reviewable:end -->
