### PR TITLE
implement expiration time, improve handlers

### DIFF
--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -28,5 +28,5 @@ kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
     > ${CFG}
 cat ${CFG}
 
-# This triggers deployment of the pod.  --force required in short term.
-kubectl apply -f ${CFG} --force
+# This triggers deployment of the pod.
+kubectl apply -f ${CFG}

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -39,9 +39,9 @@ import (
 )
 
 var (
-	jobExpirationTime = flag.Duration("jobexpirationtime", 4*time.Hour, "Time after which stale jobs will be purged")
-	shutdownTimeout   = flag.Duration("shutdowntimeout", 1*time.Minute, "Graceful shutdown time allowance")
-	statusPort        = flag.String("statusport", ":0", "The public interface port where status (and pprof) will be published")
+	jobExpirationTime = flag.Duration("JOB_EXPIRATION_TIME", 4*time.Hour, "Time after which stale jobs will be purged")
+	shutdownTimeout   = flag.Duration("SHUTDOWN_TIMEOUT", 1*time.Minute, "Graceful shutdown time allowance")
+	statusPort        = flag.String("STATUS_PORT", ":0", "The public interface port where status (and pprof) will be published")
 
 	// Context and injected variables to allow smoke testing of main()
 	mainCtx, mainCancel = context.WithCancel(context.Background())

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -255,6 +255,7 @@ func Status(w http.ResponseWriter, r *http.Request) {
 }
 
 func startStatusServer() *http.Server {
+	// TODO make this a flag before submitting.
 	statusPort := os.Getenv("STATUS_PORT")
 	if len(statusPort) == 0 {
 		statusPort = ":0"
@@ -292,7 +293,19 @@ func mustStandardTracker() *tracker.Tracker {
 	dsKey := datastore.NameKey("tracker", "jobs", nil)
 	dsKey.Namespace = "gardener"
 
-	tk, err := tracker.InitTracker(context.Background(), dsiface.AdaptClient(client), dsKey, 0)
+	// TODO - make this a flag before submitting!!!
+	expString, ok := os.LookupEnv("JOB_EXPIRATION_TIME")
+	exp := 0
+	if ok {
+		var err error
+		exp, err = strconv.Atoi(expString)
+		rtx.Must(err, "Invalid expiration time:", expString)
+	}
+
+	tk, err := tracker.InitTracker(
+		context.Background(),
+		dsiface.AdaptClient(client), dsKey,
+		time.Minute, time.Duration(exp)*time.Second)
 	rtx.Must(err, "tracker init")
 	if tk == nil {
 		log.Fatal("nil tracker")

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -39,9 +39,9 @@ import (
 )
 
 var (
-	jobExpirationTime = flag.Duration("JOB_EXPIRATION_TIME", 4*time.Hour, "Time after which stale jobs will be purged")
-	shutdownTimeout   = flag.Duration("SHUTDOWN_TIMEOUT", 1*time.Minute, "Graceful shutdown time allowance")
-	statusPort        = flag.String("STATUS_PORT", ":0", "The public interface port where status (and pprof) will be published")
+	jobExpirationTime = flag.Duration("job_expiration_time", 4*time.Hour, "Time after which stale jobs will be purged")
+	shutdownTimeout   = flag.Duration("shutdown_timeout", 1*time.Minute, "Graceful shutdown time allowance")
+	statusPort        = flag.String("status_port", ":0", "The public interface port where status (and pprof) will be published")
 
 	// Context and injected variables to allow smoke testing of main()
 	mainCtx, mainCancel = context.WithCancel(context.Background())
@@ -265,8 +265,6 @@ func Status(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "</body></html>\n")
 }
 
-var statusServerPort string
-
 func startStatusServer() *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", Status)
@@ -279,7 +277,7 @@ func startStatusServer() *http.Server {
 	}
 	rtx.Must(httpx.ListenAndServeAsync(server), "Could not start status server")
 
-	statusServerPort = strings.Split(server.Addr, "]")[1]
+	log.Println("Status server at:", server.Addr)
 	return server
 }
 

--- a/cmd/gardener/gardener_test.go
+++ b/cmd/gardener/gardener_test.go
@@ -96,12 +96,8 @@ func TestManagerMode(t *testing.T) {
 		resp.Body.Close()
 		log.Println("ok")
 
-		parts := strings.Split(statusServerAddr, "]")
-		port := parts[len(parts)-1]
-		log.Println(port)
-
 		// Now get the status
-		resp, err = waitFor("http://localhost" + port)
+		resp, err = waitFor("http://" + statusServerAddr)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/gardener/gardener_test.go
+++ b/cmd/gardener/gardener_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"context"
 	_ "expvar"
 	"io/ioutil"
 	"log"
@@ -21,10 +22,12 @@ import (
 // Would have to use :0 for all servers to allow count > 1
 
 func TestLegacyModeSetup(t *testing.T) {
+	mainCtx, mainCancel = context.WithCancel(context.Background())
+
 	vars := map[string]string{
 		"PROJECT":         "mlab-testing",
 		"QUEUE_BASE":      "fake-queue-",
-		"NUM_QUEUES":      "123",
+		"NUM_QUEUES":      "3",
 		"EXPERIMENT":      "ndt",
 		"TASKFILE_BUCKET": "archive-mlab-testing",
 		"START_DATE":      "20090220",
@@ -48,18 +51,20 @@ func TestLegacyModeSetup(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer resp.Body.Close()
 		// For now, the service comes up immediately serving "ok" for /ready
 		data, err := ioutil.ReadAll(resp.Body)
 		if string(data) != "ok" {
 			t.Fatal(string(data))
 		}
+		resp.Body.Close()
 	}()
 
 	main()
 }
 
 func TestManagerMode(t *testing.T) {
+	mainCtx, mainCancel = context.WithCancel(context.Background())
+
 	vars := map[string]string{
 		"SERVICE_MODE":   "manager",
 		"PROJECT":        "mlab-testing",

--- a/cmd/gardener/gardener_test.go
+++ b/cmd/gardener/gardener_test.go
@@ -17,6 +17,9 @@ import (
 	"github.com/m-lab/go/osx"
 )
 
+// TODO - these tests currently fail with count=10
+// Would have to use :0 for all servers to allow count > 1
+
 func TestLegacyModeSetup(t *testing.T) {
 	vars := map[string]string{
 		"PROJECT":         "mlab-testing",
@@ -59,7 +62,7 @@ func TestLegacyModeSetup(t *testing.T) {
 func TestManagerMode(t *testing.T) {
 	vars := map[string]string{
 		"SERVICE_MODE":   "manager",
-		"PROJECT":        "foobar",
+		"PROJECT":        "mlab-testing",
 		"ARCHIVE_BUCKET": "archive-mlab-testing",
 		"STATUS_PORT":    ":0",
 	}
@@ -82,12 +85,28 @@ func TestManagerMode(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer resp.Body.Close()
 		// For now, the service comes up immediately serving "ok" for /ready
 		data, err := ioutil.ReadAll(resp.Body)
 		if string(data) != "ok" {
 			t.Fatal(string(data))
 		}
+		resp.Body.Close()
+
+		// Now get the status
+		for i := 0; i < 1000; i++ {
+			time.Sleep(10 * time.Millisecond)
+			resp, err = http.Get("http://localhost:8080")
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		data, err = ioutil.ReadAll(resp.Body)
+		log.Print(string(data))
+		resp.Body.Close()
 	}()
 
 	main()

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -60,7 +60,7 @@ func (svc *Service) JobHandler(resp http.ResponseWriter, req *http.Request) {
 	if svc.tracker != nil {
 		err := svc.tracker.AddJob(job)
 		if err != nil {
-			log.Println(err)
+			log.Println(err, job)
 			resp.WriteHeader(http.StatusInternalServerError)
 			_, err = resp.Write([]byte("Job already exists.  Try again."))
 			if err != nil {

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -87,7 +87,7 @@ func TestEarlyWrapping(t *testing.T) {
 	})
 	defer monkey.Unpatch(time.Now)
 	start := time.Date(2011, 2, 3, 5, 6, 7, 8, time.UTC)
-	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0) // Only using jobmap.
+	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0) // Only using jobmap.
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -49,7 +49,9 @@ spec:
         - name: STATUS_PORT
           value: ":8081"
         - name: JOB_EXPIRATION_TIME
-          value: "14400"  # Four hours.
+          value: "4h"
+        - name: SHUTDOWN_TIMEOUT
+          value: "1m"
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -49,9 +49,9 @@ spec:
         - name: STATUS_PORT
           value: ":8081"
         - name: JOB_EXPIRATION_TIME
-          value: "4h"
+          value: "3h"
         - name: SHUTDOWN_TIMEOUT
-          value: "1m"
+          value: "5m"
 
         ports:
         - name: prometheus-port

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -23,7 +23,7 @@ func init() {
 func newStateFunc(state tracker.State) ops.ActionFunc {
 	return func(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker.Status) {
 		log.Println(j, state)
-		err := tk.SetStatus(j, state)
+		err := tk.SetStatus(j, state, "")
 		if err != nil {
 			log.Println(err)
 		}
@@ -34,7 +34,7 @@ func TestMonitor_Watch(t *testing.T) {
 	logx.LogxDebug.Set("true")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	tk, err := tracker.InitTracker(ctx, nil, nil, 0)
+	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0)
 	rtx.Must(err, "tk init")
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
 	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -101,9 +101,9 @@ func (h *Handler) update(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusFailedDependency)
 		return
 	}
-	// detail := req.Form.Get("detail")
+	detail := req.Form.Get("detail")
 
-	if err := h.tracker.SetStatus(job, State(state)); err != nil {
+	if err := h.tracker.SetStatus(job, State(state), detail); err != nil {
 		resp.WriteHeader(http.StatusGone)
 		return
 	}
@@ -134,7 +134,7 @@ func (h *Handler) errorFunc(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	h.tracker.SetStatus(job, ParseError)
+	h.tracker.SetStatus(job, ParseError, "")
 	resp.WriteHeader(http.StatusOK)
 }
 

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -19,7 +19,7 @@ func testSetup(t *testing.T) (url.URL, *tracker.Tracker, tracker.Job) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")
@@ -124,12 +124,12 @@ func TestErrorHandler(t *testing.T) {
 
 	expectGet(t, url, http.StatusMethodNotAllowed)
 
-	// Fail if job doesn't exist.
+	// Job should not yet exist.
 	expectPost(t, url, http.StatusGone)
 
 	tk.AddJob(job)
 
-	// should update state to Parsing
+	// should successfully update state to Parsing
 	expectPost(t, url, http.StatusOK)
 	stat, err := tk.GetStatus(job)
 	must(t, err)

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -298,7 +298,6 @@ func (tr *Tracker) getJSON() ([]byte, error) {
 
 // Sync snapshots the full job state and saves it to the datastore client.
 func (tr *Tracker) Sync() error {
-	log.Println("sync")
 	bytes, err := tr.getJSON()
 	if err != nil {
 		return err

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -199,7 +199,10 @@ var jobsTemplate = template.Must(template.New("").Parse(`
 		<tr>
 			<td> {{.Job}} </td>
 			<td> {{.Status.UpdateTime.Format "01/02~15:04:05"}} </td>
-			<td> {{.Status.State}} </td>
+			<td {{ if or (eq .Status.State "init") (eq .Status.State "postProcessing")}}
+					style="color: red;"
+					{{ else }}{{ end }}>
+			  {{.Status.State}} </td>
 			<td> {{.Status.UpdateDetail}} </td>
 			<td> {{.Status.LastError}} </td>
 		</tr>
@@ -226,7 +229,11 @@ func (jobs JobMap) WriteHTML(w io.Writer) error {
 		})
 	jr := JobRep{Title: "Jobs", Jobs: pairs}
 
-	return jobsTemplate.Execute(w, jr)
+	err := jobsTemplate.Execute(w, jr)
+	if err != nil {
+		log.Println(err)
+	}
+	return err
 }
 
 // saverStruct is used only for saving and loading from datastore.

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -180,14 +180,15 @@ func (jobs *JobMap) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-var jobsTemplate = template.Must(template.New("").Parse(`
+var jobsTemplate = template.Must(template.New("").Parse(
+	fmt.Sprintf(`
 	<h1>{{.Title}}</h1>
 	<style>
 	table, th, td {
 	  border: 2px solid black;
 	}
 	</style>
-	<table style="width:80%">
+	<table style="width:80%%">
 		<tr>
 			<th> Job </th>
 			<th> UpdateTime </th>
@@ -199,7 +200,7 @@ var jobsTemplate = template.Must(template.New("").Parse(`
 		<tr>
 			<td> {{.Job}} </td>
 			<td> {{.Status.UpdateTime.Format "01/02~15:04:05"}} </td>
-			<td {{ if or (eq .Status.State "init") (eq .Status.State "postProcessing")}}
+			<td {{ if or (eq .Status.State "%s") (eq .Status.State "%s")}}
 					style="color: red;"
 					{{ else }}{{ end }}>
 			  {{.Status.State}} </td>
@@ -207,7 +208,7 @@ var jobsTemplate = template.Must(template.New("").Parse(`
 			<td> {{.Status.LastError}} </td>
 		</tr>
 	    {{end}}
-	</table>`))
+	</table>`, Init, ParseComplete)))
 
 // WriteHTML writes a table containing the jobs and status.
 func (jobs JobMap) WriteHTML(w io.Writer) error {

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -116,10 +116,11 @@ type Status struct {
 
 func (s Status) String() string {
 	if len(s.LastError) > 0 {
-		return fmt.Sprintf("%s %s %s (%s)",
+		return fmt.Sprintf("%s %s (%s) %s",
 			s.UpdateTime.Format("01/02~15:04:05"),
-			s.State, s.LastError,
-			s.UpdateDetail)
+			s.State,
+			s.UpdateDetail,
+			s.LastError)
 	}
 	return fmt.Sprintf("%s %s (%s)",
 		s.UpdateTime.Format("01/02~15:04:05"),

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -190,12 +190,18 @@ var jobsTemplate = template.Must(template.New("").Parse(`
 	<table style="width:80%">
 		<tr>
 			<th> Job </th>
+			<th> UpdateTime </th>
 			<th> State </th>
+			<th> UpdateDetail </th>
+			<th> LastError </th>
 		</tr>
 	    {{range .Jobs}}
 		<tr>
 			<td> {{.Job}} </td>
-			<td> {{.State}} </td>
+			<td> {{.Status.UpdateTime.Format "01/02~15:04:05"}} </td>
+			<td> {{.Status.State}} </td>
+			<td> {{.Status.UpdateDetail}} </td>
+			<td> {{.Status.LastError}} </td>
 		</tr>
 	    {{end}}
 	</table>`))
@@ -203,8 +209,8 @@ var jobsTemplate = template.Must(template.New("").Parse(`
 // WriteHTML writes a table containing the jobs and status.
 func (jobs JobMap) WriteHTML(w io.Writer) error {
 	type Pair struct {
-		Job   Job
-		State Status
+		Job    Job
+		Status Status
 	}
 	type JobRep struct {
 		Title string
@@ -212,11 +218,11 @@ func (jobs JobMap) WriteHTML(w io.Writer) error {
 	}
 	pairs := make([]Pair, 0, len(jobs))
 	for j := range jobs {
-		pairs = append(pairs, Pair{Job: j, State: jobs[j]})
+		pairs = append(pairs, Pair{Job: j, Status: jobs[j]})
 	}
 	sort.Slice(pairs,
 		func(i, j int) bool {
-			return pairs[i].State.UpdateTime.Before(pairs[j].State.UpdateTime)
+			return pairs[i].Status.UpdateTime.Before(pairs[j].Status.UpdateTime)
 		})
 	jr := JobRep{Title: "Jobs", Jobs: pairs}
 

--- a/tracker/tracker_integration_test.go
+++ b/tracker/tracker_integration_test.go
@@ -26,7 +26,7 @@ func TestWithDatastore(t *testing.T) {
 	// quite a while to propogate.
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")
@@ -41,7 +41,7 @@ func TestWithDatastore(t *testing.T) {
 	log.Println("Calling Sync")
 	must(t, tk.Sync())
 	// Check that the sync (and InitTracker) work.
-	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
 
 	if restore.NumJobs() != 500 {

--- a/tracker/tracker_race_test.go
+++ b/tracker/tracker_race_test.go
@@ -32,7 +32,7 @@ func TestConcurrentUpdates(t *testing.T) {
 
 	// For testing, push to the saver every 5 milliseconds.
 	saverInterval := 5 * time.Millisecond
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, saverInterval)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, saverInterval, 0)
 	must(t, err)
 
 	jobs := 20
@@ -48,7 +48,7 @@ func TestConcurrentUpdates(t *testing.T) {
 			k := tracker.Job{"bucket", "ConcurrentUpdates", "type",
 				startDate.Add(time.Duration(24*rand.Intn(jobs)) * time.Hour)}
 			if i%5 == 0 {
-				err := tk.SetStatus(k, tracker.State(fmt.Sprintf("State:%d", i)))
+				err := tk.SetStatus(k, tracker.State(fmt.Sprintf("State:%d", i)), "")
 				if err != nil {
 					log.Fatal(err, " ", k)
 				}
@@ -71,7 +71,7 @@ func TestConcurrentUpdates(t *testing.T) {
 	// If verbose, dump the final state.
 	if testing.Verbose() {
 		must(t, tk.Sync())
-		restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0)
+		restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 		must(t, err)
 
 		status := restore.GetAll()


### PR DESCRIPTION
This implements a stale job expiration, and adds various improvements to handlers and status page formatting.

Also will convert from env vars to flags, though that is not yet implemented.

Also removes the --force flag from the apply, which is no longer required (for NodePort cleanup).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/223)
<!-- Reviewable:end -->
