### PR TITLE
Enable target fields in json and remove pprof from public status port.

### DIFF
--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/http/pprof"
 	"os"
 	"runtime"
 	"strconv"
@@ -270,17 +269,12 @@ func Status(w http.ResponseWriter, r *http.Request) {
 // Used for testing.
 var statusServerAddr string
 
+// Setup ONLY status server, to allow easy access to status
+// with minimal security exposure (e.g. no pprof).
 func startStatusServer() *http.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", Status)
 	mux.HandleFunc("/status", Status)
-
-	// Also allow pprof through the status server.
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	// Start up the http server.
 	server := &http.Server{

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -47,10 +47,8 @@ type JobWithTarget struct {
 	Job
 	// One of these two fields indicates the destination,
 	// either a BigQuery table, or a GCS bucket/prefix string.
-	// Initially, both fields are suppressed in json to avoid breaking
-	// existing ETL clients.
-	TargetTable           bqx.PDT `json:"-,omitempty"`
-	TargetBucketAndPrefix string  `json:"-,omitempty"` // gs://bucket/prefix
+	TargetTable           bqx.PDT `json:",omitempty"`
+	TargetBucketAndPrefix string  `json:",omitempty"` // gs://bucket/prefix
 }
 
 // NewJob creates a new job object.


### PR DESCRIPTION
These were suppressed while updating the etl client.
This also removes the pprof endpoints from the public status server on port 8081, to improve security.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/239)
<!-- Reviewable:end -->
