### PR TITLE
Check for ndt5 before ndt to prevent false positive

### DIFF
--- a/cloud/bq/dedup.go
+++ b/cloud/bq/dedup.go
@@ -231,7 +231,7 @@ func Dedup(ctx context.Context, dsExt *dataset.Dataset, src string, destTable bq
 	switch {
 	case strings.HasPrefix(destTable.TableID(), "sidestream"):
 		queryString = fmt.Sprintf(dedupTemplateSidestream, src)
-	case strings.HasPrefix(destTable.TableID(), "ndt5"):
+	case strings.HasPrefix(destTable.TableID(), "ndt5") || strings.HasPrefix(destTable.TableID(), "ndt7"):
 		queryString = fmt.Sprintf(dedupTemplateNDTResult, src)
 	case strings.HasPrefix(destTable.TableID(), "ndt"):
 		queryString = fmt.Sprintf(dedupTemplateNDT, src)

--- a/cloud/bq/dedup.go
+++ b/cloud/bq/dedup.go
@@ -231,6 +231,8 @@ func Dedup(ctx context.Context, dsExt *dataset.Dataset, src string, destTable bq
 	switch {
 	case strings.HasPrefix(destTable.TableID(), "sidestream"):
 		queryString = fmt.Sprintf(dedupTemplateSidestream, src)
+	case strings.HasPrefix(destTable.TableID(), "ndt5"):
+		queryString = fmt.Sprintf(dedupTemplateNDTResult, src)
 	case strings.HasPrefix(destTable.TableID(), "ndt"):
 		queryString = fmt.Sprintf(dedupTemplateNDT, src)
 	case strings.HasPrefix(destTable.TableID(), "switch"):
@@ -239,8 +241,6 @@ func Dedup(ctx context.Context, dsExt *dataset.Dataset, src string, destTable bq
 		queryString = fmt.Sprintf(dedupTemplateTraceroute, src)
 	case strings.HasPrefix(destTable.TableID(), "tcpinfo"):
 		queryString = fmt.Sprintf(dedupTemplateTCPInfo, src)
-	case strings.HasPrefix(destTable.TableID(), "result"):
-		queryString = fmt.Sprintf(dedupTemplateNDTResult, src)
 	default:
 		log.Println("Only handles sidestream, ndt, switch, traceroute, not " + destTable.TableID())
 		return nil, errors.New("Unknown table type")

--- a/cloud/bq/dedup.go
+++ b/cloud/bq/dedup.go
@@ -245,7 +245,6 @@ func Dedup(ctx context.Context, dsExt *dataset.Dataset, src string, destTable bq
 		log.Println("Only handles sidestream, ndt, switch, traceroute, not " + destTable.TableID())
 		return nil, errors.New("Unknown table type")
 	}
-	log.Println(queryString)
 	query := dsExt.DestQuery(queryString, destTable, bigquery.WriteTruncate)
 
 	job, err := query.Run(ctx)

--- a/cloud/bq/dedup.go
+++ b/cloud/bq/dedup.go
@@ -245,6 +245,7 @@ func Dedup(ctx context.Context, dsExt *dataset.Dataset, src string, destTable bq
 		log.Println("Only handles sidestream, ndt, switch, traceroute, not " + destTable.TableID())
 		return nil, errors.New("Unknown table type")
 	}
+	log.Println(queryString)
 	query := dsExt.DestQuery(queryString, destTable, bigquery.WriteTruncate)
 
 	job, err := query.Run(ctx)

--- a/cloud/bq/sanity.go
+++ b/cloud/bq/sanity.go
@@ -196,7 +196,7 @@ func GetTableDetail(ctx context.Context, dsExt *dataset.Dataset, table bqiface.T
 	query := legacyQuery
 	if parts[0] == "tcpinfo" {
 		query = tcpinfoQuery
-	} else if parts[0] == "result" {
+	} else if (parts[0] == "ndt5") || (parts[0] == "ndt7") {
 		query = resultNDTQuery
 	} else if parts[0] == "traceroute" {
 		query = tracerouteQuery


### PR DESCRIPTION
Because the switch conditions use "HasPrefix" the table name "ndt" also matches (incorrectly) the "ndt5" table. This change moves the ndt5 check first to prevent the mistake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/176)
<!-- Reviewable:end -->
