### PR TITLE
Read switch data from utilization/switch folder

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
@@ -54,7 +54,7 @@ spec:
         - name: TASK_FILE_SKIP # Should be 0 for normal operation
           value: "{{TASK_FILE_SKIP}}"
         - name: EXPERIMENT
-          value: "switch"
+          value: "utilization/switch"
         - name: DATASET
           value: "batch"
         - name: FINAL_DATASET


### PR DESCRIPTION
This change updates the experiment pattern for reprocessing utilization/switch data. After migrating nodes to the k8s paltform, pusher uploads switch data to a new GCS folder `utilization/switch`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/208)
<!-- Reviewable:end -->
