### PR TITLE
Restore start dates for ndt5 & tcpinfo

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-ndt5.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-ndt5.yml
@@ -49,7 +49,7 @@ spec:
         - name: TASKFILE_BUCKET
           value: "archive-measurement-lab"
         - name: START_DATE
-          value: "20200201" # TODO(soltesz): restore after normalization is complete "20190513"
+          value: "20190513"
         - name: DATE_SKIP  # Should be 0 for normal operation
           value: "0"
         - name: TASK_FILE_SKIP # Should be 0 for normal operation

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -49,7 +49,7 @@ spec:
         - name: TASKFILE_BUCKET
           value: "archive-measurement-lab"
         - name: START_DATE
-          value: "20200201" # TODO(soltesz): restore after normalization is complete "20190329"
+          value: "20190329"
         - name: DATE_SKIP  # Should be 0 for normal operation
           value: "{{DATE_SKIP}}"
         - name: TASK_FILE_SKIP # Should be 0 for normal operation


### PR DESCRIPTION
The archive normalization disrupted normal daily processing. In response, we accelerated the reprocessing of recent days by changing the reprocessing start dates. Now that it's back up to date, this change restores the start dates to their original values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/240)
<!-- Reviewable:end -->
