### PR TITLE
separate job and target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,7 @@ deploy:
 
 - provider: script
   script:
+    TARGET_BASE="gs://bqjson-mlab-sandbox"
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing ./apply-cluster.sh
   skip_cleanup: true
   on:
@@ -142,6 +143,7 @@ deploy:
   script:
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing-cluster ./apply-cluster.sh
     &&
+    TARGET_BASE="gs://bqjson-mlab-staging"
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing ./apply-cluster.sh
   on:
     repo: m-lab/etl-gardener

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ deploy:
 
 - provider: script
   script:
-    TARGET_BASE="gs://bqjson-mlab-sandbox"
+    TARGET_BASE="gs://etl-mlab-sandbox"
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing ./apply-cluster.sh
   skip_cleanup: true
   on:
@@ -143,7 +143,7 @@ deploy:
   script:
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing-cluster ./apply-cluster.sh
     &&
-    TARGET_BASE="gs://bqjson-mlab-staging"
+    TARGET_BASE="gs://etl-mlab-staging"
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing ./apply-cluster.sh
   on:
     repo: m-lab/etl-gardener

--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -23,6 +23,7 @@ CFG=/tmp/${CLUSTER}-${PROJECT}.yml
 kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
     --value GCLOUD_PROJECT=${PROJECT} \
     --value GIT_COMMIT=${TRAVIS_COMMIT} \
+    --value TARGET_BASE=${TARGET_BASE} \
     --value DATE_SKIP=${DATE_SKIP} \
     --value TASK_FILE_SKIP=${TASK_FILE_SKIP} \
     > ${CFG}

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -27,8 +27,8 @@ type Service struct {
 	startDate time.Time // The date to restart at.
 	date      time.Time // The date currently being dispatched.
 
-	jobTypes  []tracker.Job // The job prefixes to be iterated through.
-	nextIndex int           // index of TypeSource to dispatch next.
+	jobSpecs  []tracker.JobWithTarget // The job prefixes to be iterated through.
+	nextIndex int                     // index of TypeSource to dispatch next.
 }
 
 func (svc *Service) advanceDate() {
@@ -41,13 +41,13 @@ func (svc *Service) advanceDate() {
 }
 
 // NextJob returns a tracker.Job to dispatch.
-func (svc *Service) NextJob() tracker.Job {
+func (svc *Service) NextJob() tracker.JobWithTarget {
 	svc.lock.Lock()
 	defer svc.lock.Unlock()
-	if svc.nextIndex >= len(svc.jobTypes) {
+	if svc.nextIndex >= len(svc.jobSpecs) {
 		svc.advanceDate()
 	}
-	job := svc.jobTypes[svc.nextIndex]
+	job := svc.jobSpecs[svc.nextIndex]
 	job.Date = svc.date
 	svc.nextIndex++
 	return job
@@ -63,7 +63,7 @@ func (svc *Service) JobHandler(resp http.ResponseWriter, req *http.Request) {
 	}
 	job := svc.NextJob()
 	if svc.tracker != nil {
-		err := svc.tracker.AddJob(job)
+		err := svc.tracker.AddJob(job.Job)
 		if err != nil {
 			log.Println(err, job)
 			resp.WriteHeader(http.StatusInternalServerError)
@@ -89,13 +89,12 @@ func (svc *Service) JobHandler(resp http.ResponseWriter, req *http.Request) {
 func NewJobService(tk *tracker.Tracker, bucket string, startDate time.Time) (*Service, error) {
 	// TODO construct the jobs from storage bucket.
 	// TODO add bigquery destination table, based on project and data type.
-	types := []tracker.Job{
-		tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "ndt5"},
-		tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "tcpinfo"},
-	}
+	j1, _ := tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "ndt5"}.Target("gs://")
+	j2, _ := tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "tcpinfo"}.Target("gs://")
+	specs := []tracker.JobWithTarget{j1, j2}
 
 	start := startDate.UTC().Truncate(24 * time.Hour)
-	return &Service{tracker: tk, startDate: start, date: start, jobTypes: types}, nil
+	return &Service{tracker: tk, startDate: start, date: start, jobSpecs: specs}, nil
 }
 
 func post(ctx context.Context, url url.URL) ([]byte, int, error) {
@@ -117,11 +116,11 @@ func post(ctx context.Context, url url.URL) ([]byte, int, error) {
 }
 
 // NextJob is used by clients to fetch the next job from the service.
-func NextJob(ctx context.Context, base url.URL) (tracker.Job, error) {
+func NextJob(ctx context.Context, base url.URL) (tracker.JobWithTarget, error) {
 	jobURL := base
 	jobURL.Path = "job"
 
-	job := tracker.Job{}
+	job := tracker.JobWithTarget{}
 
 	b, status, err := post(ctx, jobURL)
 	if err != nil {

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 
@@ -88,9 +89,11 @@ func (svc *Service) JobHandler(resp http.ResponseWriter, req *http.Request) {
 // NewJobService creates the default job service.
 func NewJobService(tk *tracker.Tracker, bucket string, startDate time.Time) (*Service, error) {
 	// TODO construct the jobs from storage bucket.
-	// TODO add bigquery destination table, based on project and data type.
-	j1, _ := tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "ndt5"}.Target("gs://")
-	j2, _ := tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "tcpinfo"}.Target("gs://")
+	// The service cycles through the jobSpecs.  Each spec is a job (bucket/exp/type) and a target GCS bucket or BQ table.
+	// TODO get the destination bucket from a command line flag.
+	targetBase := os.Getenv("TARGET_BASE")
+	j1, _ := tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "ndt5"}.Target(targetBase + "/ndt/ndt5")
+	j2, _ := tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "tcpinfo"}.Target(targetBase + "/ndt/tcpinfo")
 	specs := []tracker.JobWithTarget{j1, j2}
 
 	start := startDate.UTC().Truncate(24 * time.Hour)

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -14,11 +14,16 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/go-test/deep"
-	job "github.com/m-lab/etl-gardener/job-service"
+	"github.com/m-lab/etl-gardener/job-service"
+	jobservice "github.com/m-lab/etl-gardener/job-service"
 	"github.com/m-lab/etl-gardener/tracker"
-	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/rtx"
 )
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
 
 func TestService_NextJob(t *testing.T) {
 	// This allows predictable behavior from time.Since in the advanceDate function.
@@ -28,37 +33,42 @@ func TestService_NextJob(t *testing.T) {
 	defer monkey.Unpatch(time.Now)
 
 	start := time.Date(2011, 2, 3, 5, 6, 7, 8, time.UTC)
-	svc, _ := job.NewJobService(nil, "fake-bucket", start)
+	svc, _ := jobservice.NewJobService(nil, "fake-bucket", start)
 	j := svc.NextJob()
-	w := tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Truncate(24 * time.Hour)}
+	w, err := tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Truncate(24 * time.Hour)}.Target("gs://")
+	rtx.Must(err, "")
 	diff := deep.Equal(w, j)
 	if diff != nil {
-		t.Fatal(diff)
+		t.Error(diff)
 	}
 	j = svc.NextJob()
-	w = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Date: start.Truncate(24 * time.Hour)}
+	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Date: start.Truncate(24 * time.Hour)}.Target("gs://")
+	rtx.Must(err, "")
 	diff = deep.Equal(w, j)
 	if diff != nil {
-		t.Fatal(diff)
+		t.Error(diff)
 	}
 	j = svc.NextJob()
-	w = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Add(24 * time.Hour).Truncate(24 * time.Hour)}
+	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Add(24 * time.Hour).Truncate(24 * time.Hour)}.Target("gs://")
+	rtx.Must(err, "")
 	diff = deep.Equal(w, j)
 	if diff != nil {
-		t.Fatal(diff)
+		t.Error(diff)
 	}
 	j = svc.NextJob()
-	w = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Date: start.Add(24 * time.Hour).Truncate(24 * time.Hour)}
+	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Date: start.Add(24 * time.Hour).Truncate(24 * time.Hour)}.Target("gs://")
+	rtx.Must(err, "")
 	diff = deep.Equal(w, j)
 	if diff != nil {
-		t.Fatal(diff)
+		t.Error(diff)
 	}
 	// Wrap
 	j = svc.NextJob()
-	w = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Truncate(24 * time.Hour)}
+	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Truncate(24 * time.Hour)}.Target("gs://")
+	rtx.Must(err, "")
 	diff = deep.Equal(w, j)
 	if diff != nil {
-		t.Fatal(diff)
+		t.Error(diff)
 	}
 }
 
@@ -139,13 +149,18 @@ type fakeGardener struct {
 	t *testing.T // for logging
 
 	lock       sync.Mutex
-	jobs       []tracker.Job
+	jobs       []tracker.JobWithTarget
 	heartbeats int
 	updates    int
 }
 
-func (g *fakeGardener) AddJob(job tracker.Job) {
-	g.jobs = append(g.jobs, job)
+func (g *fakeGardener) AddJob(job tracker.Job, target string) error {
+	jt, err := job.Target(target)
+	if err != nil {
+		return err
+	}
+	g.jobs = append(g.jobs, jt)
+	return nil
 }
 
 func (g *fakeGardener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -182,22 +197,23 @@ func TestJobClient(t *testing.T) {
 	defer cancel()
 
 	// set up a fake gardener service.
-	fg := fakeGardener{t: t, jobs: make([]tracker.Job, 0)}
-	fg.AddJob(tracker.NewJobWithDestination(
-		"foobar", "ndt", "ndt5", time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC), bqx.PDT{}))
+	fg := fakeGardener{t: t, jobs: make([]tracker.JobWithTarget, 0)}
+	spec := tracker.NewJob(
+		"foobar", "ndt", "ndt5", time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC))
+	rtx.Must(fg.AddJob(spec, "a.b.c"), "add job")
 	gardener := httptest.NewServer(&fg)
 	defer gardener.Close()
 	gURL, err := url.Parse(gardener.URL)
 	rtx.Must(err, "bad url")
 
-	j, err := job.NextJob(ctx, *gURL)
+	j, err := jobservice.NextJob(ctx, *gURL)
 	rtx.Must(err, "next job")
 
 	if j.Path() != "gs://foobar/ndt/ndt5/2019/01/01/" {
 		t.Error(j.Path())
 	}
 
-	j, err = job.NextJob(ctx, *gURL)
+	j, err = jobservice.NextJob(ctx, *gURL)
 	if err.Error() != "Internal Server Error" {
 		t.Fatal("Should be internal server error", err)
 	}

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 func init() {
 	// Always prepend the filename and line number.
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	os.Setenv("TARGET_BASE", "gs://fakebucket")
 }
 
 func TestService_NextJob(t *testing.T) {
@@ -35,28 +37,28 @@ func TestService_NextJob(t *testing.T) {
 	start := time.Date(2011, 2, 3, 5, 6, 7, 8, time.UTC)
 	svc, _ := jobservice.NewJobService(nil, "fake-bucket", start)
 	j := svc.NextJob()
-	w, err := tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Truncate(24 * time.Hour)}.Target("gs://")
+	w, err := tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Truncate(24 * time.Hour)}.Target("gs://fakebucket/ndt/ndt5")
 	rtx.Must(err, "")
 	diff := deep.Equal(w, j)
 	if diff != nil {
 		t.Error(diff)
 	}
 	j = svc.NextJob()
-	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Date: start.Truncate(24 * time.Hour)}.Target("gs://")
+	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Date: start.Truncate(24 * time.Hour)}.Target("gs://fakebucket/ndt/tcpinfo")
 	rtx.Must(err, "")
 	diff = deep.Equal(w, j)
 	if diff != nil {
 		t.Error(diff)
 	}
 	j = svc.NextJob()
-	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Add(24 * time.Hour).Truncate(24 * time.Hour)}.Target("gs://")
+	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Add(24 * time.Hour).Truncate(24 * time.Hour)}.Target("gs://fakebucket/ndt/ndt5")
 	rtx.Must(err, "")
 	diff = deep.Equal(w, j)
 	if diff != nil {
 		t.Error(diff)
 	}
 	j = svc.NextJob()
-	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Date: start.Add(24 * time.Hour).Truncate(24 * time.Hour)}.Target("gs://")
+	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Date: start.Add(24 * time.Hour).Truncate(24 * time.Hour)}.Target("gs://fakebucket/ndt/tcpinfo")
 	rtx.Must(err, "")
 	diff = deep.Equal(w, j)
 	if diff != nil {
@@ -64,7 +66,7 @@ func TestService_NextJob(t *testing.T) {
 	}
 	// Wrap
 	j = svc.NextJob()
-	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Truncate(24 * time.Hour)}.Target("gs://")
+	w, err = tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Truncate(24 * time.Hour)}.Target("gs://fakebucket/ndt/ndt5")
 	rtx.Must(err, "")
 	diff = deep.Equal(w, j)
 	if diff != nil {

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -43,7 +43,7 @@ spec:
         - name: ARCHIVE_BUCKET  # This will eventually be provided through k8s configmap.
           value: "archive-measurement-lab"
         - name: TARGET_BASE # The target BQ project or GCS bucket for parsing.
-          value: {{TARGET_BASE}}
+          value: "{{TARGET_BASE}}"
         - name: GIT_COMMIT
           value: "{{GIT_COMMIT}}"
         - name: PROJECT

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -42,6 +42,8 @@ spec:
           value: "manager"
         - name: ARCHIVE_BUCKET  # This will eventually be provided through k8s configmap.
           value: "archive-measurement-lab"
+        - name: TARGET_BASE # The target BQ project or GCS bucket for parsing.
+          value: {{TARGET_BASE}}
         - name: GIT_COMMIT
           value: "{{GIT_COMMIT}}"
         - name: PROJECT

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/ops"
 	"github.com/m-lab/etl-gardener/tracker"
-	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/dataset"
 	"github.com/m-lab/go/logx"
 	"github.com/m-lab/go/rtx"
@@ -34,8 +33,8 @@ func TestTableUtils(t *testing.T) {
 	bqClient := bqiface.AdaptClient(c)
 	ds := dataset.Dataset{Dataset: bqClient.Dataset(bqConfig.BQBatchDataset), BqClient: bqClient}
 
-	j := tracker.NewJobWithDestination(
-		"bucket", "exp", "type", time.Date(2019, 12, 1, 0, 0, 0, 0, time.UTC), bqx.PDT{})
+	j := tracker.NewJob(
+		"bucket", "exp", "type", time.Date(2019, 12, 1, 0, 0, 0, 0, time.UTC))
 	src := ops.TemplateTable(j, &ds)
 	dest := ops.PartitionedTable(j, &ds)
 
@@ -54,9 +53,9 @@ func TestStandardMonitor(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0)
 	rtx.Must(err, "tk init")
-	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp", "type", time.Now(), bqx.PDT{}))
-	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp2", "type", time.Now(), bqx.PDT{}))
-	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp2", "type2", time.Now(), bqx.PDT{}))
+	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
+	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))
+	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now()))
 
 	m, err := ops.NewStandardMonitor(context.Background(), cloud.BQConfig{}, tk)
 	rtx.Must(err, "NewMonitor failure")

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/logx"
 	"github.com/m-lab/go/rtx"
 
@@ -37,9 +36,9 @@ func TestMonitor_Watch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0)
 	rtx.Must(err, "tk init")
-	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp", "type", time.Now(), bqx.PDT{}))
-	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp2", "type", time.Now(), bqx.PDT{}))
-	tk.AddJob(tracker.NewJobWithDestination("bucket", "exp2", "type2", time.Now(), bqx.PDT{}))
+	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
+	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))
+	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now()))
 
 	m, err := ops.NewMonitor(context.Background(), cloud.BQConfig{}, tk)
 	rtx.Must(err, "NewMonitor failure")

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -77,7 +77,7 @@ func (h *Handler) heartbeat(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 	if err := h.tracker.Heartbeat(job); err != nil {
-		logx.Debug.Printf("%v %+v %v\n", err, job, job.DestinationTable)
+		logx.Debug.Printf("%v %+v\n", err, job)
 		resp.WriteHeader(http.StatusGone)
 		return
 	}

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -13,9 +13,13 @@ import (
 
 	"cloud.google.com/go/datastore"
 	"github.com/m-lab/etl-gardener/tracker"
-	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/cloudtest/dsfake"
 )
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
 
 func testSetup(t *testing.T) (url.URL, *tracker.Tracker, tracker.Job) {
 	client := dsfake.NewClient()
@@ -31,7 +35,7 @@ func testSetup(t *testing.T) (url.URL, *tracker.Tracker, tracker.Job) {
 
 	date := time.Date(2019, 01, 02, 0, 0, 0, 0, time.UTC)
 	// TODO - for now, PDT is ignored by json, so it must be empty.
-	job := tracker.NewJobWithDestination("bucket", "exp", "type", date, bqx.PDT{})
+	job := tracker.NewJob("bucket", "exp", "type", date)
 	mux := http.NewServeMux()
 	h := tracker.NewHandler(tk)
 	h.Register(mux)

--- a/tracker/tracker_race_test.go
+++ b/tracker/tracker_race_test.go
@@ -13,7 +13,6 @@ import (
 
 	"cloud.google.com/go/datastore"
 	"github.com/m-lab/etl-gardener/tracker"
-	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/cloudtest/dsfake"
 )
 
@@ -47,11 +46,10 @@ func TestConcurrentUpdates(t *testing.T) {
 	for i := 0; i < changes; i++ {
 		go func(i int) {
 			k := tracker.Job{
-				Bucket:           "bucket",
-				Experiment:       "ConcurrentUpdates",
-				Datatype:         "type",
-				Date:             startDate.Add(time.Duration(24*rand.Intn(jobs)) * time.Hour),
-				DestinationTable: bqx.PDT{"project", "dataset", "table"},
+				Bucket:     "bucket",
+				Experiment: "ConcurrentUpdates",
+				Datatype:   "type",
+				Date:       startDate.Add(time.Duration(24*rand.Intn(jobs)) * time.Hour),
 			}
 			if i%5 == 0 {
 				err := tk.SetStatus(k, tracker.State(fmt.Sprintf("State:%d", i)), "")

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -11,7 +11,6 @@ import (
 	"cloud.google.com/go/datastore"
 	"github.com/googleapis/google-cloud-go-testing/datastore/dsiface"
 
-	"github.com/m-lab/go/bqx"
 	"github.com/m-lab/go/cloudtest/dsfake"
 	"github.com/m-lab/go/logx"
 
@@ -39,9 +38,8 @@ func createJobs(t *testing.T, tk *tracker.Tracker, exp string, typ string, n int
 	date := startDate
 	for i := 0; i < n; i++ {
 		go func(date time.Time) {
-			job := tracker.NewJobWithDestination(
+			job := tracker.NewJob(
 				"bucket", exp, typ, date,
-				bqx.PDT{"project", "dataset", "table"},
 			)
 			err := tk.AddJob(job)
 			if err != nil {
@@ -58,9 +56,8 @@ func completeJobs(t *testing.T, tk *tracker.Tracker, exp string, typ string, n i
 	// Delete all jobs.
 	date := startDate
 	for i := 0; i < n; i++ {
-		job := tracker.NewJobWithDestination(
+		job := tracker.NewJob(
 			"bucket", exp, typ, date,
-			bqx.PDT{"project", "dataset", "table"},
 		)
 		err := tk.SetStatus(job, tracker.Complete, "")
 
@@ -87,11 +84,11 @@ func cleanup(client dsiface.Client, key *datastore.Key) error {
 }
 
 func TestJobPath(t *testing.T) {
-	withType := tracker.Job{"bucket", "exp", "type", startDate, bqx.PDT{"project", "dataset", "table"}}
+	withType := tracker.Job{"bucket", "exp", "type", startDate}
 	if withType.Path() != "gs://bucket/exp/type/"+startDate.Format("2006/01/02/") {
 		t.Error("wrong path:", withType.Path())
 	}
-	withoutType := tracker.Job{"bucket", "exp", "", startDate, bqx.PDT{"project", "dataset", "table"}}
+	withoutType := tracker.Job{"bucket", "exp", "", startDate}
 	if withoutType.Path() != "gs://bucket/exp/"+startDate.Format("2006/01/02/") {
 		t.Error("wrong path", withType.Path())
 	}
@@ -158,7 +155,7 @@ func TestUpdate(t *testing.T) {
 
 	createJobs(t, tk, "JobToUpdate", "type", 1)
 
-	job := tracker.Job{"bucket", "JobToUpdate", "type", startDate, bqx.PDT{"project", "dataset", "table"}}
+	job := tracker.Job{"bucket", "JobToUpdate", "type", startDate}
 	must(t, tk.SetStatus(job, tracker.Parsing, ""))
 	must(t, tk.SetStatus(job, tracker.Stabilizing, ""))
 
@@ -170,7 +167,7 @@ func TestUpdate(t *testing.T) {
 		t.Error("Incorrect job state", job)
 	}
 
-	err = tk.SetStatus(tracker.Job{"bucket", "JobToUpdate", "other-type", startDate, bqx.PDT{"project", "dataset", "table"}}, tracker.Stabilizing, "")
+	err = tk.SetStatus(tracker.Job{"bucket", "JobToUpdate", "other-type", startDate}, tracker.Stabilizing, "")
 	if err != tracker.ErrJobNotFound {
 		t.Error(err, "should have been ErrJobNotFound")
 	}
@@ -206,7 +203,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 		t.Error("Should be ErrJobNotFound", err)
 	}
 
-	js := tracker.NewJobWithDestination("bucket", "exp", "type", startDate, bqx.PDT{"project", "dataset", "table"})
+	js := tracker.NewJob("bucket", "exp", "type", startDate)
 	must(t, tk.AddJob(js))
 
 	err = tk.AddJob(js)
@@ -232,7 +229,7 @@ func TestJobMapHTML(t *testing.T) {
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
 	}
-	js := tracker.NewJobWithDestination("bucket", "exp", "type", startDate, bqx.PDT{"project", "dataset", "table"})
+	js := tracker.NewJob("bucket", "exp", "type", startDate)
 	must(t, tk.AddJob(js))
 
 	buf := bytes.Buffer{}
@@ -252,7 +249,7 @@ func TestExpiration(t *testing.T) {
 	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 5*time.Millisecond, 10*time.Millisecond)
 	must(t, err)
 
-	job := tracker.NewJobWithDestination("bucket", "exp", "type", startDate, bqx.PDT{"project", "dataset", "table"})
+	job := tracker.NewJob("bucket", "exp", "type", startDate)
 	err = tk.SetStatus(job, tracker.Parsing, "")
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)


### PR DESCRIPTION
This must follow after m-lab/etl/#841 is merged to avoid breaking etl build.

This separates out the Target from the Job source, to make updates and tracker simpler.  It also introduces a second GCS target type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/233)
<!-- Reviewable:end -->
