### PR TITLE
Add general persistence utility.

### DIFF
--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -29,13 +29,14 @@ func NewBase(name string) Base {
 	return Base{name: name}
 }
 
-// PersistentStore provides API for saving state objects.
-type PersistentStore interface {
+// Saver provides API for saving and retrieving StateObjects.
+type Saver interface {
 	Save(ctx context.Context, o StateObject) error
 	Delete(ctx context.Context, o StateObject) error
+	Fetch(ctx context.Context, o StateObject) error
 }
 
-// DatastoreSaver will implement a Saver that stores state objects in Datastore.
+// DatastoreSaver implements a Saver that stores state objects in Datastore.
 type DatastoreSaver struct {
 	Client    *datastore.Client
 	Namespace string
@@ -49,7 +50,7 @@ func NewDatastoreSaver(ctx context.Context, project string) (*DatastoreSaver, er
 	if err != nil {
 		return nil, err
 	}
-	return &DatastoreSaver{client, "scoreboard"}, nil
+	return &DatastoreSaver{Client: client, Namespace: "scoreboard"}, nil
 }
 
 func (ds *DatastoreSaver) key(o StateObject) *datastore.Key {
@@ -80,7 +81,7 @@ func (ds *DatastoreSaver) Delete(ctx context.Context, o StateObject) error {
 	return ctx.Err()
 }
 
-// Fetch fetches state of requested StateObject from Datastore.
+// Fetch implements Saver.Fetch to fetch state of requested StateObject from Datastore.
 func (ds *DatastoreSaver) Fetch(ctx context.Context, o StateObject) error {
 	key := datastore.Key{Kind: o.Kind(), Name: o.Name(), Namespace: ds.Namespace}
 	return ds.Client.Get(ctx, &key, o)

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -1,0 +1,87 @@
+package persistence
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/datastore"
+)
+
+// StateObject defines the interface for objects to be saved/retrieved from datastore.
+type StateObject interface {
+	Name() string
+	Kind() string // Should be implemented in the actual type, as return reflect.TypeOf(o).Name()
+}
+
+// Base is the base for persistent objects.  All StateObjects should embed
+// Base and call NewBase to initialize.
+type Base struct {
+	name string
+}
+
+// Name implements StateObject.Name
+func (o Base) Name() string {
+	return o.name
+}
+
+// NewBase initializes a Base object.
+func NewBase(name string) Base {
+	return Base{name: name}
+}
+
+// PersistentStore provides API for saving state objects.
+type PersistentStore interface {
+	Save(ctx context.Context, o StateObject) error
+	Delete(ctx context.Context, o StateObject) error
+}
+
+// DatastoreSaver will implement a Saver that stores state objects in Datastore.
+type DatastoreSaver struct {
+	Client    *datastore.Client
+	Namespace string
+}
+
+// NewDatastoreSaver creates and returns an appropriate saver.
+// ctx is only used to create the client.
+// TODO - if this ever needs more context, use cloud.Config
+func NewDatastoreSaver(ctx context.Context, project string) (*DatastoreSaver, error) {
+	client, err := datastore.NewClient(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	return &DatastoreSaver{client, "scoreboard"}, nil
+}
+
+func (ds *DatastoreSaver) key(o StateObject) *datastore.Key {
+	k := datastore.NameKey(o.Kind(), o.Name(), nil)
+	k.Namespace = ds.Namespace
+	return k
+}
+
+// Save implements Saver.Save using Datastore.
+func (ds *DatastoreSaver) Save(ctx context.Context, o StateObject) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	_, err := ds.Client.Put(ctx, ds.key(o), o)
+	if err != nil {
+		return err
+	}
+	return ctx.Err()
+}
+
+// Delete implements Saver.Delete using Datastore.
+func (ds *DatastoreSaver) Delete(ctx context.Context, o StateObject) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	err := ds.Client.Delete(ctx, ds.key(o))
+	if err != nil {
+		return err
+	}
+	return ctx.Err()
+}
+
+// Fetch fetches state of requested StateObject from Datastore.
+func (ds *DatastoreSaver) Fetch(ctx context.Context, o StateObject) error {
+	key := datastore.Key{Kind: o.Kind(), Name: o.Name(), Namespace: ds.Namespace}
+	return ds.Client.Get(ctx, &key, o)
+}

--- a/persistence/persistence_test.go
+++ b/persistence/persistence_test.go
@@ -1,0 +1,61 @@
+package persistence_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"cloud.google.com/go/datastore"
+
+	"github.com/m-lab/etl-gardener/persistence"
+	"github.com/m-lab/go/rtx"
+)
+
+type O1 struct {
+	persistence.Base
+
+	Integer int32
+}
+
+// Kind implements StateObject.Kind
+func (o O1) Kind() string {
+	return reflect.TypeOf(o).Name()
+}
+
+func NewO1(name string) O1 {
+	return O1{Base: persistence.NewBase(name)}
+}
+
+func assertStateObject(so persistence.StateObject) {
+	assertStateObject(O1{})
+}
+
+func TestDatastoreSaver(t *testing.T) {
+	ctx := context.Background()
+	ds, err := persistence.NewDatastoreSaver(ctx, "mlab-testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	o := NewO1("foobar")
+	o.Integer = 1234
+	err = ds.Save(ctx, &o)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	o.Integer = 0
+	err = ds.Fetch(ctx, &o)
+	rtx.Must(err, "Fetch error")
+	t.Log(o)
+	if o.Integer != 1234 {
+		t.Error("Integer should be 1234", o)
+	}
+
+	err = ds.Delete(ctx, &o)
+	rtx.Must(err, "Delete error")
+	err = ds.Fetch(ctx, &o)
+	if err != datastore.ErrNoSuchEntity {
+		t.Fatal("Should have errored")
+	}
+}

--- a/scoreboard/README.md
+++ b/scoreboard/README.md
@@ -1,6 +1,8 @@
 # Gardener Scoreboard
 
-The scoreboard keeps track of the state of all parsing activities, persists the data in datastore, and recovers the scoreboard state from datastore on startup or recovery.
+The scoreboard keeps track of the state of all parsing activities, persists
+the data in datastore, and recovers the scoreboard state from datastore on
+startup or recovery.
 
 The scoreboard is used by other components of Gardener to decide:
 
@@ -8,7 +10,8 @@ The scoreboard is used by other components of Gardener to decide:
 1. when a job has failed and needs to be recovered,
 1. when postprocessing actions should be initiated.
 
-The scoreboard provides an API to the other Gardener components to answer questions about the system state.
+The scoreboard provides an API to the other Gardener components to answer
+questions about the system state.
 
 1.
 1.

--- a/scoreboard/README.md
+++ b/scoreboard/README.md
@@ -1,0 +1,15 @@
+# Gardener Scoreboard
+
+The scoreboard keeps track of the state of all parsing activities, persists the data in datastore, and recovers the scoreboard state from datastore on startup or recovery.
+
+The scoreboard is used by other components of Gardener to decide:
+
+1. what jobs to do next,
+1. when a job has failed and needs to be recovered,
+1. when postprocessing actions should be initiated.
+
+The scoreboard provides an API to the other Gardener components to answer questions about the system state.
+
+1.
+1.
+1.


### PR DESCRIPTION
This generalizes code in state.go to be more flexible, allowing arbitrary data types derived from persistence.Base

Question: Should this go in go/dsx, or storagex, now or in the future?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/197)
<!-- Reviewable:end -->
