### PR TITLE
faster tcpinfo, slower sidestream and ndt

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
@@ -62,7 +62,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-ndt-batch-"
         - name: NUM_QUEUES
-          value: "16"
+          value: "8"  # There are actually 16 but we don't need so many now.
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
@@ -62,7 +62,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-sidestream-batch-"
         - name: NUM_QUEUES
-          value: "16"
+          value: "8"  # There are actually 16 but we don't need so many now.
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -63,7 +63,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-tcpinfo-batch-"
         - name: NUM_QUEUES
-          value: "2"
+          value: "4"
 
         ports:
         - name: prometheus-port


### PR DESCRIPTION
This change reduces the processing rate for ndt and sidestream (by reducing the number of active task-queues, to make more resources available for tcpinfo processing.

It also increases the number of tcpinfo queues, to increase the amount of available tcpinfo work.
