### PR TITLE
fix panic

### DIFF
--- a/rex/rex.go
+++ b/rex/rex.go
@@ -377,7 +377,10 @@ func (rex *ReprocessingExecutor) finish(ctx context.Context, t *state.Task, term
 	status, err := job.Wait(ctx)
 	if err != nil {
 		if err != state.ErrTaskSuspended {
-			log.Println(status.Err(), src.FullyQualifiedName())
+			log.Println(err, src.FullyQualifiedName())
+			if status != nil {
+				log.Println(status.Err(), src.FullyQualifiedName())
+			}
 			t.SetError(ctx, err, "job.Wait")
 		}
 		return err


### PR DESCRIPTION
Fixes a bad pointer dereference that causes panic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/171)
<!-- Reviewable:end -->
