### PR TITLE
Add persistent volume claims to GKE deployment configs

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
@@ -83,5 +83,14 @@ spec:
             memory: "3Gi"
             cpu: "1"
 
+        volumeMounts:
+        - mountPath: /volume-claim
+          name: switch-storage
+
       nodeSelector:
         gardener-node: "true"
+
+      volumes:
+      - name: switch-storage
+        persistentVolumeClaim:
+          claimName: gardener-switch-disk0

--- a/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
@@ -84,5 +84,15 @@ spec:
             memory: "3Gi"
             cpu: "1"
 
+        volumeMounts:
+        - mountPath: /volume-claim
+          name: ndt-storage
+
       nodeSelector:
         gardener-node: "true"
+
+      volumes:
+      - name: ndt-storage
+        persistentVolumeClaim:
+          claimName: gardener-ndt-disk0
+

--- a/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
@@ -84,5 +84,15 @@ spec:
             memory: "3Gi"
             cpu: "1"
 
+        volumeMounts:
+        - mountPath: /volume-claim
+          name: sidestream-storage
+
       nodeSelector:
         gardener-node: "true"
+
+      volumes:
+      - name: sidestream-storage
+        persistentVolumeClaim:
+          claimName: gardener-sidestream-disk0
+

--- a/k8s/data-processing-cluster/persistentvolumes/persistent-volumes.yml
+++ b/k8s/data-processing-cluster/persistentvolumes/persistent-volumes.yml
@@ -1,9 +1,48 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: auto-etl-gardener-disk0
+  name: gardener-ndt-disk0
   annotations:
-    volume.beta.kubernetes.io/storage-class: "fast"
+    volume.beta.kubernetes.io/storage-class: "slow"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+--
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gardener-switch-disk0
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "slow"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+--
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gardener-sidestream-disk0
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "slow"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+--
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gardener-tcpinfo-disk0
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "slow"
 spec:
   accessModes:
     - ReadWriteOnce

--- a/k8s/data-processing-cluster/persistentvolumes/persistent-volumes.yml
+++ b/k8s/data-processing-cluster/persistentvolumes/persistent-volumes.yml
@@ -10,7 +10,7 @@ spec:
   resources:
     requests:
       storage: 10Gi
---
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -23,7 +23,7 @@ spec:
   resources:
     requests:
       storage: 10Gi
---
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -36,7 +36,7 @@ spec:
   resources:
     requests:
       storage: 10Gi
---
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
This change adds per-deployment volume-claim definitions to guarantee that only one instance of each deployment is running at once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/157)
<!-- Reviewable:end -->
