### PR TITLE
Use clusterip instead of loadbalancer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,16 @@ deploy:
     all_branches: true
     condition: $TRAVIS_BRANCH == sandbox-* && $TRAVIS_EVENT_TYPE == push
 
+- provider: script
+  script:
+    DATE_SKIP="2" TASK_FILE_SKIP="4"
+    $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing ./apply-cluster.sh
+  skip_cleanup: true
+  on:
+    repo: m-lab/etl-gardener
+    all_branches: true
+    condition: $TRAVIS_BRANCH == universal-sandbox-* && $TRAVIS_EVENT_TYPE == push
+
 #########################################
 ## Staging
 - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ script:
 - $HOME/gopath/bin/goveralls -coverprofile=_merge.cov -service=travis-ci
 
 # Validate docker build.
-- docker build .
+# - docker build .
 
 #################################################################################
 # Deployment Section

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ before_script:
 - sleep 2 # allow time for emulator to start up.
 - $(gcloud beta emulators datastore env-init)
 
+- netstat -4  # List the ports in use.
+
 script:
 # To start, run all the non-integration unit tests.
 - cd $TRAVIS_BUILD_DIR
@@ -82,7 +84,7 @@ script:
 - $HOME/gopath/bin/gocovmerge _*.cov > _merge.cov
 - $HOME/gopath/bin/goveralls -coverprofile=_merge.cov -service=travis-ci
 
-# Clean build and prepare for deployment
+# Validate docker build.
 - docker build .
 
 #################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as builder
+FROM golang:1.13 as builder
 
 ENV CGO_ENABLED 0
 
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/m-lab/etl-gardener
 COPY . .
 
 # Get the requirements and put the produced binaries in /go/bin
-RUN go get -v -t ./...
+RUN go get -v ./...
 RUN go install \
       -v \
       -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \

--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -29,4 +29,4 @@ kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
 cat ${CFG}
 
 # This triggers deployment of the pod.
-kubectl apply -f ${CFG}
+kubectl apply -f ${CFG} --force

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -332,7 +332,7 @@ func main() {
 	case "manager":
 		// This is new new "manager" mode, in which Gardener provides /job and /update apis
 		// for parsers to get work and report progress.
-		globalTracker := mustStandardTracker()
+		globalTracker = mustStandardTracker()
 		handler := tracker.NewHandler(globalTracker)
 		handler.Register(http.DefaultServeMux)
 

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -273,7 +273,7 @@ func mustStandardTracker() *tracker.Tracker {
 	dsKey := datastore.NameKey("tracker", "jobs", nil)
 	dsKey.Namespace = "gardener"
 
-	tk, err := tracker.InitTracker(context.Background(), dsiface.AdaptClient(client), dsKey, 0)
+	tk, err := tracker.InitTracker(context.Background(), dsiface.AdaptClient(client), dsKey, time.Minute)
 	rtx.Must(err, "tracker init")
 	if tk == nil {
 		log.Fatal("nil tracker")

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -293,7 +293,18 @@ func mustStandardTracker() *tracker.Tracker {
 	dsKey := datastore.NameKey("tracker", "jobs", nil)
 	dsKey.Namespace = "gardener"
 
-	tk, err := tracker.InitTracker(context.Background(), dsiface.AdaptClient(client), dsKey, time.Minute)
+	expString, ok := os.LookupEnv("JOB_EXPIRATION_TIME")
+	exp := 0
+	if ok {
+		var err error
+		exp, err = strconv.Atoi(expString)
+		rtx.Must(err, "Invalid expiration time:", expString)
+	}
+
+	tk, err := tracker.InitTracker(
+		context.Background(),
+		dsiface.AdaptClient(client), dsKey,
+		time.Minute, time.Duration(exp)*time.Second)
 	rtx.Must(err, "tracker init")
 	if tk == nil {
 		log.Fatal("nil tracker")

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -255,7 +255,7 @@ func Status(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "</body></html>\n")
 }
 
-func startStatusServer(port string) {
+func startStatusServer(port string) *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", Status)
 	mux.HandleFunc("/status", Status)
@@ -266,6 +266,8 @@ func startStatusServer(port string) {
 		Handler: mux,
 	}
 	rtx.Must(httpx.ListenAndServeAsync(server), "Could not start status server")
+
+	return server
 }
 
 var healthy = false
@@ -316,7 +318,8 @@ func main() {
 	// Expose prometheus and pprof metrics on a separate port.
 	prometheusx.MustServeMetrics()
 
-	startStatusServer(":8081")
+	statusServer := startStatusServer(":8081")
+	defer statusServer.Close()
 
 	http.HandleFunc("/", Status)
 	http.HandleFunc("/status", Status)

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -255,14 +255,18 @@ func Status(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "</body></html>\n")
 }
 
-func startStatusServer(port string) *http.Server {
+func startStatusServer() *http.Server {
+	statusPort := os.Getenv("STATUS_PORT")
+	if len(statusPort) == 0 {
+		statusPort = ":0"
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", Status)
 	mux.HandleFunc("/status", Status)
 
 	// Start up the http server.
 	server := &http.Server{
-		Addr:    port,
+		Addr:    statusPort,
 		Handler: mux,
 	}
 	rtx.Must(httpx.ListenAndServeAsync(server), "Could not start status server")
@@ -318,8 +322,9 @@ func main() {
 	// Expose prometheus and pprof metrics on a separate port.
 	prometheusx.MustServeMetrics()
 
-	statusServer := startStatusServer(":8081")
+	statusServer := startStatusServer()
 	defer statusServer.Close()
+	log.Println("Status server at", statusServer.Addr)
 
 	http.HandleFunc("/", Status)
 	http.HandleFunc("/status", Status)

--- a/cmd/gardener/gardener_test.go
+++ b/cmd/gardener/gardener_test.go
@@ -40,11 +40,12 @@ func TestLegacyModeSetup(t *testing.T) {
 	}
 }
 
-func xTestManagerMode(t *testing.T) {
+func TestManagerMode(t *testing.T) {
 	vars := map[string]string{
 		"SERVICE_MODE":   "manager",
 		"PROJECT":        "foobar",
 		"ARCHIVE_BUCKET": "archive-mlab-testing",
+		"STATUS_PORT":    ":0",
 	}
 	for k, v := range vars {
 		cleanup := osx.MustSetenv(k, v)

--- a/cmd/gardener/gardener_test.go
+++ b/cmd/gardener/gardener_test.go
@@ -40,7 +40,7 @@ func TestLegacyModeSetup(t *testing.T) {
 	}
 }
 
-func TestManagerMode(t *testing.T) {
+func xTestManagerMode(t *testing.T) {
 	vars := map[string]string{
 		"SERVICE_MODE":   "manager",
 		"PROJECT":        "foobar",

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -62,7 +62,7 @@ func (svc *Service) JobHandler(resp http.ResponseWriter, req *http.Request) {
 	if svc.tracker != nil {
 		err := svc.tracker.AddJob(job)
 		if err != nil {
-			log.Println(err)
+			log.Println(err, job)
 			resp.WriteHeader(http.StatusInternalServerError)
 			_, err = resp.Write([]byte("Job already exists.  Try again."))
 			if err != nil {

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -22,6 +22,8 @@ type Service struct {
 	startDate time.Time // The date to restart at.
 	date      time.Time // The date currently being dispatched.
 
+	discardAge time.Duration // Time after which a stale job should be restarted.
+
 	jobTypes  []tracker.Job // The job prefixes to be iterated through.
 	nextIndex int           // index of TypeSource to dispatch next.
 }
@@ -89,5 +91,5 @@ func NewJobService(tk *tracker.Tracker, startDate time.Time) (*Service, error) {
 	}
 
 	start := startDate.UTC().Truncate(24 * time.Hour)
-	return &Service{tracker: tk, startDate: start, date: start, jobTypes: types}, nil
+	return &Service{tracker: tk, startDate: start, date: start, discardAge: discardAge, jobTypes: types}, nil
 }

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -91,5 +91,5 @@ func NewJobService(tk *tracker.Tracker, startDate time.Time) (*Service, error) {
 	}
 
 	start := startDate.UTC().Truncate(24 * time.Hour)
-	return &Service{tracker: tk, startDate: start, date: start, discardAge: discardAge, jobTypes: types}, nil
+	return &Service{tracker: tk, startDate: start, date: start, jobTypes: types}, nil
 }

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -87,7 +87,7 @@ func TestEarlyWrapping(t *testing.T) {
 	})
 	defer monkey.Unpatch(time.Now)
 	start := time.Date(2011, 2, 3, 5, 6, 7, 8, time.UTC)
-	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0) // Only using jobmap.
+	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0) // Only using jobmap.
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -52,6 +52,8 @@ spec:
           containerPort: 9090
         - name: service-port
           containerPort: 8080
+        - name: status-port  # This one will be external
+          containerPort: 8081
 
         livenessProbe:
           httpGet:

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -46,6 +46,8 @@ spec:
           value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
+        - name: STATUS_PORT
+          value: ":8081"
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -48,6 +48,8 @@ spec:
           value: "{{GCLOUD_PROJECT}}"
         - name: STATUS_PORT
           value: ":8081"
+        - name: JOB_EXPIRATION_TIME
+          value: "14400"  # Four hours.
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing/services/etl-gardener-service.yml
+++ b/k8s/data-processing/services/etl-gardener-service.yml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   name: etl-gardener-service
   namespace: default
-  annotations:
-    cloud.google.com/load-balancer-type: "Internal"
+  # annotations:
+  #  cloud.google.com/load-balancer-type: "Internal"
 spec:
   ports:
   - port: 8080

--- a/k8s/data-processing/services/etl-gardener-service.yml
+++ b/k8s/data-processing/services/etl-gardener-service.yml
@@ -17,3 +17,18 @@ spec:
   type: ClusterIP
   # type: LoadBalancer
   # loadBalancerIP: 10.100.1.2  # etl-gardener us-east1/default/default-gardener subnet - this hard codes the service address.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: etl-gardener-status
+  namespace: default
+spec:
+  ports:
+  - port: 8081
+    protocol: TCP
+    targetPort: 8081
+  selector:
+    run: etl-gardener-universal
+  sessionAffinity: None
+  type: LoadBalancer

--- a/k8s/data-processing/services/etl-gardener-service.yml
+++ b/k8s/data-processing/services/etl-gardener-service.yml
@@ -13,5 +13,7 @@ spec:
   selector:
     run: etl-gardener-universal
   sessionAffinity: None
-  type: LoadBalancer
-  loadBalancerIP: 10.100.1.2  # etl-gardener us-east1/default/default-gardener subnet - this hard codes the service address.
+  # Trying different approach, with etl in same cluster, like prometheus-service.yml
+  type: ClusterIP
+  # type: LoadBalancer
+  # loadBalancerIP: 10.100.1.2  # etl-gardener us-east1/default/default-gardener subnet - this hard codes the service address.

--- a/k8s/data-processing/services/etl-gardener-status.yml
+++ b/k8s/data-processing/services/etl-gardener-status.yml
@@ -1,16 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: etl-gardener-service
+  name: etl-gardener-status
   namespace: default
-  annotations:
-    cloud.google.com/load-balancer-type: "Internal"
 spec:
   ports:
-  - port: 8080
+  - port: 8081
     protocol: TCP
-    targetPort: 8080
+    targetPort: 8081
   selector:
     run: etl-gardener-universal
   sessionAffinity: None
-  type: ClusterIP
+  type: LoadBalancer

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -101,9 +101,9 @@ func (h *Handler) update(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusFailedDependency)
 		return
 	}
-	// detail := req.Form.Get("detail")
+	detail := req.Form.Get("detail")
 
-	if err := h.tracker.SetStatus(job, State(state)); err != nil {
+	if err := h.tracker.SetStatus(job, State(state), detail); err != nil {
 		resp.WriteHeader(http.StatusGone)
 		return
 	}
@@ -134,7 +134,7 @@ func (h *Handler) errorFunc(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	h.tracker.SetStatus(job, ParseError)
+	h.tracker.SetStatus(job, ParseError, "")
 	resp.WriteHeader(http.StatusOK)
 }
 

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -19,7 +19,7 @@ func testSetup(t *testing.T) (url.URL, *tracker.Tracker, tracker.Job) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -124,12 +124,12 @@ func TestErrorHandler(t *testing.T) {
 
 	expectGet(t, url, http.StatusMethodNotAllowed)
 
-	// Fail if job doesn't exist.
+	// Job should not yet exist.
 	expectPost(t, url, http.StatusGone)
 
 	tk.AddJob(job)
 
-	// should update state to Parsing
+	// should successfully update state to Parsing
 	expectPost(t, url, http.StatusOK)
 	stat, err := tk.GetStatus(job)
 	must(t, err)

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -297,6 +297,7 @@ func (tr *Tracker) getJSON() ([]byte, error) {
 
 // Sync snapshots the full job state and saves it to the datastore client.
 func (tr *Tracker) Sync() error {
+	log.Println("sync")
 	bytes, err := tr.getJSON()
 	if err != nil {
 		return err

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -179,11 +179,20 @@ func (jobs *JobMap) UnmarshalJSON(data []byte) error {
 
 var jobsTemplate = template.Must(template.New("").Parse(`
 	<h1>{{.Title}}</h1>
-	<table>
+	<style>
+	table, th, td {
+	  border: 2px solid black;
+	}
+	</style>
+	<table style="width:80%">
+		<tr>
+			<th> Job </th> 
+			<th> State </th>
+		</tr>
 	    {{range .Jobs}}
 		<tr>
 			<td> {{.Job}} </td> 
-			<td> {{.State}} </td>
+			<td> {{.State.}} </td>
 		</tr>
 	    {{end}}
 	</table>`))

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"sort"
 	"sync"
 	"time"
 
@@ -192,7 +193,7 @@ var jobsTemplate = template.Must(template.New("").Parse(`
 	    {{range .Jobs}}
 		<tr>
 			<td> {{.Job}} </td> 
-			<td> {{.State.}} </td>
+			<td> {{.State}} </td>
 		</tr>
 	    {{end}}
 	</table>`))
@@ -211,6 +212,10 @@ func (jobs JobMap) WriteHTML(w io.Writer) error {
 	for j := range jobs {
 		pairs = append(pairs, Pair{Job: j, State: jobs[j]})
 	}
+	sort.Slice(pairs,
+		func(i, j int) bool {
+			return pairs[i].State.UpdateTime.Before(pairs[j].State.UpdateTime)
+		})
 	jr := JobRep{Title: "Jobs", Jobs: pairs}
 
 	return jobsTemplate.Execute(w, jr)

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -274,7 +274,7 @@ func InitTracker(
 		log.Println(err, key)
 		jobMap = make(JobMap, 100)
 	}
-	t := Tracker{client: client, dsKey: key, jobs: jobMap}
+	t := Tracker{client: client, dsKey: key, jobs: jobMap, expirationTime: expirationTime}
 	if client != nil && saveInterval > 0 {
 		t.saveEvery(saveInterval)
 	}
@@ -334,6 +334,9 @@ func (tr *Tracker) GetStatus(job Job) (Status, error) {
 // AddJob adds a new job to the Tracker.
 // May return ErrJobAlreadyExists if job already exists.
 func (tr *Tracker) AddJob(job Job) error {
+	status := NewStatus()
+	status.UpdateTime = time.Now()
+
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
 	_, ok := tr.jobs[job]
@@ -343,8 +346,7 @@ func (tr *Tracker) AddJob(job Job) error {
 
 	// TODO - should call this JobsInFlight, to avoid confusion with Tasks in parser.
 	metrics.TasksInFlight.Inc()
-	state := NewStatus()
-	tr.jobs[job] = state
+	tr.jobs[job] = status
 	return nil
 }
 

--- a/tracker/tracker_integration_test.go
+++ b/tracker/tracker_integration_test.go
@@ -26,7 +26,7 @@ func TestWithDatastore(t *testing.T) {
 	// quite a while to propogate.
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")
@@ -41,7 +41,7 @@ func TestWithDatastore(t *testing.T) {
 	log.Println("Calling Sync")
 	must(t, tk.Sync())
 	// Check that the sync (and InitTracker) work.
-	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
 
 	if restore.NumJobs() != 500 {

--- a/tracker/tracker_race_test.go
+++ b/tracker/tracker_race_test.go
@@ -48,7 +48,7 @@ func TestConcurrentUpdates(t *testing.T) {
 			k := tracker.Job{"bucket", "ConcurrentUpdates", "type",
 				startDate.Add(time.Duration(24*rand.Intn(jobs)) * time.Hour)}
 			if i%5 == 0 {
-				err := tk.SetStatus(k, tracker.State(fmt.Sprintf("State:%d", i)))
+				err := tk.SetStatus(k, tracker.State(fmt.Sprintf("State:%d", i)), "")
 				if err != nil {
 					log.Fatal(err, " ", k)
 				}

--- a/tracker/tracker_race_test.go
+++ b/tracker/tracker_race_test.go
@@ -32,7 +32,7 @@ func TestConcurrentUpdates(t *testing.T) {
 
 	// For testing, push to the saver every 5 milliseconds.
 	saverInterval := 5 * time.Millisecond
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, saverInterval)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, saverInterval, 0)
 	must(t, err)
 
 	jobs := 20
@@ -71,7 +71,7 @@ func TestConcurrentUpdates(t *testing.T) {
 	// If verbose, dump the final state.
 	if testing.Verbose() {
 		must(t, tk.Sync())
-		restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+		restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 		must(t, err)
 
 		status := restore.GetAll()

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -93,7 +93,7 @@ func TestTrackerAddDelete(t *testing.T) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")
@@ -108,7 +108,7 @@ func TestTrackerAddDelete(t *testing.T) {
 	log.Println("Calling Sync")
 	must(t, tk.Sync())
 	// Check that the sync (and InitTracker) work.
-	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
 
 	if restore.NumJobs() != 500 {
@@ -132,7 +132,7 @@ func TestUpdate(t *testing.T) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
 
 	createJobs(t, tk, "JobToUpdate", "type", 1)
@@ -163,7 +163,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
 
 	job := tracker.Job{}
@@ -189,7 +189,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 }
 
 func TestJobMapHTML(t *testing.T) {
-	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0)
+	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0)
 	must(t, err)
 
 	job := tracker.Job{}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -51,7 +51,7 @@ func completeJobs(t *testing.T, tk *tracker.Tracker, exp string, typ string, n i
 	date := startDate
 	for i := 0; i < n; i++ {
 		job := tracker.Job{"bucket", exp, typ, date}
-		err := tk.SetStatus(job, tracker.Complete)
+		err := tk.SetStatus(job, tracker.Complete, "")
 
 		if err != nil {
 			t.Error(err, job)
@@ -137,8 +137,8 @@ func TestUpdate(t *testing.T) {
 	createJobs(t, tk, "JobToUpdate", "type", 1)
 
 	job := tracker.Job{"bucket", "JobToUpdate", "type", startDate}
-	must(t, tk.SetStatus(job, tracker.Parsing))
-	must(t, tk.SetStatus(job, tracker.Stabilizing))
+	must(t, tk.SetStatus(job, tracker.Parsing, ""))
+	must(t, tk.SetStatus(job, tracker.Stabilizing, ""))
 
 	status, err := tk.GetStatus(job)
 	if err != nil {
@@ -148,7 +148,7 @@ func TestUpdate(t *testing.T) {
 		t.Error("Incorrect job state", job)
 	}
 
-	err = tk.SetStatus(tracker.Job{"bucket", "JobToUpdate", "other-type", startDate}, tracker.Stabilizing)
+	err = tk.SetStatus(tracker.Job{"bucket", "JobToUpdate", "other-type", startDate}, tracker.Stabilizing, "")
 	if err != tracker.ErrJobNotFound {
 		t.Error(err, "should have been ErrJobNotFound")
 	}
@@ -166,7 +166,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 	must(t, err)
 
 	job := tracker.Job{}
-	err = tk.SetStatus(job, tracker.Parsing)
+	err = tk.SetStatus(job, tracker.Parsing, "")
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
 	}
@@ -178,10 +178,10 @@ func TestNonexistentJobAccess(t *testing.T) {
 		t.Error("Should be ErrJobAlreadyExists", err)
 	}
 
-	must(t, tk.SetStatus(js, tracker.Complete))
+	must(t, tk.SetStatus(js, tracker.Complete, ""))
 
 	// Job should be gone now.
-	err = tk.SetStatus(js, "foobar")
+	err = tk.SetStatus(js, "foobar", "")
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
 	}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -172,6 +172,11 @@ func TestNonexistentJobAccess(t *testing.T) {
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
 	}
+	err = tk.UpdateJob(job, tracker.NewStatus())
+	if err != tracker.ErrJobNotFound {
+		t.Error("Should be ErrJobNotFound", err)
+	}
+
 	js := tracker.NewJob("bucket", "exp", "type", startDate)
 	must(t, tk.AddJob(js))
 

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -1,6 +1,7 @@
 package tracker_test
 
 import (
+	"bytes"
 	"context"
 	"log"
 	"sync"
@@ -184,5 +185,24 @@ func TestNonexistentJobAccess(t *testing.T) {
 	err = tk.SetStatus(js, "foobar", "")
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
+	}
+}
+
+func TestJobMapHTML(t *testing.T) {
+	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0)
+	must(t, err)
+
+	job := tracker.Job{}
+	err = tk.SetStatus(job, tracker.Parsing, "")
+	if err != tracker.ErrJobNotFound {
+		t.Error("Should be ErrJobNotFound", err)
+	}
+	js := tracker.NewJob("bucket", "exp", "type", startDate)
+	must(t, tk.AddJob(js))
+
+	buf := bytes.Buffer{}
+
+	if err = tk.WriteHTMLStatusTo(context.Background(), &buf); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"bou.ke/monkey"
 	"cloud.google.com/go/datastore"
 	"github.com/GoogleCloudPlatform/google-cloud-go-testing/datastore/dsiface"
 	"github.com/m-lab/etl-gardener/tracker"
@@ -205,4 +206,40 @@ func TestJobMapHTML(t *testing.T) {
 	if err = tk.WriteHTMLStatusTo(context.Background(), &buf); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestExpiration(t *testing.T) {
+	// This allows us to manipulate the Since function to exercise expiration.
+	now := time.Date(2018, 2, 6, 1, 2, 3, 4, time.UTC)
+	monkey.Patch(time.Now, func() time.Time {
+		return now
+	})
+	defer monkey.Unpatch(time.Now)
+
+	client := dsfake.NewClient()
+	dsKey := datastore.NameKey("TestExpiration", "jobs", nil)
+	dsKey.Namespace = "gardener"
+	defer must(t, cleanup(client, dsKey))
+
+	// Expire jobs after 1 second of monkey time.
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 10*time.Millisecond, time.Second)
+	must(t, err)
+
+	job := tracker.NewJob("bucket", "exp", "type", startDate)
+	err = tk.SetStatus(job, tracker.Parsing, "")
+	if err != tracker.ErrJobNotFound {
+		t.Error("Should be ErrJobNotFound", err)
+	}
+	must(t, tk.AddJob(job))
+
+	err = tk.AddJob(job)
+	if err != tracker.ErrJobAlreadyExists {
+		t.Error("Should be ErrJobAlreadyExists", err)
+	}
+
+	now = now.Add(2 * time.Second)    // Jump ahead in time.
+	time.Sleep(20 * time.Millisecond) // Allow saver to run.
+
+	// Job should have been removed by saveEvery, so this should succeed.
+	must(t, tk.AddJob(job))
 }


### PR DESCRIPTION
soltesz suggested in comments on m-lab/etl#788 that if we use ClusterIP for gardener, we can then use the DNS local syntax to address gardener from ETL in the same cluster, like:
etl-gardener-service.default.svc.cluster.local

Note that PING to the hostname does not currently work, but wget does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/221)
<!-- Reviewable:end -->
