### PR TITLE
Sandbox ratelimitexceeded

### DIFF
--- a/cloud/bq/dedup.go
+++ b/cloud/bq/dedup.go
@@ -211,9 +211,6 @@ var dedupTemplateNDTLegacy = `
 		row_number = 1`
 
 // Dedup executes a query that dedups and writes to destination partition.
-// This function is alpha status.  The interface may change without notice
-// or major version number change.
-//
 // `src` is relative to the project:dataset of dsExt.
 // `destTable` specifies the table to write to, typically created with
 //   dsExt.BqClient.DatasetInProject(...).Table(...)
@@ -221,7 +218,6 @@ var dedupTemplateNDTLegacy = `
 // NOTE: If destination table is partitioned, destTable MUST include the partition
 // suffix to avoid accidentally overwriting the entire table.
 // TODO - move these functions to go/bqext package
-// TODO - should we get the context from the dsExt?
 func Dedup(ctx context.Context, dsExt *dataset.Dataset, src string, destTable bqiface.Table) (bqiface.Job, error) {
 	if !strings.Contains(destTable.TableID(), "$") {
 		meta, err := destTable.Metadata(ctx)

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -204,7 +204,6 @@ func doDispatchLoop(ctx context.Context, handler *reproc.TaskHandler, startDate 
 		if err != nil {
 			// Only error expected here is ErrTerminating
 			log.Println(err)
-			return
 		}
 
 		// Advance to next date, possibly skipping days if DATE_SKIP env var was set.

--- a/state/state.go
+++ b/state/state.go
@@ -51,6 +51,7 @@ var (
 	ErrInvalidQueue           = errors.New("invalid queue")
 	ErrTaskSuspended          = errors.New("task suspended")
 	ErrTableNotFound          = errors.New("Not found: Table")
+	ErrBQRateLimitExceeded    = errors.New("Bigquery rateLimitExceeded")
 	ErrRowsFromOtherPartition = errors.New("Rows belong to different partition")
 )
 


### PR DESCRIPTION
The rateLimitExceeded job error is persistent.  The current code keeps rechecking it, spamming the logs, and hiding the error state from the status report.

This PR properly handles that error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/172)
<!-- Reviewable:end -->
