### PR TITLE
Reprocess faster from archive-mlab-oti

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-ndt5.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-ndt5.yml
@@ -49,7 +49,7 @@ spec:
         - name: TASKFILE_BUCKET
           value: "archive-measurement-lab"
         - name: START_DATE
-          value: "20190513"
+          value: "20200201" # TODO(soltesz): restore after normalization is complete "20190513"
         - name: DATE_SKIP  # Should be 0 for normal operation
           value: "0"
         - name: TASK_FILE_SKIP # Should be 0 for normal operation

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -49,7 +49,7 @@ spec:
         - name: TASKFILE_BUCKET
           value: "archive-measurement-lab"
         - name: START_DATE
-          value: "20190329"
+          value: "20200201" # TODO(soltesz): restore after normalization is complete "20190329"
         - name: DATE_SKIP  # Should be 0 for normal operation
           value: "{{DATE_SKIP}}"
         - name: TASK_FILE_SKIP # Should be 0 for normal operation


### PR DESCRIPTION
This change modifies the source gcs bucket for ndt5 and tcpinfo in order to reprocess current dates faster.

As well, it modifies the dedup and sanity checks to use the basename of the ParseInfo.TaskFilename so that multiple archive sources do not conflict with one another. A similar strategy will be used with updating the legacy configs for ndtweb100 and sidestream to use the normalized gcs folder names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/234)
<!-- Reviewable:end -->
