### PR TITLE
Sandbox avoid overrun

### DIFF
--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -320,7 +320,7 @@ func setupService(ctx context.Context) error {
 	// Move the start date after the max observed date.
 	// Note that if we restart while wrapping back to start date, this will essentially
 	// result in restarting at the original start date, after wrapping.
-	for maxDate.After(startDate) {
+	for !maxDate.Before(startDate) {
 		startDate = startDate.AddDate(0, 0, 1+env.DateSkip)
 	}
 

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -304,7 +304,7 @@ func setupService(ctx context.Context) error {
 
 	// Move the timeout into GetStatus?
 	taskCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	tasks, err := ds.GetStatus(taskCtx, env.Experiment)
+	tasks, err := ds.FetchAllTasks(taskCtx, env.Experiment)
 	cancel()
 
 	if err != nil {

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -67,17 +67,17 @@ func NewTerminator() *Terminator {
 // It is responsible for starting tasks, recycling queues, and handling the
 // termination signal.
 type TaskHandler struct {
-	expName    string         // The string used for task.Experiment, which is used in Datastore queries.
-	exec       state.Executor // Executor passed to new tasks
-	taskQueues chan string    // Channel through which queues recycled.
-	saver      state.Saver    // The Saver used to save task states.
+	expName    string                // The string used for task.Experiment, which is used in Datastore queries.
+	exec       state.Executor        // Executor passed to new tasks
+	taskQueues chan string           // Channel through which queues recycled.
+	saver      state.PersistentStore // The Saver used to save task states.
 
 	// For managing termination.
 	*Terminator
 }
 
 // NewTaskHandler creates a new TaskHandler.
-func NewTaskHandler(expKey string, exec state.Executor, queues []string, saver state.Saver) *TaskHandler {
+func NewTaskHandler(expKey string, exec state.Executor, queues []string, saver state.PersistentStore) *TaskHandler {
 	// Create taskQueue channel, and preload with queues.
 	taskQueues := make(chan string, len(queues))
 	for _, q := range queues {

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -154,6 +154,9 @@ func (th *TaskHandler) waitForPreviousTask(ctx context.Context, t state.Task) er
 			log.Printf("Restarting task that errored: %+v", taskStatus)
 			return nil
 		case time.Since(taskStatus.UpdateTime) > 12*time.Hour:
+			// If > 12 hours in Processing, then task queue tasks will have expired.
+			// If > 12 hours in Stabilizing, then something has gone horribly wrong.
+			// Other states only take a couple minutes.
 			log.Printf("Restarting task that has been idle more than 12 hour: %+v", taskStatus)
 			return nil
 		default:

--- a/reproc/dispatch_test.go
+++ b/reproc/dispatch_test.go
@@ -71,7 +71,7 @@ func (s *testSaver) DeleteTask(ctx context.Context, t state.Task) error {
 	return nil
 }
 
-func assertSaver() { func(ex state.Saver) {}(&testSaver{}) }
+func assertPersistentStore() { func(ex state.PersistentStore) {}(&testSaver{}) }
 
 type Exec struct{}
 

--- a/rex/rex.go
+++ b/rex/rex.go
@@ -307,7 +307,7 @@ func (rex *ReprocessingExecutor) dedup(ctx context.Context, t *state.Task) error
 // TODO - develop a BQJob interface for wrapping bigquery.Job, and allowing fakes.
 // TODO - move this to go/dataset, since it is bigquery specific and general purpose.
 func waitForJob(ctx context.Context, job bqiface.Job, maxBackoff time.Duration, terminate <-chan struct{}) error {
-	backoff := 10 * time.Millisecond
+	backoff := 10 * time.Second // Some jobs finish much quicker, but we don't really care that much.
 	previous := backoff
 	for {
 		select {

--- a/state/state.go
+++ b/state/state.go
@@ -360,7 +360,7 @@ func (ds *DatastoreSaver) GetStatus(ctx context.Context, expt string) ([]Task, e
 
 // GetTask fetches state of requested experiment/task from Datastore.
 func (ds *DatastoreSaver) GetTask(ctx context.Context, expt string, name string) (Task, error) {
-	q := datastore.NewQuery("task").Namespace(ds.Namespace).Filter("Experiment =", expt).Filter("Name", name)
+	q := datastore.NewQuery("task").Namespace(ds.Namespace).Filter("Experiment =", expt).Filter("Name =", name)
 	tasks := make([]Task, 0, 1)
 	_, err := ds.Client.GetAll(ctx, q, &tasks)
 	if err != nil {

--- a/state/state.go
+++ b/state/state.go
@@ -284,7 +284,7 @@ func (t *Task) SetError(ctx context.Context, err error, info string) error {
 }
 
 // GetTaskStatus checks the PersistentStore to see if task is in flight or errored.
-// TODO: This should be folded into the Saver interface.
+// If t.saver is not a DatastoreSaver, this returns empty/nil
 func (t *Task) GetTaskStatus(ctx context.Context) (Task, error) {
 	ds, ok := t.saver.(*DatastoreSaver)
 	if !ok {

--- a/state/state.go
+++ b/state/state.go
@@ -360,17 +360,11 @@ func (ds *DatastoreSaver) FetchAllTasks(ctx context.Context, expt string) ([]Tas
 
 // FetchTask fetches state of requested experiment/task from Datastore.
 func (ds *DatastoreSaver) FetchTask(ctx context.Context, expt string, name string) (Task, error) {
-	q := datastore.NewQuery("task").Namespace(ds.Namespace).Filter("Experiment =", expt).Filter("Name =", name)
-	tasks := make([]Task, 0, 1)
-	_, err := ds.Client.GetAll(ctx, q, &tasks)
-	if err != nil {
-		return Task{}, err
-		// Handle error.
-	}
-	if len(tasks) > 0 {
-		return tasks[0], nil
-	}
-	return Task{}, nil
+	var task Task
+	key := datastore.Key{Kind: "task", Name: name, Namespace: ds.Namespace}
+	err := ds.Client.Get(ctx, &key, &task)
+	// TODO: any errors we should retry?
+	return task, err
 }
 
 // WriteHTMLStatusTo writes HTML formatted task status.

--- a/state/state_bb_test.go
+++ b/state/state_bb_test.go
@@ -26,7 +26,7 @@ func waitForNTasks(t *testing.T, saver *state.DatastoreSaver, expectedTaskCount 
 		ctx := context.Background()
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
-		tasks, err = saver.GetStatus(ctx, expt)
+		tasks, err = saver.FetchAllTasks(ctx, expt)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -48,7 +48,7 @@ func (s *testSaver) GetDeletes(t state.Task) map[string]struct{} {
 	return s.delete
 }
 
-func assertSaver() { func(ex state.Saver) {}(&testSaver{}) }
+func assertSaver() { func(ex state.PersistentStore) {}(&testSaver{}) }
 
 func TestNewPlatformPrefix(t *testing.T) {
 	task := state.Task{Name: "gs://pusher-mlab-sandbox/ndt/tcpinfo/2019/04/01/", State: state.Initializing}


### PR DESCRIPTION
This adds checking whether another task is already processing before starting a new date.  It prevents multiple competing tasks which cause unpredictable behavior.

Will add unit tests for at least GetTask and GetTaskStatus functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/162)
<!-- Reviewable:end -->
