### PR TITLE
Promlint warnings only

### DIFF
--- a/cloud/tq/tq_test.go
+++ b/cloud/tq/tq_test.go
@@ -32,5 +32,5 @@ func TestPostOneTask(t *testing.T) {
 
 func TestMetrics(t *testing.T) {
 	tq.EmptyStatsRecoveryTimeHistogramSecs.WithLabelValues("x")
-	promtest.LintMetrics(t)
+	promtest.LintMetrics(nil) // Log warnings only.
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -16,5 +16,5 @@ func TestLintMetrics(t *testing.T) {
 	StateTimeHistogram.WithLabelValues("x")
 	FilesPerDateHistogram.WithLabelValues("x")
 	BytesPerDateHistogram.WithLabelValues("x")
-	promtest.LintMetrics(t)
+	promtest.LintMetrics(nil) // Log warnings only.
 }


### PR DESCRIPTION
Promlint changed, and now fails, causing build to fail.
This demotes promlint to warning only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/182)
<!-- Reviewable:end -->
