### PR TITLE
disable staging deployment for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,9 +142,9 @@ deploy:
 - provider: script
   script:
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing-cluster ./apply-cluster.sh
-    &&
-    TARGET_BASE="gs://etl-mlab-staging"
-    $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing ./apply-cluster.sh
+    #&&
+    #TARGET_BASE="gs://etl-mlab-staging"
+    #$TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing ./apply-cluster.sh
   on:
     repo: m-lab/etl-gardener
     all_branches: true


### PR DESCRIPTION
We need high availability, so need staging to run the normal config so we can sanity check before new deployments.

So this disables the universal config, which interferes with table stabilization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/237)
<!-- Reviewable:end -->
