### PR TITLE
U sandbox destination field

### DIFF
--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -87,8 +87,9 @@ func (svc *Service) JobHandler(resp http.ResponseWriter, req *http.Request) {
 
 // NewJobService creates the default job service.
 func NewJobService(tk *tracker.Tracker, bucket string, startDate time.Time) (*Service, error) {
+	// TODO construct the jobs from storage bucket.
+	// TODO add bigquery destination table, based on project and data type.
 	types := []tracker.Job{
-		// Hack for sandbox only.
 		tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "ndt5"},
 		tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "tcpinfo"},
 	}

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -182,7 +182,7 @@ func TestJobClient(t *testing.T) {
 
 	// set up a fake gardener service.
 	fg := fakeGardener{t: t, jobs: make([]tracker.Job, 0)}
-	fg.AddJob(tracker.NewJob("foobar", "ndt", "ndt5", time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC), ""))
+	fg.AddJob(tracker.NewJobWithDestination("foobar", "ndt", "ndt5", time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC), ""))
 	gardener := httptest.NewServer(&fg)
 	defer gardener.Close()
 	gURL, err := url.Parse(gardener.URL)

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -182,7 +182,7 @@ func TestJobClient(t *testing.T) {
 
 	// set up a fake gardener service.
 	fg := fakeGardener{t: t, jobs: make([]tracker.Job, 0)}
-	fg.AddJob(tracker.NewJob("foobar", "ndt", "ndt5", time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC)))
+	fg.AddJob(tracker.NewJob("foobar", "ndt", "ndt5", time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC), ""))
 	gardener := httptest.NewServer(&fg)
 	defer gardener.Close()
 	gURL, err := url.Parse(gardener.URL)

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -33,7 +33,7 @@ func TestTableUtils(t *testing.T) {
 	bqClient := bqiface.AdaptClient(c)
 	ds := dataset.Dataset{Dataset: bqClient.Dataset(bqConfig.BQBatchDataset), BqClient: bqClient}
 
-	j := tracker.NewJob("bucket", "exp", "type", time.Date(2019, 12, 1, 0, 0, 0, 0, time.UTC), "")
+	j := tracker.NewJobWithDestination("bucket", "exp", "type", time.Date(2019, 12, 1, 0, 0, 0, 0, time.UTC), "")
 	src := ops.TemplateTable(j, &ds)
 	dest := ops.PartitionedTable(j, &ds)
 
@@ -52,9 +52,9 @@ func TestStandardMonitor(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0)
 	rtx.Must(err, "tk init")
-	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now(), ""))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now(), ""))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now(), ""))
+	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp", "type", time.Now(), ""))
+	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp2", "type", time.Now(), ""))
+	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp2", "type2", time.Now(), ""))
 
 	m, err := ops.NewStandardMonitor(context.Background(), cloud.BQConfig{}, tk)
 	rtx.Must(err, "NewMonitor failure")

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -33,7 +33,7 @@ func TestTableUtils(t *testing.T) {
 	bqClient := bqiface.AdaptClient(c)
 	ds := dataset.Dataset{Dataset: bqClient.Dataset(bqConfig.BQBatchDataset), BqClient: bqClient}
 
-	j := tracker.NewJob("bucket", "exp", "type", time.Date(2019, 12, 1, 0, 0, 0, 0, time.UTC))
+	j := tracker.NewJob("bucket", "exp", "type", time.Date(2019, 12, 1, 0, 0, 0, 0, time.UTC), "")
 	src := ops.TemplateTable(j, &ds)
 	dest := ops.PartitionedTable(j, &ds)
 
@@ -52,9 +52,9 @@ func TestStandardMonitor(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0)
 	rtx.Must(err, "tk init")
-	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now()))
+	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now(), ""))
+	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now(), ""))
+	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now(), ""))
 
 	m, err := ops.NewStandardMonitor(context.Background(), cloud.BQConfig{}, tk)
 	rtx.Must(err, "NewMonitor failure")

--- a/ops/ops.go
+++ b/ops/ops.go
@@ -164,7 +164,7 @@ func (m *Monitor) Watch(ctx context.Context, period time.Duration) {
 		case <-ticker.C:
 			debug.Println("===== Monitor Loop Starting =====")
 			// These jobs may be deleted by other calls to GetAll, so tk.UpdateJob may fail.
-			jobs := m.tk.GetAll()
+			jobs, _, _ := m.tk.GetState()
 			// Iterate over the job/status map...
 			for j, s := range jobs {
 				// If job is in a state that has an associated action...

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -36,9 +36,9 @@ func TestMonitor_Watch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0)
 	rtx.Must(err, "tk init")
-	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now(), ""))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now(), ""))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now(), ""))
+	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp", "type", time.Now(), ""))
+	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp2", "type", time.Now(), ""))
+	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp2", "type2", time.Now(), ""))
 
 	m, err := ops.NewMonitor(context.Background(), cloud.BQConfig{}, tk)
 	rtx.Must(err, "NewMonitor failure")

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -36,9 +36,9 @@ func TestMonitor_Watch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0)
 	rtx.Must(err, "tk init")
-	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now()))
+	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now(), ""))
+	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now(), ""))
+	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now(), ""))
 
 	m, err := ops.NewMonitor(context.Background(), cloud.BQConfig{}, tk)
 	rtx.Must(err, "NewMonitor failure")

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -26,7 +26,7 @@ func testSetup(t *testing.T) (url.URL, *tracker.Tracker, tracker.Job) {
 	}
 
 	date := time.Date(2019, 01, 02, 0, 0, 0, 0, time.UTC)
-	job := tracker.NewJob("bucket", "exp", "type", date)
+	job := tracker.NewJob("bucket", "exp", "type", date, "project.dataset.table")
 	mux := http.NewServeMux()
 	h := tracker.NewHandler(tk)
 	h.Register(mux)

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -26,7 +26,7 @@ func testSetup(t *testing.T) (url.URL, *tracker.Tracker, tracker.Job) {
 	}
 
 	date := time.Date(2019, 01, 02, 0, 0, 0, 0, time.UTC)
-	job := tracker.NewJob("bucket", "exp", "type", date, "project.dataset.table")
+	job := tracker.NewJobWithDestination("bucket", "exp", "type", date, "project.dataset.table")
 	mux := http.NewServeMux()
 	h := tracker.NewHandler(tk)
 	h.Register(mux)

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -43,8 +43,19 @@ type Job struct {
 }
 
 // NewJob creates a new job object.
+// DEPRECATED
 // NB:  The date will be converted to UTC and truncated to day boundary!
-func NewJob(bucket, exp, typ string, date time.Time, table string) Job {
+func NewJob(bucket, exp, typ string, date time.Time) Job {
+	return Job{Bucket: bucket,
+		Experiment: exp,
+		Datatype:   typ,
+		Date:       date.UTC().Truncate(24 * time.Hour),
+	}
+}
+
+// NewJobWithDestination creates a new job object.
+// NB:  The date will be converted to UTC and truncated to day boundary!
+func NewJobWithDestination(bucket, exp, typ string, date time.Time, table string) Job {
 	return Job{Bucket: bucket,
 		Experiment:       exp,
 		Datatype:         typ,

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -36,6 +36,9 @@ type Job struct {
 	Experiment string
 	Datatype   string
 	Date       time.Time
+
+	// BigQuery destination table
+	DestinationTable string `json:",omitempty"`
 }
 
 // NewJob creates a new job object.

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -27,6 +27,7 @@ import (
 	"github.com/googleapis/google-cloud-go-testing/datastore/dsiface"
 
 	"github.com/m-lab/etl-gardener/metrics"
+	"github.com/m-lab/go/logx"
 )
 
 // Job describes a reprocessing "Job", which includes
@@ -43,11 +44,13 @@ type Job struct {
 
 // NewJob creates a new job object.
 // NB:  The date will be converted to UTC and truncated to day boundary!
-func NewJob(bucket, exp, typ string, date time.Time) Job {
+func NewJob(bucket, exp, typ string, date time.Time, table string) Job {
 	return Job{Bucket: bucket,
-		Experiment: exp,
-		Datatype:   typ,
-		Date:       date.UTC().Truncate(24 * time.Hour)}
+		Experiment:       exp,
+		Datatype:         typ,
+		Date:             date.UTC().Truncate(24 * time.Hour),
+		DestinationTable: table,
+	}
 }
 
 // Path returns the GCS path prefix to the job data.
@@ -78,6 +81,7 @@ var (
 	ErrJobIsObsolete          = errors.New("job is obsolete")
 	ErrInvalidStateTransition = errors.New("invalid state transition")
 	ErrNotYetImplemented      = errors.New("not yet implemented")
+	ErrNoChange               = errors.New("no change since last save")
 )
 
 // State types are used for the Status.State values
@@ -259,27 +263,35 @@ func (jobs JobMap) WriteHTML(w io.Writer) error {
 // saverStruct is used only for saving and loading from datastore.
 type saverStruct struct {
 	SaveTime time.Time
-	Jobs     []byte `datastore:",noindex"`
+	LastInit Job
+	// Jobs is encoded as json, because datastore doesn't handle maps.
+	Jobs []byte `datastore:",noindex"`
+}
+
+func loadFromDatastore(ctx context.Context, client dsiface.Client, key *datastore.Key) (saverStruct, error) {
+	state := saverStruct{Jobs: make([]byte, 0, 100000)}
+	if client == nil {
+		return state, ErrClientIsNil
+	}
+
+	err := client.Get(ctx, key, &state) // This should error?
+	return state, err
 }
 
 // loadJobMap loads the persisted map of jobs in flight.
-func loadJobMap(ctx context.Context, client dsiface.Client, key *datastore.Key) (JobMap, error) {
-	if client == nil {
-		return nil, ErrClientIsNil
-	}
-	state := saverStruct{time.Time{}, make([]byte, 0, 100000)}
-
-	err := client.Get(ctx, key, &state) // This should error?
+func loadJobMap(ctx context.Context, client dsiface.Client, key *datastore.Key) (JobMap, Job, error) {
+	state, err := loadFromDatastore(ctx, client, key)
 	if err != nil {
-		return nil, err
+		return nil, Job{}, err
 	}
+
 	jobMap := make(JobMap, 100)
 	log.Println("Unmarshalling", len(state.Jobs))
 	err = json.Unmarshal(state.Jobs, &jobMap)
 	if err != nil {
-		return nil, err
+		return nil, Job{}, err
 	}
-	return jobMap, nil
+	return jobMap, state.LastInit, nil
 }
 
 // Tracker keeps track of all the jobs in flight.
@@ -290,8 +302,12 @@ type Tracker struct {
 	ticker *time.Ticker
 
 	// The lock should be held whenever accessing the jobs JobMap
-	lock sync.Mutex
-	jobs JobMap // Map from Job to Status.
+	lock         sync.Mutex
+	lastModified time.Time
+
+	// These are the stored values.
+	lastInit Job    // The last job that was initialized.
+	jobs     JobMap // Map from Job to Status.
 
 	// Time after which stale job should be ignored or replaced.
 	expirationTime time.Duration
@@ -304,12 +320,12 @@ func InitTracker(
 	client dsiface.Client, key *datastore.Key,
 	saveInterval time.Duration, expirationTime time.Duration) (*Tracker, error) {
 
-	jobMap, err := loadJobMap(ctx, client, key)
+	jobMap, lastInit, err := loadJobMap(ctx, client, key)
 	if err != nil {
 		log.Println(err, key)
 		jobMap = make(JobMap, 100)
 	}
-	t := Tracker{client: client, dsKey: key, jobs: jobMap, expirationTime: expirationTime}
+	t := Tracker{client: client, dsKey: key, lastModified: time.Now(), lastInit: lastInit, jobs: jobMap, expirationTime: expirationTime}
 	if client != nil && saveInterval > 0 {
 		t.saveEvery(saveInterval)
 	}
@@ -326,7 +342,7 @@ func (tr *Tracker) NumJobs() int {
 
 // NumFailed returns the number of failed jobs.
 func (tr *Tracker) NumFailed() int {
-	jobs := tr.GetAll()
+	jobs, _, _ := tr.GetState()
 	counts := make(map[State]int, 20)
 
 	for _, s := range jobs {
@@ -335,33 +351,43 @@ func (tr *Tracker) NumFailed() int {
 	return counts[Failed]
 }
 
-// getJSON creates a json encoding of the job map.
-func (tr *Tracker) getJSON() ([]byte, error) {
-	jobs := tr.GetAll()
-	return json.Marshal(jobs)
-}
-
-// Sync snapshots the full job state and saves it to the datastore client.
-func (tr *Tracker) Sync() error {
-	bytes, err := tr.getJSON()
+// Sync snapshots the full job state and saves it to the datastore client IFF it has changed.
+// Returns time last saved, which may or may not be updated.
+func (tr *Tracker) Sync(lastSave time.Time) (time.Time, error) {
+	jobs, lastInit, lastMod := tr.GetState()
+	jsonJobs, err := jobs.MarshalJSON()
 	if err != nil {
-		return err
+		return lastSave, err
+	}
+
+	if lastMod.Before(lastSave) {
+		logx.Debug.Println("Skipping save", lastMod, lastSave)
+		return lastSave, nil
 	}
 
 	// Save the full state.
-	state := saverStruct{time.Now(), bytes}
+	lastTry := time.Now()
+	state := saverStruct{time.Now(), lastInit, jsonJobs}
 	ctx, cf := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cf()
 	_, err = tr.client.Put(ctx, tr.dsKey, &state)
 
-	return err
+	if err != nil {
+		return lastSave, err
+	}
+	return lastTry, nil
 }
 
 func (tr *Tracker) saveEvery(interval time.Duration) {
 	tr.ticker = time.NewTicker(interval)
 	go func() {
+		lastSave := time.Time{}
 		for range tr.ticker.C {
-			tr.Sync()
+			var err error
+			lastSave, err = tr.Sync(lastSave)
+			if err != nil {
+				log.Println(err)
+			}
 		}
 	}()
 }
@@ -390,6 +416,8 @@ func (tr *Tracker) AddJob(job Job) error {
 		return ErrJobAlreadyExists
 	}
 
+	tr.lastInit = job
+	tr.lastModified = time.Now()
 	// TODO - should call this JobsInFlight, to avoid confusion with Tasks in parser.
 	metrics.TasksInFlight.Inc()
 	tr.jobs[job] = status
@@ -406,6 +434,7 @@ func (tr *Tracker) UpdateJob(job Job, state Status) error {
 		return ErrJobNotFound
 	}
 
+	tr.lastModified = time.Now()
 	if state.isDone() {
 		delete(tr.jobs, job)
 		metrics.TasksInFlight.Dec()
@@ -454,9 +483,9 @@ func (tr *Tracker) SetJobError(job Job, errString string) error {
 	return tr.UpdateJob(job, status)
 }
 
-// GetAll returns the full job map.
+// GetState returns the full job map, last initialized Job, and last mod time.
 // It also cleans up any expired jobs from the tracker.
-func (tr *Tracker) GetAll() JobMap {
+func (tr *Tracker) GetState() (JobMap, Job, time.Time) {
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
 	m := make(JobMap, len(tr.jobs))
@@ -465,19 +494,21 @@ func (tr *Tracker) GetAll() JobMap {
 			// Remove any obsolete jobs.
 			metrics.TasksInFlight.Dec()
 			log.Println("Deleting stale job", k)
+			tr.lastModified = time.Now()
 			delete(tr.jobs, k)
 		} else {
 			m[k] = v
 		}
 	}
-	return m
+	return m, tr.lastInit, tr.lastModified
 }
 
 // WriteHTMLStatusTo writes out the status of all jobs to the html writer.
 func (tr *Tracker) WriteHTMLStatusTo(ctx context.Context, w io.Writer) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	jobs := tr.GetAll()
+	// TODO - add the lastInit job.
+	jobs, _, _ := tr.GetState()
 
 	fmt.Fprint(w, "<div>Tracker State</div>\n")
 

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -280,7 +280,7 @@ type saverStruct struct {
 }
 
 func loadFromDatastore(ctx context.Context, client dsiface.Client, key *datastore.Key) (saverStruct, error) {
-	state := saverStruct{Jobs: make([]byte, 0, 100000)}
+	state := saverStruct{Jobs: make([]byte, 0)}
 	if client == nil {
 		return state, ErrClientIsNil
 	}
@@ -366,14 +366,14 @@ func (tr *Tracker) NumFailed() int {
 // Returns time last saved, which may or may not be updated.
 func (tr *Tracker) Sync(lastSave time.Time) (time.Time, error) {
 	jobs, lastInit, lastMod := tr.GetState()
-	jsonJobs, err := jobs.MarshalJSON()
-	if err != nil {
-		return lastSave, err
-	}
-
 	if lastMod.Before(lastSave) {
 		logx.Debug.Println("Skipping save", lastMod, lastSave)
 		return lastSave, nil
+	}
+
+	jsonJobs, err := jobs.MarshalJSON()
+	if err != nil {
+		return lastSave, err
 	}
 
 	// Save the full state.

--- a/tracker/tracker_integration_test.go
+++ b/tracker/tracker_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"log"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/datastore"
 	"github.com/googleapis/google-cloud-go-testing/datastore/dsiface"
@@ -39,7 +40,8 @@ func TestWithDatastore(t *testing.T) {
 	}
 
 	log.Println("Calling Sync")
-	must(t, tk.Sync())
+	_, err = tk.Sync(time.Time{})
+	must(t, err)
 	// Check that the sync (and InitTracker) work.
 	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
@@ -50,7 +52,8 @@ func TestWithDatastore(t *testing.T) {
 
 	completeJobs(t, tk, "500Jobs", "type", numJobs)
 
-	must(t, tk.Sync())
+	_, err = tk.Sync(time.Time{})
+	must(t, err)
 
 	if tk.NumJobs() != 0 {
 		t.Error("Job cleanup failed", tk.NumJobs())

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -38,7 +38,7 @@ func createJobs(t *testing.T, tk *tracker.Tracker, exp string, typ string, n int
 	date := startDate
 	for i := 0; i < n; i++ {
 		go func(date time.Time) {
-			job := tracker.NewJob("bucket", exp, typ, date, "project.dataset.table")
+			job := tracker.NewJobWithDestination("bucket", exp, typ, date, "project.dataset.table")
 			err := tk.AddJob(job)
 			if err != nil {
 				t.Error(err)
@@ -199,7 +199,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 		t.Error("Should be ErrJobNotFound", err)
 	}
 
-	js := tracker.NewJob("bucket", "exp", "type", startDate, "project.dataset.table")
+	js := tracker.NewJobWithDestination("bucket", "exp", "type", startDate, "project.dataset.table")
 	must(t, tk.AddJob(js))
 
 	err = tk.AddJob(js)
@@ -225,7 +225,7 @@ func TestJobMapHTML(t *testing.T) {
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
 	}
-	js := tracker.NewJob("bucket", "exp", "type", startDate, "project.dataset.table")
+	js := tracker.NewJobWithDestination("bucket", "exp", "type", startDate, "project.dataset.table")
 	must(t, tk.AddJob(js))
 
 	buf := bytes.Buffer{}
@@ -245,7 +245,7 @@ func TestExpiration(t *testing.T) {
 	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 5*time.Millisecond, 10*time.Millisecond)
 	must(t, err)
 
-	job := tracker.NewJob("bucket", "exp", "type", startDate, "project.dataset.table")
+	job := tracker.NewJobWithDestination("bucket", "exp", "type", startDate, "project.dataset.table")
 	err = tk.SetStatus(job, tracker.Parsing, "")
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/googleapis/google-cloud-go-testing/datastore/dsiface"
 
 	"github.com/m-lab/go/cloudtest/dsfake"
+	"github.com/m-lab/go/logx"
 
 	"github.com/m-lab/etl-gardener/tracker"
 )
@@ -37,7 +38,7 @@ func createJobs(t *testing.T, tk *tracker.Tracker, exp string, typ string, n int
 	date := startDate
 	for i := 0; i < n; i++ {
 		go func(date time.Time) {
-			job := tracker.NewJob("bucket", exp, typ, date)
+			job := tracker.NewJob("bucket", exp, typ, date, "project.dataset.table")
 			err := tk.AddJob(job)
 			if err != nil {
 				t.Error(err)
@@ -53,7 +54,7 @@ func completeJobs(t *testing.T, tk *tracker.Tracker, exp string, typ string, n i
 	// Delete all jobs.
 	date := startDate
 	for i := 0; i < n; i++ {
-		job := tracker.Job{"bucket", exp, typ, date}
+		job := tracker.Job{"bucket", exp, typ, date, "project.dataset.table"}
 		err := tk.SetStatus(job, tracker.Complete, "")
 
 		if err != nil {
@@ -79,17 +80,19 @@ func cleanup(client dsiface.Client, key *datastore.Key) error {
 }
 
 func TestJobPath(t *testing.T) {
-	withType := tracker.Job{"bucket", "exp", "type", startDate}
+	withType := tracker.Job{"bucket", "exp", "type", startDate, "project.dataset.table"}
 	if withType.Path() != "gs://bucket/exp/type/"+startDate.Format("2006/01/02/") {
 		t.Error("wrong path:", withType.Path())
 	}
-	withoutType := tracker.Job{"bucket", "exp", "", startDate}
+	withoutType := tracker.Job{"bucket", "exp", "", startDate, "project.dataset.table"}
 	if withoutType.Path() != "gs://bucket/exp/"+startDate.Format("2006/01/02/") {
 		t.Error("wrong path", withType.Path())
 	}
 }
 
 func TestTrackerAddDelete(t *testing.T) {
+	logx.LogxDebug.Set("true")
+
 	client := dsfake.NewClient()
 	dsKey := datastore.NameKey("TestTrackerAddDelete", "jobs", nil)
 	dsKey.Namespace = "gardener"
@@ -108,7 +111,9 @@ func TestTrackerAddDelete(t *testing.T) {
 	}
 
 	log.Println("Calling Sync")
-	must(t, tk.Sync())
+	if _, err := tk.Sync(time.Time{}); err != nil {
+		must(t, err)
+	}
 	// Check that the sync (and InitTracker) work.
 	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
 	must(t, err)
@@ -123,7 +128,9 @@ func TestTrackerAddDelete(t *testing.T) {
 
 	completeJobs(t, tk, "500Jobs", "type", numJobs)
 
-	must(t, tk.Sync())
+	if _, err := tk.Sync(time.Time{}); err != nil {
+		must(t, err)
+	}
 
 	if tk.NumJobs() != 0 {
 		t.Error("Job cleanup failed", tk.NumJobs())
@@ -144,7 +151,7 @@ func TestUpdate(t *testing.T) {
 
 	createJobs(t, tk, "JobToUpdate", "type", 1)
 
-	job := tracker.Job{"bucket", "JobToUpdate", "type", startDate}
+	job := tracker.Job{"bucket", "JobToUpdate", "type", startDate, "project.dataset.table"}
 	must(t, tk.SetStatus(job, tracker.Parsing, ""))
 	must(t, tk.SetStatus(job, tracker.Stabilizing, ""))
 
@@ -156,7 +163,7 @@ func TestUpdate(t *testing.T) {
 		t.Error("Incorrect job state", job)
 	}
 
-	err = tk.SetStatus(tracker.Job{"bucket", "JobToUpdate", "other-type", startDate}, tracker.Stabilizing, "")
+	err = tk.SetStatus(tracker.Job{"bucket", "JobToUpdate", "other-type", startDate, "project.dataset.table"}, tracker.Stabilizing, "")
 	if err != tracker.ErrJobNotFound {
 		t.Error(err, "should have been ErrJobNotFound")
 	}
@@ -192,7 +199,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 		t.Error("Should be ErrJobNotFound", err)
 	}
 
-	js := tracker.NewJob("bucket", "exp", "type", startDate)
+	js := tracker.NewJob("bucket", "exp", "type", startDate, "project.dataset.table")
 	must(t, tk.AddJob(js))
 
 	err = tk.AddJob(js)
@@ -218,7 +225,7 @@ func TestJobMapHTML(t *testing.T) {
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
 	}
-	js := tracker.NewJob("bucket", "exp", "type", startDate)
+	js := tracker.NewJob("bucket", "exp", "type", startDate, "project.dataset.table")
 	must(t, tk.AddJob(js))
 
 	buf := bytes.Buffer{}
@@ -238,7 +245,7 @@ func TestExpiration(t *testing.T) {
 	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 5*time.Millisecond, 10*time.Millisecond)
 	must(t, err)
 
-	job := tracker.NewJob("bucket", "exp", "type", startDate)
+	job := tracker.NewJob("bucket", "exp", "type", startDate, "project.dataset.table")
 	err = tk.SetStatus(job, tracker.Parsing, "")
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)


### PR DESCRIPTION
This PR:
  Adds DestinationTable to Job struct.  ETL will eventually use this to determine the output table.
  Adds last modified time to tracker, so that sync doesn't have to do anything if nothing has changed.
  Adds lastInit to tracker, to keep track of the last job that was created.  This will allow restarting gardener where it left off, in the next PR.

The DestinationTable is currently empty, so that it doesn't break ETL.  Once ETL is redeployed, it will be able to handle this field without breaking, and Gardener can start populating it.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/230)
<!-- Reviewable:end -->
