### PR TITLE
Add gardener-universal with static ip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,8 +142,6 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-oti data-processing-cluster ./apply-cluster.sh
-    &&
-    $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-oti data-processing ./apply-cluster.sh
   skip_cleanup: true
   on:
     repo: m-lab/etl-gardener

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,6 +115,9 @@ deploy:
   script:
     DATE_SKIP="2" TASK_FILE_SKIP="4"
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing-cluster ./apply-cluster.sh
+    &&
+    DATE_SKIP="2" TASK_FILE_SKIP="4"
+    $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing ./apply-cluster.sh
   skip_cleanup: true
   on:
     repo: m-lab/etl-gardener
@@ -124,7 +127,10 @@ deploy:
 #########################################
 ## Staging
 - provider: script
-  script: $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing-cluster ./apply-cluster.sh
+  script:
+    $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing-cluster ./apply-cluster.sh
+    &&
+    $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing ./apply-cluster.sh
   skip_cleanup: true
   on:
     repo: m-lab/etl-gardener
@@ -134,7 +140,10 @@ deploy:
 #########################################
 ## Production
 - provider: script
-  script: $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-oti data-processing-cluster ./apply-cluster.sh
+  script:
+    $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-oti data-processing-cluster ./apply-cluster.sh
+    &&
+    $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-oti data-processing ./apply-cluster.sh
   skip_cleanup: true
   on:
     repo: m-lab/etl-gardener

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -255,7 +255,7 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func jobServer(w http.ResponseWriter, r *http.Request) {
+func jobHandler(w http.ResponseWriter, r *http.Request) {
 	// This is a real hardcoded task to return.
 	log.Println(r.RequestURI)
 	fmt.Fprint(w, "archive-measurement-lab/ndt/tcpinfo/2019/10/01")
@@ -292,7 +292,7 @@ func main() {
 	case "manager":
 		// This is new new "manager" mode, in which Gardener provides /job and /update apis
 		// for parsers to get work and report progress.
-		http.HandleFunc("/job", jobServer) // healthCheck works correctly
+		http.HandleFunc("/job", jobHandler) // healthCheck works correctly
 		healthy = true
 		log.Println("Running as manager service")
 	case "legacy":

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -1,0 +1,90 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: etl-gardener-universal
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      # Used to match pre-existing pods that may be affected during updates.
+      run: etl-gardener-universal
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  # Pod template.
+  template:
+    metadata:
+      labels:
+        # Note: run=etl-gardener-universal should match a service config with a
+        # public IP and port so that it is publicly accessible.
+        run: etl-gardener-universal
+      annotations:
+        # Tell prometheus service discovery to collect metrics from the containers.
+        prometheus.io/scrape: 'true'
+    spec:
+      # When container receives SIGTERM, it begins a new checkpoint. This can
+      # take longer than the default grace period of 30s.
+      terminationGracePeriodSeconds: 60
+
+      # Place the pod into the Guaranteed QoS by setting equal resource
+      # requests and limits for *all* containers in the pod.
+      # For more background, see:
+      # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md
+      containers:
+      - image: gcr.io/{{GCLOUD_PROJECT}}/github-m-lab-etl-gardener:{{GIT_COMMIT}}
+        name: etl-gardener
+        args: ["--prometheusx.listen-address=:9090"]
+        env:
+        - name: SERVICE_MODE # Whether to use task-queues or run as manager.
+          value: "manager"
+        - name: ARCHIVE_BUCKET  # This will eventually be provided through k8s configmap.
+          value: "archive-measurement-lab"
+        - name: GIT_COMMIT
+          value: "{{GIT_COMMIT}}"
+        - name: PROJECT
+          value: "{{GCLOUD_PROJECT}}"
+
+        ports:
+        - name: prometheus-port
+          containerPort: 9090
+        - name: service-port
+          containerPort: 8080
+
+        livenessProbe:
+          httpGet:
+            path: /alive
+            port: service-port
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 4
+          successThreshold: 1
+          failureThreshold: 3
+
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: service-port
+
+        resources:
+          requests:
+            memory: "3Gi"
+            cpu: "1"
+          limits:
+            memory: "3Gi"
+            cpu: "1"
+
+        volumeMounts:
+        - mountPath: /volume-claim
+          name: gardener-storage
+
+      nodeSelector:
+        gardener-node: "true"
+
+      volumes:
+      - name: gardener-storage
+        persistentVolumeClaim:
+          claimName: gardener-universal  # This forces a singleton instance.
+

--- a/k8s/data-processing/persistentvolumes/persistent-volumes.yml
+++ b/k8s/data-processing/persistentvolumes/persistent-volumes.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gardener-universal
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "fast"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/data-processing/persistentvolumes/storage-class.yml
+++ b/k8s/data-processing/persistentvolumes/storage-class.yml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: slow
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-standard
+---
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  name: fast
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd

--- a/k8s/data-processing/services/etl-gardener-service.yml
+++ b/k8s/data-processing/services/etl-gardener-service.yml
@@ -5,9 +5,6 @@ metadata:
   namespace: default
   annotations:
     cloud.google.com/load-balancer-type: "Internal"
-    #cloud.google.com/neg: '{"exposed_ports":{"8080":{}}}'
-    # INGRESS seems to persist even after commenting this out!
-    # kubernetes.io/ingress.regional-static-ip-name: mlab-etl-gardener
 spec:
   ports:
   - port: 8080

--- a/k8s/data-processing/services/etl-gardener-service.yml
+++ b/k8s/data-processing/services/etl-gardener-service.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etl-gardener-service
+  namespace: default
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
+    #cloud.google.com/neg: '{"exposed_ports":{"8080":{}}}'
+    # INGRESS seems to persist even after commenting this out!
+    # kubernetes.io/ingress.regional-static-ip-name: mlab-etl-gardener
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: etl-gardener-universal
+  sessionAffinity: None
+  type: LoadBalancer
+  loadBalancerIP: 10.100.1.2  # etl-gardener us-east1/default/default-gardener subnet - this hard codes the service address.


### PR DESCRIPTION
This adds a new Gardener config, running in the data-processing cluster, using the "default-gardener" subnetwork to provide static internal IP address for ETL parsers to reach the Gardener.

It does not use task queues or drive any workload at this time.  The workload serving through /job will be developed next.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/193)
<!-- Reviewable:end -->
