### PR TITLE
Support NDT Result unified schema reprocessing for ndt5

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@
 
 [![Waffle.io](https://badge.waffle.io/m-lab/etl-gardener.svg?title=Ready)](http://waffle.io/m-lab/etl-gardener)
 
-
-## Gardener provides services for maintaining and reprocessing mlab data.
+Gardener provides services for maintaining and reprocessing M-Lab data.
 
 ## Unit Testing
+
 Travis now uses the datastore emulator to better support unit tests.
 Tests continue to use mlab-testing, so that they can be run manually from
 workstation without configuring the emulator.
 
 To start the emulator, .travis.yml now includes:
+
 ```base
 - gcloud components install beta
 - gcloud components install cloud-datastore-emulator

--- a/cloud/bq/dedup.go
+++ b/cloud/bq/dedup.go
@@ -200,7 +200,7 @@ var dedupTemplateTCPInfo = `
     )
 	WHERE row_number = 1`
 
-var dedupTemplateNDTLegacy = `
+var dedupTemplateNDTResult = `
 	#standardSQL
 	SELECT * EXCEPT (row_number)
 	FROM (
@@ -239,8 +239,8 @@ func Dedup(ctx context.Context, dsExt *dataset.Dataset, src string, destTable bq
 		queryString = fmt.Sprintf(dedupTemplateTraceroute, src)
 	case strings.HasPrefix(destTable.TableID(), "tcpinfo"):
 		queryString = fmt.Sprintf(dedupTemplateTCPInfo, src)
-	case strings.HasPrefix(destTable.TableID(), "legacy"):
-		queryString = fmt.Sprintf(dedupTemplateNDTLegacy, src)
+	case strings.HasPrefix(destTable.TableID(), "result"):
+		queryString = fmt.Sprintf(dedupTemplateNDTResult, src)
 	default:
 		log.Println("Only handles sidestream, ndt, switch, traceroute, not " + destTable.TableID())
 		return nil, errors.New("Unknown table type")

--- a/cloud/bq/sanity.go
+++ b/cloud/bq/sanity.go
@@ -176,7 +176,7 @@ func GetTableDetail(ctx context.Context, dsExt *dataset.Dataset, table bqiface.T
     FROM `+"`%s.%s`"+`
 		%s  -- where clause`,
 		dataset, tableName, where)
-	
+
 	tracerouteQuery := fmt.Sprintf(`
 		#standardSQL
 		SELECT COUNT(DISTINCT ParseInfo.TaskFileName) AS TestCount, COUNT(DISTINCT ParseInfo.TaskFileName) AS TaskFileCount
@@ -184,7 +184,7 @@ func GetTableDetail(ctx context.Context, dsExt *dataset.Dataset, table bqiface.T
 		%s  -- where clause`,
 		dataset, tableName, where)
 
-	legacyNDTQuery := fmt.Sprintf(`
+	resultNDTQuery := fmt.Sprintf(`
 		#standardSQL
 		SELECT COUNT(DISTINCT test_id) AS TestCount, COUNT(DISTINCT ParseInfo.TaskFileName) AS TaskFileCount
     FROM `+"`%s.%s`"+`
@@ -196,8 +196,8 @@ func GetTableDetail(ctx context.Context, dsExt *dataset.Dataset, table bqiface.T
 	query := legacyQuery
 	if parts[0] == "tcpinfo" {
 		query = tcpinfoQuery
-	} else if parts[0] == "legacy" {
-		query = legacyNDTQuery
+	} else if parts[0] == "result" {
+		query = resultNDTQuery
 	} else if parts[0] == "traceroute" {
 		query = tracerouteQuery
 	}

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -197,7 +197,7 @@ func doDispatchLoop(ctx context.Context, handler *reproc.TaskHandler, startDate 
 	next := startDate
 
 	for {
-		prefix := next.Format(fmt.Sprintf("gs://%s/%s/2006/01/02/", bucket, experiment))
+		prefix := fmt.Sprintf("gs://%s/%s/", bucket, experiment) + next.Format("2006/01/02/")
 
 		// Note that this blocks until a queue is available.
 		err := handler.AddTask(ctx, prefix)

--- a/k8s/data-processing-cluster/deployments/etl-gardener-result.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-result.yml
@@ -54,7 +54,7 @@ spec:
         - name: TASK_FILE_SKIP # Should be 0 for normal operation
           value: "0"
         - name: EXPERIMENT
-          value: "ndt/result"
+          value: "ndt/ndt5"
         - name: DATASET
           value: "batch"
         - name: FINAL_DATASET

--- a/k8s/data-processing-cluster/deployments/etl-gardener-result.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-result.yml
@@ -1,14 +1,14 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: etl-gardener-legacy
+  name: etl-gardener-result
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
       # Used to match pre-existing pods that may be affected during updates.
-      run: etl-gardener-legacy
+      run: etl-gardener-result
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -20,7 +20,7 @@ spec:
       labels:
         # Note: run=etl-gardener-server should match a service config with a
         # public IP and port so that it is publicly accessible.
-        run: etl-gardener-legacy
+        run: etl-gardener-result
       annotations:
         # Tell prometheus service discovery to collect metrics from the containers.
         prometheus.io/scrape: 'true'
@@ -54,7 +54,7 @@ spec:
         - name: TASK_FILE_SKIP # Should be 0 for normal operation
           value: "0"
         - name: EXPERIMENT
-          value: "ndt/legacy"
+          value: "ndt/result"
         - name: DATASET
           value: "batch"
         - name: FINAL_DATASET
@@ -87,13 +87,13 @@ spec:
 
         volumeMounts:
         - mountPath: /volume-claim
-          name: legacy-storage
+          name: result-storage
 
       nodeSelector:
         gardener-node: "true"
 
       volumes:
-      - name: legacy-storage
+      - name: result-storage
         persistentVolumeClaim:
-          claimName: gardener-legacy-disk0
+          claimName: gardener-result-disk0
 

--- a/k8s/data-processing-cluster/persistentvolumes/persistent-volumes.yml
+++ b/k8s/data-processing-cluster/persistentvolumes/persistent-volumes.yml
@@ -53,7 +53,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: gardener-legacy-disk0
+  name: gardener-result-disk0
   annotations:
     volume.beta.kubernetes.io/storage-class: "slow"
 spec:

--- a/k8s/data-processing-cluster/services/etl-gardener-result-service.yml
+++ b/k8s/data-processing-cluster/services/etl-gardener-result-service.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: etl-gardener-legacy-service
+  name: etl-gardener-result-service
   namespace: default
 spec:
   ports:
@@ -9,6 +9,6 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    run: etl-gardener-legacy
+    run: etl-gardener-result
   sessionAffinity: None
   type: LoadBalancer

--- a/state/state.go
+++ b/state/state.go
@@ -159,7 +159,7 @@ func NewTask(expName string, name string, queue string, saver PersistentStore) (
 // These are common with code in etl/etl/globals.go
 const (
 	bucket   = `gs://([^/]*)/`
-	expType  = `(?:([a-z-]+)/)?([a-z-]+)/` // experiment OR experiment/type
+	expType  = `(?:([a-z-]+)/)?([a-z0-9-]+)/` // experiment OR experiment/type
 	datePath = `(\d{4}/[01]\d/[0123]\d)/`
 )
 


### PR DESCRIPTION
Part of https://github.com/m-lab/dev-tracker/issues/378 and https://github.com/m-lab/ndt-server/issues/143

This change updates gardener to reprocess data saved in the new unified schema for ndt5.

Mostly name changes from "legacy" to "result". Also one bug fix to prevent numbers in the experiment or datatype path from being interpreted as dates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/173)
<!-- Reviewable:end -->
