### PR TITLE
Job Tracker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,9 @@ script:
     go test -v -coverprofile=_integration.cov ./... -tags=integration ;
   fi
 
+# Also run some concurrency sensitive tests with -race
+- go test -v ./tracker/... -race
+
 # Combine coverage of unit tests and integration tests and send the results to coveralls.
 - $HOME/gopath/bin/gocovmerge _*.cov > _merge.cov
 - $HOME/gopath/bin/goveralls -coverprofile=_merge.cov -service=travis-ci

--- a/tracker/testClient_test.go
+++ b/tracker/testClient_test.go
@@ -2,6 +2,7 @@ package tracker_test
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"sync"
 
@@ -20,6 +21,8 @@ func validateDatastoreEntity(e interface{}) error {
 	}
 	return nil
 }
+
+var ErrNotImplemented = errors.New("Not implemented")
 
 // This implements a crude datastore test client.  It is somewhat
 // simplistic and incomplete.  It works only for basic Put, Get, and Delete,

--- a/tracker/testClient_test.go
+++ b/tracker/testClient_test.go
@@ -3,6 +3,7 @@ package tracker_test
 import (
 	"context"
 	"errors"
+	"log"
 	"reflect"
 	"sync"
 
@@ -80,4 +81,14 @@ func (c *testClient) Put(ctx context.Context, key *datastore.Key, src interface{
 	v := reflect.ValueOf(src)
 	c.objects[*key] = reflect.Indirect(v)
 	return key, nil
+}
+
+func (c *testClient) DumpKeys() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	log.Println(len(c.objects), "keys")
+	for k := range c.objects {
+		log.Println("Key:", k)
+	}
+
 }

--- a/tracker/testClient_test.go
+++ b/tracker/testClient_test.go
@@ -1,0 +1,80 @@
+package tracker_test
+
+import (
+	"context"
+	"reflect"
+	"sync"
+
+	"cloud.google.com/go/datastore"
+	"github.com/GoogleCloudPlatform/google-cloud-go-testing/datastore/dsiface"
+)
+
+func validateDatastoreEntity(e interface{}) error {
+	v := reflect.ValueOf(e)
+	if v.Kind() != reflect.Ptr {
+		return datastore.ErrInvalidEntityType
+	}
+	// NOTE: This is over-restrictive, but fine for current purposes.
+	if reflect.Indirect(v).Kind() != reflect.Struct {
+		return datastore.ErrInvalidEntityType
+	}
+	return nil
+}
+
+// This implements a crude datastore test client.  It is somewhat
+// simplistic and incomplete.  It works only for basic Put, Get, and Delete,
+// but may not work always work correctly.
+type testClient struct {
+	dsiface.Client // For unimplemented methods
+	lock           sync.Mutex
+	objects        map[datastore.Key]reflect.Value
+}
+
+func newTestClient() *testClient {
+	return &testClient{objects: make(map[datastore.Key]reflect.Value, 10)}
+}
+
+func (c *testClient) Close() error { return nil }
+
+func (c *testClient) Count(ctx context.Context, q *datastore.Query) (n int, err error) {
+	return 0, ErrNotImplemented
+}
+
+func (c *testClient) Delete(ctx context.Context, key *datastore.Key) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	_, ok := c.objects[*key]
+	if !ok {
+		return datastore.ErrNoSuchEntity
+	}
+	delete(c.objects, *key)
+	return nil
+}
+
+func (c *testClient) Get(ctx context.Context, key *datastore.Key, dst interface{}) (err error) {
+	err = validateDatastoreEntity(dst)
+	if err != nil {
+		return err
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	v := reflect.ValueOf(dst)
+	o, ok := c.objects[*key]
+	if !ok {
+		return datastore.ErrNoSuchEntity
+	}
+	v.Elem().Set(o)
+	return nil
+}
+
+func (c *testClient) Put(ctx context.Context, key *datastore.Key, src interface{}) (*datastore.Key, error) {
+	err := validateDatastoreEntity(src)
+	if err != nil {
+		return nil, err
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	v := reflect.ValueOf(src)
+	c.objects[*key] = reflect.Indirect(v)
+	return key, nil
+}

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -1,10 +1,26 @@
 // Package tracker tracks status of all jobs, and handles persistence.
 //
+// Concurrency properties:
+//  1. The job map is protected by a Mutex, but lock is only required
+//     to get a copy or set the JobState value, so there is minimal
+//     contention.
+//  2. JobState objects are persisted to a Saver by a separate
+//     goroutine that periodically updates any modified JobState objects.
+//     The JobState's updatetime is used to determine whether it needs
+//     to be saved.
 package tracker
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"log"
+	"sync"
 	"time"
+
+	"cloud.google.com/go/datastore"
+	"github.com/GoogleCloudPlatform/google-cloud-go-testing/datastore/dsiface"
 )
 
 // Job describes a reprocessing "Job", which includes
@@ -25,4 +41,229 @@ func JobKey(bucket string, exp string, typ string, date time.Time) string {
 // Key generates the prefix key for lookups.
 func (j Job) Key() string {
 	return JobKey(j.Bucket, j.Experiment, j.Datatype, j.Date)
+}
+
+// Error declarations
+var (
+	ErrJobAlreadyExists       = errors.New("job already exists")
+	ErrJobNotFound            = errors.New("job not found")
+	ErrJobIsObsolete          = errors.New("job is obsolete")
+	ErrInvalidStateTransition = errors.New("invalid state transition")
+	ErrNotYetImplemented      = errors.New("not yet implemented")
+)
+
+// State types are used for the JobState.State values
+// This is intended to enforce type safety, but compiler accepts string assignment.  8-(
+type State string
+
+// State values
+const (
+	Init          State = "init"
+	Parsing       State = "parsing"
+	Stabilizing   State = "stabilizing"
+	Deduplicating State = "deduplicating"
+	Joining       State = "joining"
+	Failed        State = "failed"
+	Complete      State = "complete"
+)
+
+// A JobState describes the state of a bucket/exp/type/YYYY/MM/DD job.
+// Completed jobs are removed from the persistent store.
+// Errored jobs are maintained in the persistent store for debugging.
+// JobState should be updated only by the Tracker, which will
+// ensure correct serialization and Saver updates.
+type JobState struct {
+	Job
+
+	UpdateTime    time.Time // Time of last update.
+	HeartbeatTime time.Time // Time of last ETL heartbeat.
+
+	State     State  // String defining the current state.
+	LastError string // The most recent error encountered.
+
+	// Note that these are not persisted
+	errors []string // all errors related to the job.
+}
+
+func (j JobState) isDone() bool {
+	return j.State == Complete
+}
+
+// NewJobState creates a new JobState with provided parameters.
+// NB:  The date will be converted to UTC and truncated to day boundary!
+func NewJobState(bucket string, exp string, typ string, date time.Time) JobState {
+	return JobState{
+		Job: Job{Bucket: bucket,
+			Experiment: exp,
+			Datatype:   typ,
+			Date:       date.UTC().Truncate(24 * time.Hour)},
+		State:  Init,
+		errors: make([]string, 0, 1),
+	}
+}
+
+// Tracker keeps track of all the jobs in flight.
+// Only tracker functions should access any of the fields.
+type Tracker struct {
+	client dsiface.Client
+	dsKey  *datastore.Key
+	ticker *time.Ticker
+
+	lock sync.Mutex
+	jobs map[string]*JobState // Map from prefix to JobState.
+}
+
+type saverStruct struct {
+	SaveTime time.Time
+	Jobs     []byte `datastore:",noindex"`
+}
+
+// InitTracker recovers the Tracker state from a Client object.
+// May return error if recovery fails.
+func InitTracker(ctx context.Context, client dsiface.Client, saveInterval time.Duration) (*Tracker, error) {
+	// TODO implement recovery.
+	t := Tracker{client: client, jobs: make(map[string]*JobState, 100)}
+	t.dsKey = datastore.NameKey("tracker", "state", nil)
+	t.dsKey.Namespace = "gardener"
+
+	if client != nil {
+		state := saverStruct{time.Time{}, make([]byte, 0, 100000)}
+
+		err := client.Get(ctx, t.dsKey, &state) // This should error?
+		if err != nil {
+			if err != datastore.ErrNoSuchEntity {
+				return nil, err
+			}
+			log.Println(err)
+		} else {
+			log.Println("Unmarshalling", len(state.Jobs))
+			json.Unmarshal(state.Jobs, &t.jobs)
+		}
+	}
+
+	if saveInterval > 0 {
+		t.saveEvery(saveInterval)
+	}
+	return &t, nil
+}
+
+// NumJobs returns the number of jobs in flight.  This includes
+// jobs in "Complete" state that have not been removed from saver.
+func (tr *Tracker) NumJobs() int {
+	tr.lock.Lock()
+	defer tr.lock.Unlock()
+	return len(tr.jobs)
+}
+
+func (tr *Tracker) getJSON() ([]byte, error) {
+	tr.lock.Lock()
+	defer tr.lock.Unlock()
+	// First delete any completed jobs.
+	for key, job := range tr.jobs {
+		if job.isDone() {
+			delete(tr.jobs, key)
+		}
+	}
+	return json.Marshal(tr.jobs)
+}
+
+// Sync snapshots the full job state and saves it to the datastore client.
+func (tr *Tracker) Sync() error {
+	bytes, err := tr.getJSON()
+	if err != nil {
+		return err
+	}
+
+	// Save the full state.
+	state := saverStruct{time.Now(), bytes}
+	ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cf()
+	_, err = tr.client.Put(ctx, tr.dsKey, &state)
+
+	return err
+}
+
+func (tr *Tracker) saveEvery(interval time.Duration) {
+	tr.ticker = time.NewTicker(interval)
+	go func() {
+		for range tr.ticker.C {
+			tr.Sync()
+		}
+	}()
+}
+
+// GetJob gets a copy of an existing job.
+func (tr *Tracker) GetJob(prefix string) (JobState, error) {
+	tr.lock.Lock()
+	defer tr.lock.Unlock()
+	job := tr.jobs[prefix]
+	if job == nil {
+		return JobState{}, ErrJobNotFound
+	}
+	return *job, nil
+}
+
+// AddJob adds a new job to the Tracker.
+// May return ErrJobAlreadyExists if job already exists.
+func (tr *Tracker) AddJob(job JobState) error {
+	tr.lock.Lock()
+	defer tr.lock.Unlock()
+	_, ok := tr.jobs[job.Key()]
+	if ok {
+		return ErrJobAlreadyExists
+	}
+
+	tr.jobs[job.Key()] = &job
+	return nil
+}
+
+// updateJob updates an existing job.
+// May return ErrJobNotFound if job no longer exists.
+func (tr *Tracker) updateJob(job JobState) error {
+	tr.lock.Lock()
+	defer tr.lock.Unlock()
+	_, ok := tr.jobs[job.Key()]
+	if !ok {
+		return ErrJobNotFound
+	}
+
+	if job.isDone() {
+		delete(tr.jobs, job.Key())
+	} else {
+		tr.jobs[job.Key()] = &job
+	}
+	return nil
+}
+
+// SetJobState updates a job's state, and handles persistence.
+func (tr *Tracker) SetJobState(prefix string, newState State) error {
+	job, err := tr.GetJob(prefix)
+	if err != nil {
+		return err
+	}
+	job.State = newState
+	job.UpdateTime = time.Now()
+	return tr.updateJob(job)
+}
+
+// Heartbeat updates a job's heartbeat time.
+func (tr *Tracker) Heartbeat(prefix string) error {
+	job, err := tr.GetJob(prefix)
+	if err != nil {
+		return err
+	}
+	job.HeartbeatTime = time.Now()
+	return tr.updateJob(job)
+}
+
+// SetJobError updates a job's error fields, and handles persistence.
+func (tr *Tracker) SetJobError(prefix string, errString string) error {
+	job, err := tr.GetJob(prefix)
+	if err != nil {
+		return err
+	}
+	job.UpdateTime = time.Now()
+	job.LastError = errString
+	job.errors = append(job.errors, errString)
+	return tr.updateJob(job)
 }

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -61,7 +61,9 @@ const (
 	Deduplicating State = "deduplicating"
 	Joining       State = "joining"
 	Failed        State = "failed"
-	Complete      State = "complete"
+	// Note that GetStatus will never return Complete, as the
+	// Job is removed when SetJobState is called with Complete.
+	Complete State = "complete"
 )
 
 // A Status describes the state of a bucket/exp/type/YYYY/MM/DD job.
@@ -198,12 +200,6 @@ func (tr *Tracker) NumJobs() int {
 func (tr *Tracker) getJSON() ([]byte, error) {
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
-	// First delete any completed jobs.
-	for key, job := range tr.jobs {
-		if job.isDone() {
-			delete(tr.jobs, key)
-		}
-	}
 	return json.Marshal(tr.jobs)
 }
 

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -94,7 +94,7 @@ func NewStatus() Status {
 }
 
 // JobMap is defined to allow custom json marshal/unmarshal.
-// It defines the map from Job to Status
+// It defines the map from Job to Status.
 type JobMap map[Job]Status
 
 // MarshalJSON implements json.Marshal

--- a/tracker/tracker_integration_test.go
+++ b/tracker/tracker_integration_test.go
@@ -27,7 +27,7 @@ func TestWithDatastore(t *testing.T) {
 	}
 
 	numJobs := 500
-	createJobs(t, tk, "500Jobs", numJobs)
+	createJobs(t, tk, "500Jobs", "type", numJobs)
 	if tk.NumJobs() != 500 {
 		t.Fatal("Incorrect number of jobs", tk.NumJobs())
 	}
@@ -42,7 +42,7 @@ func TestWithDatastore(t *testing.T) {
 		t.Fatal("Incorrect number of jobs", restore.NumJobs())
 	}
 
-	completeJobs(t, tk, "500Jobs", numJobs)
+	completeJobs(t, tk, "500Jobs", "type", numJobs)
 
 	tk.Sync()
 

--- a/tracker/tracker_integration_test.go
+++ b/tracker/tracker_integration_test.go
@@ -22,6 +22,8 @@ func TestWithDatastore(t *testing.T) {
 
 	dsKey := datastore.NameKey("TestWithDatastore", "jobs", nil)
 	dsKey.Namespace = "gardener"
+	// NOTE: datastore has eventual consistency, and deletes seem to take
+	// quite a while to propogate.
 	defer must(t, cleanup(client, dsKey))
 
 	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0)

--- a/tracker/tracker_integration_test.go
+++ b/tracker/tracker_integration_test.go
@@ -1,0 +1,53 @@
+// +build integration
+
+package tracker_test
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/google-cloud-go-testing/datastore/dsiface"
+
+	"cloud.google.com/go/datastore"
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+// This test uses an actual datastore client.
+// It should generally be run with the datastore emulator.
+func TestWithDatastore(t *testing.T) {
+	dsc, err := datastore.NewClient(context.Background(), "mlab-testing")
+	client := dsiface.AdaptClient(dsc)
+	must(t, err)
+
+	tk, err := tracker.InitTracker(context.Background(), client, 0)
+	must(t, err)
+	if tk == nil {
+		t.Fatal("nil Tracker")
+	}
+
+	numJobs := 500
+	createJobs(t, tk, "500Jobs", numJobs)
+	if tk.NumJobs() != 500 {
+		t.Fatal("Incorrect number of jobs", tk.NumJobs())
+	}
+
+	log.Println("Calling Sync")
+	must(t, tk.Sync()) // This causes invalid entity type
+	// Check that the sync (and InitTracker) work.
+	restore, err := tracker.InitTracker(context.Background(), client, 0)
+	must(t, err)
+
+	if restore.NumJobs() != 500 {
+		t.Fatal("Incorrect number of jobs", restore.NumJobs())
+	}
+
+	completeJobs(t, tk, "500Jobs", numJobs)
+
+	tk.Sync()
+
+	if tk.NumJobs() != 0 {
+		t.Error("Job cleanup failed", tk.NumJobs())
+	}
+
+}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -52,7 +52,7 @@ func completeJobs(t *testing.T, tk *tracker.Tracker, exp string, typ string, n i
 	date := startDate
 	for i := 0; i < n; i++ {
 		job := tracker.Job{"bucket", exp, typ, date}
-		err := tk.SetJobState(job, tracker.Complete)
+		err := tk.SetStatus(job, tracker.Complete)
 
 		if err != nil {
 			t.Error(err, job)
@@ -127,9 +127,9 @@ func TestUpdate(t *testing.T) {
 	defer completeJobs(t, tk, "JobToUpdate", "type", 2)
 
 	job := tracker.Job{"bucket", "JobToUpdate", "type", startDate}
-	must(t, tk.SetJobState(job, tracker.Parsing))
+	must(t, tk.SetStatus(job, tracker.Parsing))
 
-	must(t, tk.SetJobState(job, tracker.Stabilizing))
+	must(t, tk.SetStatus(job, tracker.Stabilizing))
 
 	status, err := tk.GetStatus(job)
 	if err != nil {
@@ -139,13 +139,13 @@ func TestUpdate(t *testing.T) {
 		t.Error("Incorrect job state", job)
 	}
 
-	err = tk.SetJobState(tracker.Job{"bucket", "JobToUpdate", "nontype", startDate}, tracker.Stabilizing)
+	err = tk.SetStatus(tracker.Job{"bucket", "JobToUpdate", "nontype", startDate}, tracker.Stabilizing)
 	if err != tracker.ErrJobNotFound {
 		t.Error(err, "should have been ErrJobNotFound")
 	}
 }
 
-// This tests whether AddJob and SetJobState generate appropriate
+// This tests whether AddJob and SetStatus generate appropriate
 // errors when job doesn't exist.
 func TestNonexistentJobAccess(t *testing.T) {
 	client := newTestClient()
@@ -157,7 +157,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 	must(t, err)
 
 	job := tracker.Job{}
-	err = tk.SetJobState(job, tracker.Parsing)
+	err = tk.SetStatus(job, tracker.Parsing)
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
 	}
@@ -172,10 +172,10 @@ func TestNonexistentJobAccess(t *testing.T) {
 		t.Error("Should be ErrJobAlreadyExists", err)
 	}
 
-	tk.SetJobState(js, tracker.Complete)
+	tk.SetStatus(js, tracker.Complete)
 
 	// Job should be gone now.
-	err = tk.SetJobState(js, "foobar")
+	err = tk.SetStatus(js, "foobar")
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
 	}
@@ -209,7 +209,7 @@ func TestConcurrentUpdates(t *testing.T) {
 			k := tracker.Job{"bucket", "ConcurrentUpdates", "type",
 				startDate.Add(time.Duration(24*rand.Intn(jobs)) * time.Hour)}
 			if i%5 == 0 {
-				err := tk.SetJobState(k, tracker.State(fmt.Sprintf("State:%d", i)))
+				err := tk.SetStatus(k, tracker.State(fmt.Sprintf("State:%d", i)))
 				if err != nil {
 					log.Fatal(err, " ", k)
 				}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -124,11 +124,9 @@ func TestUpdate(t *testing.T) {
 	must(t, err)
 
 	createJobs(t, tk, "JobToUpdate", "type", 2)
-	defer completeJobs(t, tk, "JobToUpdate", "type", 2)
 
 	job := tracker.Job{"bucket", "JobToUpdate", "type", startDate}
 	must(t, tk.SetStatus(job, tracker.Parsing))
-
 	must(t, tk.SetStatus(job, tracker.Stabilizing))
 
 	status, err := tk.GetStatus(job)
@@ -139,7 +137,7 @@ func TestUpdate(t *testing.T) {
 		t.Error("Incorrect job state", job)
 	}
 
-	err = tk.SetStatus(tracker.Job{"bucket", "JobToUpdate", "nontype", startDate}, tracker.Stabilizing)
+	err = tk.SetStatus(tracker.Job{"bucket", "JobToUpdate", "other-type", startDate}, tracker.Stabilizing)
 	if err != tracker.ErrJobNotFound {
 		t.Error(err, "should have been ErrJobNotFound")
 	}
@@ -198,12 +196,12 @@ func TestConcurrentUpdates(t *testing.T) {
 
 	jobs := 20
 	createJobs(t, tk, "ConcurrentUpdates", "type", jobs)
-	defer completeJobs(t, tk, "ConcurrentUpdates", "type", jobs)
 
 	changes := 20 * jobs
 	start := time.Now()
 	wg := sync.WaitGroup{}
 	wg.Add(changes)
+	// Execute large number of concurrent updates and heartbeats.
 	for i := 0; i < changes; i++ {
 		go func(i int) {
 			k := tracker.Job{"bucket", "ConcurrentUpdates", "type",

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -112,8 +112,8 @@ func TestTrackerAddDelete(t *testing.T) {
 	}
 }
 
-// This tests basic Add and update of 2 jobs, and verifies
-// correct error returned when trying to update a third job.
+// This tests basic Add and update of one jobs, and verifies
+// correct error returned when trying to update a non-existent job.
 func TestUpdate(t *testing.T) {
 	client := newTestClient()
 	dsKey := datastore.NameKey("TestUpdate", "jobs", nil)
@@ -123,7 +123,7 @@ func TestUpdate(t *testing.T) {
 	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
 	must(t, err)
 
-	createJobs(t, tk, "JobToUpdate", "type", 2)
+	createJobs(t, tk, "JobToUpdate", "type", 1)
 
 	job := tracker.Job{"bucket", "JobToUpdate", "type", startDate}
 	must(t, tk.SetStatus(job, tracker.Parsing))

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -1,0 +1,205 @@
+package tracker_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+func must(t *testing.T, err error) {
+	if err != nil {
+		log.Output(2, err.Error())
+		t.Fatal(err)
+	}
+}
+
+var startDate = time.Date(2011, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func createJobs(t *testing.T, tk *tracker.Tracker, exp string, n int) {
+	// Create 100 jobs in parallel
+	wg := sync.WaitGroup{}
+	wg.Add(n)
+	date := startDate
+	for i := 0; i < n; i++ {
+		go func(date time.Time) {
+			job := tracker.NewJobState("bucket", exp, date)
+			err := tk.AddJob(job)
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}(date)
+		date = date.Add(24 * time.Hour)
+	}
+	wg.Wait()
+}
+
+func completeJobs(t *testing.T, tk *tracker.Tracker, exp string, n int) {
+	// Delete all jobs.
+	date := startDate
+	for i := 0; i < n; i++ {
+		key := tracker.JobKey("bucket", exp, date)
+		err := tk.SetJobState(key, tracker.Complete)
+		if err != nil {
+			t.Error(err, key)
+		}
+		date = date.Add(24 * time.Hour)
+	}
+	tk.Sync() // Force synchronous save cycle.
+}
+
+var ErrNotImplemented = errors.New("Not implemented")
+
+func TestTrackerAddDelete(t *testing.T) {
+	client := newTestClient()
+
+	tk, err := tracker.InitTracker(context.Background(), client, 0)
+	must(t, err)
+	if tk == nil {
+		t.Fatal("nil Tracker")
+	}
+
+	numJobs := 500
+	createJobs(t, tk, "500Jobs", numJobs)
+	if tk.NumJobs() != 500 {
+		t.Fatal("Incorrect number of jobs", tk.NumJobs())
+	}
+
+	log.Println("Calling Sync")
+	must(t, tk.Sync())
+	// Check that the sync (and InitTracker) work.
+	restore, err := tracker.InitTracker(context.Background(), client, 0)
+	must(t, err)
+
+	if restore.NumJobs() != 500 {
+		t.Fatal("Incorrect number of jobs", restore.NumJobs())
+	}
+
+	completeJobs(t, tk, "500Jobs", numJobs)
+
+	tk.Sync()
+
+	if tk.NumJobs() != 0 {
+		t.Error("Job cleanup failed", tk.NumJobs())
+	}
+
+}
+
+// This tests basic Add and update of 2 jobs, and verifies
+// correct error returned when trying to update a third job.
+func TestUpdate(t *testing.T) {
+	client := newTestClient()
+
+	tk, err := tracker.InitTracker(context.Background(), client, 0)
+	must(t, err)
+
+	createJobs(t, tk, "JobToUpdate", 2)
+	defer completeJobs(t, tk, "JobToUpdate", 2)
+
+	prefix := tracker.JobKey("bucket", "JobToUpdate", startDate)
+	must(t, tk.SetJobState(prefix, tracker.Parsing))
+
+	must(t, tk.SetJobState(prefix, tracker.Stabilizing))
+
+	job, err := tk.GetJob(prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != tracker.Stabilizing {
+		t.Error("Incorrect job state", job)
+	}
+
+	err = tk.SetJobState("no such job", tracker.Stabilizing)
+	if err != tracker.ErrJobNotFound {
+		t.Error(err, "should have been ErrJobNotFound")
+	}
+}
+
+// This tests whether AddJob and SetJobState generate appropriate
+// errors when job doesn't exist.
+func TestNonexistentJobAccess(t *testing.T) {
+	client := newTestClient()
+
+	tk, err := tracker.InitTracker(context.Background(), client, 0)
+	must(t, err)
+
+	err = tk.SetJobState("foobar", tracker.Parsing)
+	if err != tracker.ErrJobNotFound {
+		t.Error("Should be ErrJobNotFound", err)
+	}
+	job := tracker.NewJobState("foobar", "exp", startDate)
+	err = tk.AddJob(job)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = tk.AddJob(job)
+	if err != tracker.ErrJobAlreadyExists {
+		t.Error("Should be ErrJobAlreadyExists", err)
+	}
+
+	tk.SetJobState(job.Key(), tracker.Complete)
+
+	// Job should be gone now.
+	err = tk.SetJobState(job.Key(), "foobar")
+	if err != tracker.ErrJobNotFound {
+		t.Error("Should be ErrJobNotFound", err)
+	}
+}
+
+func TestConcurrentUpdates(t *testing.T) {
+	// The test is intended to exercise job updates at a high
+	// rate, and ensure that are no races.
+	// It should be run with -race to detect any concurrency
+	// problems.
+	client := newTestClient()
+	// For testing, push to the saver every 5 milliseconds.
+	saverInterval := 5 * time.Millisecond
+	tk, err := tracker.InitTracker(context.Background(), client, saverInterval)
+	must(t, err)
+
+	jobs := 20
+	createJobs(t, tk, "ConcurrentUpdates", jobs)
+	defer completeJobs(t, tk, "ConcurrentUpdates", jobs)
+
+	changes := 20 * jobs
+	start := time.Now()
+	wg := sync.WaitGroup{}
+	wg.Add(changes)
+	for i := 0; i < changes; i++ {
+		go func(i int) {
+			k := tracker.JobKey("bucket", "ConcurrentUpdates",
+				startDate.Add(time.Duration(24*rand.Intn(jobs))*time.Hour))
+			if i%5 == 0 {
+				err := tk.SetJobState(k, tracker.State(fmt.Sprintf("State:%d", i)))
+				if err != nil {
+					log.Fatal(err, " ", k)
+				}
+			} else {
+				err := tk.Heartbeat(k)
+				if err != nil {
+					log.Fatal(err, " ", k)
+				}
+			}
+			wg.Done()
+		}(i)
+		time.Sleep(200 * time.Microsecond)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+	if elapsed > 2*time.Second {
+		t.Error("Expected elapsed time < 2 seconds", elapsed)
+	}
+}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -33,7 +33,7 @@ func createJobs(t *testing.T, tk *tracker.Tracker, exp string, typ string, n int
 	date := startDate
 	for i := 0; i < n; i++ {
 		go func(date time.Time) {
-			job := tracker.NewJobState("bucket", exp, typ, date)
+			job := tracker.NewJob("bucket", exp, typ, date)
 			err := tk.AddJob(job)
 			if err != nil {
 				t.Error(err)
@@ -137,7 +137,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
 	}
-	js := tracker.NewJobState("bucket", "exp", "type", startDate)
+	js := tracker.NewJob("bucket", "exp", "type", startDate)
 	err = tk.AddJob(js)
 	if err != nil {
 		t.Error(err)
@@ -148,10 +148,10 @@ func TestNonexistentJobAccess(t *testing.T) {
 		t.Error("Should be ErrJobAlreadyExists", err)
 	}
 
-	tk.SetJobState(js.Job, tracker.Complete)
+	tk.SetJobState(js, tracker.Complete)
 
 	// Job should be gone now.
-	err = tk.SetJobState(js.Job, "foobar")
+	err = tk.SetJobState(js, "foobar")
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
 	}


### PR DESCRIPTION
Tracker contains a JobMap, which maps from Job to Status.
Includes thread-safe functions for querying, updating, and persisting.

Supercedes https://github.com/m-lab/etl-gardener/pull/201, which used strings for keys.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/213)
<!-- Reviewable:end -->
