### PR TITLE
Add reprocessing of yesterday at 3:00 am UTC.

### DIFF
--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -317,7 +317,6 @@ func doDispatchLoop(ctx context.Context, handler *TaskHandler, bucket string, ex
 					log.Println(err)
 				}
 			}
-			// For now, process every day in sandbox
 			nextRecent = nextRecent.AddDate(0, 0, 1+dateSkip)
 		}
 

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -273,16 +273,12 @@ queueLoop:
 
 // findNextRecentDay finds an appropriate date to start daily processing.
 func findNextRecentDay(start time.Time, skip int) time.Time {
-	// Temp hack
-	hack := time.Now().Add(-14 * time.Hour).Truncate(24 * time.Hour)
-	log.Println("Next will be", hack)
-	return hack
-
 	// Normally we'll reprocess yesterday after 6:00 am UTC.
 	// However, allow a couple more hours of leeway when restarting.
 	// This may mean yesterday gets processed twice in a row.
-	yesterday := time.Now().Add(-8 * time.Hour).Truncate(24 * time.Hour)
+	yesterday := time.Now().Add(-8 * time.Hour).UTC().Truncate(24 * time.Hour)
 	if skip == 0 {
+		log.Println("yesterday is:", yesterday.Format("2006/01/02 15:04 UTC"))
 		return yesterday
 	}
 

--- a/reproc/dispatch_test.go
+++ b/reproc/dispatch_test.go
@@ -75,6 +75,18 @@ func (s *testSaver) DeleteTask(ctx context.Context, t state.Task) error {
 	return nil
 }
 
+func (s *testSaver) getTaskStates() [][]state.Task {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	taskStates := make([][]state.Task, len(s.tasks))
+	i := 0
+	for _, t := range s.tasks {
+		taskStates[i] = t
+		i++
+	}
+	return taskStates
+}
+
 func assertPersistentStore() { func(ex state.PersistentStore) {}(&testSaver{}) }
 
 type Exec struct{}
@@ -244,7 +256,8 @@ func TestDoDispatchLoop(t *testing.T) {
 	recent := "gs://foobar/exp" + start.Add(-24*time.Hour).Format("/2006/01/02/")
 	// We expect to see at least 3 distinct recent dates...
 	recents := map[string]bool{}
-	for _, task := range saver.tasks {
+	tasks := saver.getTaskStates()
+	for _, task := range tasks {
 		taskEnd := task[len(task)-1]
 		if taskEnd.Name >= recent {
 			t.Log(taskEnd)

--- a/reproc/dispatch_test.go
+++ b/reproc/dispatch_test.go
@@ -10,7 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
+
 	"github.com/m-lab/etl-gardener/reproc"
 	"github.com/m-lab/etl-gardener/state"
 )

--- a/reproc/export_test.go
+++ b/reproc/export_test.go
@@ -1,0 +1,3 @@
+package reproc
+
+var DoDispatchLoop = doDispatchLoop


### PR DESCRIPTION
This temporarily provides the function of the "daily" pipeline.

Eventually this will be replaced with incremental processing of new archive files as they arrive, but this is good enough for the short term.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/202)
<!-- Reviewable:end -->
