### PR TITLE
Refactor main

### DIFF
--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -231,6 +231,7 @@ var healthy = false
 // healthCheck, for now, used for both /ready and /alive.
 func healthCheck(w http.ResponseWriter, r *http.Request) {
 	if !healthy {
+		log.Println("Reporting unhealthy for", r.RequestURI)
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, `{"message": "Internal server error."}`)
 	} else {

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -301,6 +301,9 @@ func doDispatchLoop(ctx context.Context, handler *TaskHandler, bucket string, ex
 }
 
 // RunDispatchLoop sets up dispatch loop.
+// TODO inject DatastoreSaver to allow unit testing??  TaskHandler would require a fake task queue.
+// However, this code will be replaced soon.  Replacement code should have better unit tests, but it might
+// be wasted effort to improve coverage on this code.
 func RunDispatchLoop(ctx context.Context, th *TaskHandler, project string, bucket string, exp string, startDate time.Time, dateSkip int) error {
 	ds, err := state.NewDatastoreSaver(ctx, project)
 	if err != nil {

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -330,8 +330,8 @@ func RunDispatchLoop(ctx context.Context, th *TaskHandler, project string, bucke
 	// Move the start date after the max observed date.
 	// Note that if we restart while wrapping back to start date, this will essentially
 	// result in restarting at the original start date, after wrapping.
-	for !maxDate.Before(startDate) {
-		restartDate = startDate.AddDate(0, 0, 1+dateSkip)
+	for !maxDate.Before(restartDate) {
+		restartDate = restartDate.AddDate(0, 0, 1+dateSkip)
 	}
 
 	log.Println("Using start date of", startDate)


### PR DESCRIPTION
Move some functions into reproc package.
Pull task-queue specific env var loading into function.
Add "SERVICE_MODE" env var.

Would be nice to have unit tests for code moved to reproc, but this code is deprecated and expected to be replaced with job service related code in next 4 to 6 weeks.  So better to put the effort into testing the new code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/191)
<!-- Reviewable:end -->
