### PR TITLE
Use ClusterIP, and add public /status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,7 @@ script:
 - $HOME/gopath/bin/gocovmerge _*.cov > _merge.cov
 - $HOME/gopath/bin/goveralls -coverprofile=_merge.cov -service=travis-ci
 
-# Clean build and prepare for deployment
-- docker build .
+# Docker build is done in google cloud builer
 
 #################################################################################
 # Deployment Section
@@ -128,6 +127,16 @@ deploy:
     repo: m-lab/etl-gardener
     all_branches: true
     condition: $TRAVIS_BRANCH == sandbox-* && $TRAVIS_EVENT_TYPE == push
+
+- provider: script
+  script:
+    DATE_SKIP="2" TASK_FILE_SKIP="4"
+    $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing ./apply-cluster.sh
+  skip_cleanup: true
+  on:
+    repo: m-lab/etl-gardener
+    all_branches: true
+    condition: $TRAVIS_BRANCH == universal-sandbox-* && $TRAVIS_EVENT_TYPE == push
 
 #########################################
 ## Staging

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as builder
+FROM golang:1.13 as builder
 
 ENV CGO_ENABLED 0
 
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/m-lab/etl-gardener
 COPY . .
 
 # Get the requirements and put the produced binaries in /go/bin
-RUN go get -v -t ./...
+RUN go get -v ./...
 RUN go install \
       -v \
       -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
@@ -17,7 +17,7 @@ RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 COPY --from=builder /go/bin/gardener /bin/gardener
 
-EXPOSE 9090 8080
+EXPOSE 9090 8080 8081
 
 WORKDIR /
 ENTRYPOINT [ "/bin/gardener" ]

--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -28,5 +28,5 @@ kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
     > ${CFG}
 cat ${CFG}
 
-# This triggers deployment of the pod.
-kubectl apply -f ${CFG}
+# This triggers deployment of the pod.  --force required in short term.
+kubectl apply -f ${CFG} --force

--- a/cmd/gardener/gardener_test.go
+++ b/cmd/gardener/gardener_test.go
@@ -45,6 +45,7 @@ func TestManagerMode(t *testing.T) {
 		"SERVICE_MODE":   "manager",
 		"PROJECT":        "foobar",
 		"ARCHIVE_BUCKET": "archive-mlab-testing",
+		"STATUS_PORT":    ":0",
 	}
 	for k, v := range vars {
 		cleanup := osx.MustSetenv(k, v)

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -46,12 +46,18 @@ spec:
           value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
+        - name: STATUS_PORT
+          value: ":8081"
+        - name: JOB_EXPIRATION_TIME
+          value: "14400"  # Four hours.
 
         ports:
         - name: prometheus-port
           containerPort: 9090
         - name: service-port
           containerPort: 8080
+        - name: status-port  # This one will be external
+          containerPort: 8081
 
         livenessProbe:
           httpGet:

--- a/k8s/data-processing/services/etl-gardener-status.yml
+++ b/k8s/data-processing/services/etl-gardener-status.yml
@@ -1,16 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: etl-gardener-service
+  name: etl-gardener-status
   namespace: default
-  annotations:
-    cloud.google.com/load-balancer-type: "Internal"
 spec:
   ports:
-  - port: 8080
+  - port: 8081
     protocol: TCP
-    targetPort: 8080
+    targetPort: 8081
   selector:
     run: etl-gardener-universal
   sessionAffinity: None
-  type: ClusterIP
+  type: LoadBalancer


### PR DESCRIPTION
soltesz suggested in comments on m-lab/etl#788 that if we use ClusterIP for gardener, we can then use the DNS local syntax to address gardener from ETL in the same cluster, like:
etl-gardener-service.default.svc.cluster.local

This implements that change, and also adds a public /status service.  It also adds a Jobs section to the status page.

Note that PING (from ETL instances) to the local hostname does not work (which confused me for a while), but wget works fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/222)
<!-- Reviewable:end -->
