### PR TITLE
Support more stats in universal

### DIFF
--- a/cloud/bq/dedup.go
+++ b/cloud/bq/dedup.go
@@ -104,12 +104,12 @@ ErrorTimeout:
 	// If we fall through here, then there is some problem...
 	if strings.Contains(err.Error(), "Not found: Table") {
 		log.Println("Timeout waiting for table creation:", tt.FullyQualifiedName())
-		metrics.FailCount.WithLabelValues("TableNotFoundTimeout")
+		metrics.FailCount.WithLabelValues(tt.DatasetID(), tt.TableID(), "TableNotFoundTimeout")
 		return ErrTableNotFound
 	}
 	// We are seeing occasional Error 500: An internal error ...
 	log.Println(err, tt.FullyQualifiedName())
-	metrics.FailCount.WithLabelValues("TableMetaErr")
+	metrics.FailCount.WithLabelValues(tt.DatasetID(), tt.TableID(), "TableMetaErr")
 	return err
 }
 

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -40,7 +40,7 @@ import (
 )
 
 var (
-	jobExpirationTime = flag.Duration("job_expiration_time", 4*time.Hour, "Time after which stale jobs will be purged")
+	jobExpirationTime = flag.Duration("job_expiration_time", 24*time.Hour, "Time after which stale jobs will be purged")
 	shutdownTimeout   = flag.Duration("shutdown_timeout", 1*time.Minute, "Graceful shutdown time allowance")
 	statusPort        = flag.String("status_port", ":0", "The public interface port where status (and pprof) will be published")
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -18,7 +18,7 @@ var (
 			Name: "gardener_started_total",
 			Help: "Number of date tasks started.",
 		},
-		[]string{"experiment"},
+		[]string{"experiment", "datatype"},
 	)
 
 	// CompletedCount counts the number of date tasks completed.
@@ -32,7 +32,7 @@ var (
 			Name: "gardener_completed_total",
 			Help: "Number of date tasks completed.",
 		},
-		[]string{"experiment"},
+		[]string{"experiment", "datatype"},
 	)
 
 	// FailCount counts the number of requests that result in a fatal failure.
@@ -47,7 +47,7 @@ var (
 			Name: "gardener_fail_total",
 			Help: "Number of processing failures.",
 		},
-		[]string{"status"},
+		[]string{"experiment", "datatype", "status"}, // TODO Change to failure
 	)
 
 	// WarningCount counts all warnings encountered during processing a request.
@@ -61,7 +61,7 @@ var (
 			Name: "gardener_warning_total",
 			Help: "Number of processing warnings.",
 		},
-		[]string{"status"},
+		[]string{"experiment", "datatype", "status"}, // TODO change to warning
 	)
 
 	// TasksInFlight maintains a count of the number of tasks in flight.
@@ -70,11 +70,12 @@ var (
 	//   gardener_tasks_in_flight
 	// Example usage:
 	// metrics.TasksInFlight.Add(1)
-	TasksInFlight = promauto.NewGauge(
+	TasksInFlight = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gardener_tasks_in_flight",
 			Help: "Number of tasks in flight",
 		},
+		[]string{"experiment", "datatype"},
 	)
 
 	// StateDate identifies the date of the most recent update to each state.
@@ -95,7 +96,7 @@ var (
 	// we currently have separate gardener deployments for each type.
 	// Usage example:
 	//   metrics.StateTimeHistogram.WithLabelValues(
-	//           StateName[state]).Observe(time.Since(start).Seconds())
+	//           datatype, StateName[state]).Observe(time.Since(start).Seconds())
 	StateTimeHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "gardener_state_time_histogram",
@@ -106,7 +107,7 @@ var (
 				100, 300, 1000, 1800, 3600, 2 * 3600, 4 * 3600, 8 * 3600, 12 * 3600,
 			},
 		},
-		[]string{"state"})
+		[]string{"experiment", "datatype", "state"})
 
 	// FilesPerDateHistogram provides a histogram of files per date submitted to pipeline.
 	//
@@ -117,7 +118,7 @@ var (
 	//   gardener_files_count{year="...", le="..."}
 	// Usage example:
 	//   metrics.FilesPerDateHistogram.WithLabelValues(
-	//           "2011").Observe(files)
+	//           "ndt5", "2011").Observe(files)
 	FilesPerDateHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "gardener_files",
@@ -130,7 +131,7 @@ var (
 				100000, 120000, 140000, 170000, 200000, 240000, 280000, 320000, 380000, 440000, 500000, 600000, 700000, 800000, 900000,
 			},
 		},
-		[]string{"year"},
+		[]string{"experiment", "datatype", "year"},
 	)
 
 	// BytesPerDateHistogram provides a histogram of bytes per date submitted to pipeline
@@ -142,7 +143,7 @@ var (
 	//   gardener_bytes_count{year="...", le="..."}
 	// Usage example:
 	//   metrics.BytesPerDateHistogram.WithLabelValues(
-	//           "2011").Observe(bytes)
+	//           "ndt5", "2011").Observe(bytes)
 	BytesPerDateHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "gardener_bytes",
@@ -156,6 +157,6 @@ var (
 				10000000000, 14000000000, 20000000000, 28000000000, 40000000000, 56000000000, 80000000000,
 			},
 		},
-		[]string{"year"},
+		[]string{"experiment", "datatype", "year"},
 	)
 )

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,7 +12,7 @@ var (
 	// Provides metrics:
 	//   gardener_started_total{experiment}
 	// Example usage:
-	// metrics.StartedCount.WithLabelValues("sidestream").Inc()
+	// metrics.StartedCount.WithLabelValues(exp, dt).Inc()
 	StartedCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "gardener_started_total",
@@ -26,7 +26,7 @@ var (
 	// Provides metrics:
 	//   gardener_completed_total{experiment}
 	// Example usage:
-	// metrics.CompletedCount.WithLabelValues("sidestream").Inc()
+	// metrics.CompletedCount.WithLabelValues(exp, dt).Inc()
 	CompletedCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "gardener_completed_total",
@@ -41,7 +41,7 @@ var (
 	// Provides metrics:
 	//   gardener_fail_total{status}
 	// Example usage:
-	// metrics.FailCount.WithLabelValues("BadTableName").Inc()
+	// metrics.FailCount.WithLabelValues(exp, dt, "BadTableName").Inc()
 	FailCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "gardener_fail_total",
@@ -55,7 +55,7 @@ var (
 	// Provides metrics:
 	//   gardener_warning_total{status}
 	// Example usage:
-	// metrics.WarningCount.WithLabelValues("funny xyz").Inc()
+	// metrics.WarningCount.WithLabelValues(exp, dt, "funny xyz").Inc()
 	WarningCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "gardener_warning_total",
@@ -69,7 +69,7 @@ var (
 	// Provides metrics:
 	//   gardener_tasks_in_flight
 	// Example usage:
-	// metrics.TasksInFlight.Add(1)
+	// metrics.TasksInFlight.WithLabelValues(exp, dt).Inc
 	TasksInFlight = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gardener_tasks_in_flight",
@@ -83,7 +83,7 @@ var (
 	// Provides metrics:
 	//   gardener_state_date
 	// Example usage:
-	// metrics.StateDate.WithLabelValues(datatype, StateNames[t.State]).Observe(time.Now())
+	// metrics.StateDate.WithLabelValues(exp, dt, StateNames[t.State]).Observe(time.Now())
 	StateDate = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gardener_state_date",
@@ -96,7 +96,7 @@ var (
 	// we currently have separate gardener deployments for each type.
 	// Usage example:
 	//   metrics.StateTimeHistogram.WithLabelValues(
-	//           datatype, StateName[state]).Observe(time.Since(start).Seconds())
+	//           exp, dt, StateName[state]).Observe(time.Since(start).Seconds())
 	StateTimeHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "gardener_state_time_histogram",
@@ -118,7 +118,7 @@ var (
 	//   gardener_files_count{year="...", le="..."}
 	// Usage example:
 	//   metrics.FilesPerDateHistogram.WithLabelValues(
-	//           "ndt5", "2011").Observe(files)
+	//           "ndt", "ndt5", "2011").Observe(files)
 	FilesPerDateHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "gardener_files",
@@ -143,7 +143,7 @@ var (
 	//   gardener_bytes_count{year="...", le="..."}
 	// Usage example:
 	//   metrics.BytesPerDateHistogram.WithLabelValues(
-	//           "ndt5", "2011").Observe(bytes)
+	//           "ndt", "ndt5", "2011").Observe(bytes)
 	BytesPerDateHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "gardener_bytes",

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -65,6 +65,7 @@ var (
 	)
 
 	// TasksInFlight maintains a count of the number of tasks in flight.
+	// TODO consider deprecating this and using Started - Completed.
 	//
 	// Provides metrics:
 	//   gardener_tasks_in_flight

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func TestLintMetrics(t *testing.T) {
-	StartedCount.WithLabelValues("x")
-	CompletedCount.WithLabelValues("x")
-	FailCount.WithLabelValues("x")
-	WarningCount.WithLabelValues("x")
+	StartedCount.WithLabelValues("exp", "type", "status"
+	CompletedCount.WithLabelValues("exp", "type", "status"
+	FailCount.WithLabelValues("exp", "type", "status"
+	WarningCount.WithLabelValues("exp", "type", "status")
 	StateDate.WithLabelValues("exp", "type", "x")
-	StateTimeHistogram.WithLabelValues("x")
-	FilesPerDateHistogram.WithLabelValues("x")
-	BytesPerDateHistogram.WithLabelValues("x")
+	StateTimeHistogram.WithLabelValues("exp", "type", "x")
+	FilesPerDateHistogram.WithLabelValues("exp", "type", "x")
+	BytesPerDateHistogram.WithLabelValues("exp", "type", "x")
 	promtest.LintMetrics(nil) // Log warnings only.
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func TestLintMetrics(t *testing.T) {
-	StartedCount.WithLabelValues("exp", "type", "status"
-	CompletedCount.WithLabelValues("exp", "type", "status"
-	FailCount.WithLabelValues("exp", "type", "status"
+	StartedCount.WithLabelValues("exp", "type")
+	CompletedCount.WithLabelValues("exp", "type")
+	FailCount.WithLabelValues("exp", "type", "status")
 	WarningCount.WithLabelValues("exp", "type", "status")
 	StateDate.WithLabelValues("exp", "type", "x")
 	StateTimeHistogram.WithLabelValues("exp", "type", "x")

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -237,13 +237,13 @@ queueLoop:
 		if t.ErrInfo != "" || t.ErrMsg != "" {
 			log.Println("Skipping:", t.Name, t.ErrMsg, t.ErrInfo)
 			// datatype is not readily available in legacy code.
-			metrics.FailCount.WithLabelValues(t.Experiment, "", "skipping task with error").Inc()
+			metrics.FailCount.WithLabelValues(t.Experiment, t.Experiment, "skipping task with error").Inc()
 			continue
 		}
 		if t.Queue != "" {
 			if strings.TrimSpace(t.Queue) != t.Queue {
 				log.Println("invalid queue name", t)
-				metrics.FailCount.WithLabelValues(t.Experiment, "", "bad queue name").Inc()
+				metrics.FailCount.WithLabelValues(t.Experiment, t.Experiment, "bad queue name").Inc()
 				// Skip updating task date, as this entry is somehow corrupted.
 				continue
 			}
@@ -254,7 +254,7 @@ queueLoop:
 				th.StartTask(ctx, t)
 			} else {
 				log.Println("Queue", t.Queue, "already in use.  Skipping", t)
-				metrics.FailCount.WithLabelValues(t.Experiment, "", "queue not available").Inc()
+				metrics.FailCount.WithLabelValues(t.Experiment, t.Experiment, "queue not available").Inc()
 				continue
 			}
 		} else {

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -236,6 +236,7 @@ queueLoop:
 		t := tasks[i]
 		if t.ErrInfo != "" || t.ErrMsg != "" {
 			log.Println("Skipping:", t.Name, t.ErrMsg, t.ErrInfo)
+			// datatype is not readily available in legacy code.
 			metrics.FailCount.WithLabelValues(t.Experiment, "", "skipping task with error").Inc()
 			continue
 		}

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -236,13 +236,13 @@ queueLoop:
 		t := tasks[i]
 		if t.ErrInfo != "" || t.ErrMsg != "" {
 			log.Println("Skipping:", t.Name, t.ErrMsg, t.ErrInfo)
-			metrics.FailCount.WithLabelValues("skipping task with error").Inc()
+			metrics.FailCount.WithLabelValues(t.Experiment, "", "skipping task with error").Inc()
 			continue
 		}
 		if t.Queue != "" {
 			if strings.TrimSpace(t.Queue) != t.Queue {
 				log.Println("invalid queue name", t)
-				metrics.FailCount.WithLabelValues("bad queue name").Inc()
+				metrics.FailCount.WithLabelValues(t.Experiment, "", "bad queue name").Inc()
 				// Skip updating task date, as this entry is somehow corrupted.
 				continue
 			}
@@ -253,7 +253,7 @@ queueLoop:
 				th.StartTask(ctx, t)
 			} else {
 				log.Println("Queue", t.Queue, "already in use.  Skipping", t)
-				metrics.FailCount.WithLabelValues("queue not available").Inc()
+				metrics.FailCount.WithLabelValues(t.Experiment, "", "queue not available").Inc()
 				continue
 			}
 		} else {

--- a/rex/rex.go
+++ b/rex/rex.go
@@ -87,8 +87,8 @@ func (rex *ReprocessingExecutor) Next(ctx context.Context, t *state.Task, termin
 		// TODO - handle zero task case.
 		fileCount, byteCount, err := rex.queue(ctx, t)
 		// Update the metrics, even if there is an error, since the files were submitted to the queue already.
-		metrics.FilesPerDateHistogram.WithLabelValues(strconv.Itoa(t.Date.Year())).Observe(float64(fileCount))
-		metrics.BytesPerDateHistogram.WithLabelValues(strconv.Itoa(t.Date.Year())).Observe(float64(byteCount))
+		metrics.FilesPerDateHistogram.WithLabelValues(t.Experiment, "", strconv.Itoa(t.Date.Year())).Observe(float64(fileCount))
+		metrics.BytesPerDateHistogram.WithLabelValues(t.Experiment, "", strconv.Itoa(t.Date.Year())).Observe(float64(byteCount))
 		if err != nil {
 			// SetError also pushes to datastore, like Update(ctx, )
 			t.SetError(ctx, err, "rex.queue")
@@ -208,7 +208,7 @@ func (rex *ReprocessingExecutor) waitForParsing(ctx context.Context, t *state.Ta
 		// in case there is some bad network condition, service failure,
 		// or perhaps the queue_pusher is down.
 		log.Println(err)
-		metrics.WarningCount.WithLabelValues("IsEmptyError").Inc()
+		metrics.WarningCount.WithLabelValues(t.Experiment, "", "IsEmptyError").Inc()
 		// TODO update metric
 		time.Sleep(time.Duration(60+rand.Intn(120)) * time.Second)
 	}

--- a/rex/rex.go
+++ b/rex/rex.go
@@ -81,7 +81,7 @@ func (rex *ReprocessingExecutor) Next(ctx context.Context, t *state.Task, termin
 		// if it does?  Also check if it has a streaming buffer?
 		// Nothing to do.
 		t.Update(ctx, state.Queuing)
-		metrics.StartedCount.WithLabelValues("sidestream").Inc()
+		metrics.StartedCount.WithLabelValues(t.Experiment, "").Inc()
 
 	case state.Queuing:
 		// TODO - handle zero task case.

--- a/rex/rex.go
+++ b/rex/rex.go
@@ -81,14 +81,14 @@ func (rex *ReprocessingExecutor) Next(ctx context.Context, t *state.Task, termin
 		// if it does?  Also check if it has a streaming buffer?
 		// Nothing to do.
 		t.Update(ctx, state.Queuing)
-		metrics.StartedCount.WithLabelValues(t.Experiment, "").Inc()
+		metrics.StartedCount.WithLabelValues(t.Experiment, t.Experiment).Inc()
 
 	case state.Queuing:
 		// TODO - handle zero task case.
 		fileCount, byteCount, err := rex.queue(ctx, t)
 		// Update the metrics, even if there is an error, since the files were submitted to the queue already.
-		metrics.FilesPerDateHistogram.WithLabelValues(t.Experiment, "", strconv.Itoa(t.Date.Year())).Observe(float64(fileCount))
-		metrics.BytesPerDateHistogram.WithLabelValues(t.Experiment, "", strconv.Itoa(t.Date.Year())).Observe(float64(byteCount))
+		metrics.FilesPerDateHistogram.WithLabelValues(t.Experiment, t.Experiment, strconv.Itoa(t.Date.Year())).Observe(float64(fileCount))
+		metrics.BytesPerDateHistogram.WithLabelValues(t.Experiment, t.Experiment, strconv.Itoa(t.Date.Year())).Observe(float64(byteCount))
 		if err != nil {
 			// SetError also pushes to datastore, like Update(ctx, )
 			t.SetError(ctx, err, "rex.queue")
@@ -208,7 +208,7 @@ func (rex *ReprocessingExecutor) waitForParsing(ctx context.Context, t *state.Ta
 		// in case there is some bad network condition, service failure,
 		// or perhaps the queue_pusher is down.
 		log.Println(err)
-		metrics.WarningCount.WithLabelValues(t.Experiment, "", "IsEmptyError").Inc()
+		metrics.WarningCount.WithLabelValues(t.Experiment, t.Experiment, "IsEmptyError").Inc()
 		// TODO update metric
 		time.Sleep(time.Duration(60+rand.Intn(120)) * time.Second)
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -223,7 +223,7 @@ func (t *Task) SourceAndDest(ds *dataset.Dataset) (bqiface.Table, bqiface.Table,
 		// If there is a parse error, log and skip request.
 		// Datatype may be incorporated into Experiment, but this is legacy path, and
 		// will be deprecated soon.
-		metrics.FailCount.WithLabelValues(t.Experiment, "", "BadDedupPrefix")
+		metrics.FailCount.WithLabelValues(t.Experiment, t.Experiment, "BadDedupPrefix")
 		return nil, nil, err
 	}
 
@@ -250,7 +250,7 @@ func (t *Task) Save(ctx context.Context) error {
 	t.UpdateTime = time.Now()
 	// Datatype may be incorporated into Experiment, but this is legacy path, and
 	// will be deprecated soon.
-	metrics.StateDate.WithLabelValues(t.Experiment, "", StateNames[t.State]).Set(float64(t.Date.Unix()))
+	metrics.StateDate.WithLabelValues(t.Experiment, t.Experiment, StateNames[t.State]).Set(float64(t.Date.Unix()))
 	return t.saver.SaveTask(ctx, *t)
 }
 
@@ -259,12 +259,12 @@ func (t *Task) Update(ctx context.Context, st State) error {
 	duration := time.Since(t.UpdateTime)
 	// Datatype may be incorporated into Experiment, but this is legacy path, and
 	// will be deprecated soon.
-	metrics.StateTimeHistogram.WithLabelValues(t.Experiment, "", StateNames[t.State]).Observe(duration.Seconds())
+	metrics.StateTimeHistogram.WithLabelValues(t.Experiment, t.Experiment, StateNames[t.State]).Observe(duration.Seconds())
 	t.State = st
 	t.UpdateTime = time.Now()
 	// Datatype may be incorporated into Experiment, but this is legacy path, and
 	// will be deprecated soon.
-	metrics.StateDate.WithLabelValues(t.Experiment, "", StateNames[t.State]).Set(float64(t.Date.Unix()))
+	metrics.StateDate.WithLabelValues(t.Experiment, t.Experiment, StateNames[t.State]).Set(float64(t.Date.Unix()))
 	if t.saver == nil {
 		return ErrNoSaver
 	}
@@ -283,7 +283,7 @@ func (t *Task) Delete(ctx context.Context) error {
 func (t *Task) SetError(ctx context.Context, err error, info string) error {
 	// Datatype may be incorporated into Experiment, but this is legacy path, and
 	// will be deprecated soon.
-	metrics.FailCount.WithLabelValues(t.Experiment, "", info)
+	metrics.FailCount.WithLabelValues(t.Experiment, t.Experiment, info)
 	if t.saver == nil {
 		return ErrNoSaver
 	}
@@ -330,8 +330,8 @@ type Terminator interface {
 
 // Process handles all steps of processing a task.
 func (t Task) Process(ctx context.Context, ex Executor, doneWithQueue func(), term Terminator) {
-	metrics.TasksInFlight.WithLabelValues(t.Experiment, "").Inc()
-	defer metrics.TasksInFlight.WithLabelValues(t.Experiment, "").Dec()
+	metrics.TasksInFlight.WithLabelValues(t.Experiment, t.Experiment).Inc()
+	defer metrics.TasksInFlight.WithLabelValues(t.Experiment, t.Experiment).Dec()
 loop:
 	for t.State != Done { //&& t.ErrMsg == "" {
 		select {
@@ -352,7 +352,7 @@ loop:
 	}
 	// Datatype may be incorporated into Experiment, but this is legacy path, and
 	// will be deprecated soon.
-	metrics.CompletedCount.WithLabelValues(t.Experiment, "").Inc()
+	metrics.CompletedCount.WithLabelValues(t.Experiment, t.Experiment).Inc()
 	if t.ErrMsg == "" {
 		// Only delete the state entry if it completed without error.
 		t.Delete(ctx)
@@ -360,7 +360,7 @@ loop:
 		// Datatype may be incorporated into Experiment, but this is legacy path, and
 		// will be deprecated soon.
 		// TODO Is this double counting?
-		metrics.FailCount.WithLabelValues(t.Experiment, "",
+		metrics.FailCount.WithLabelValues(t.Experiment, t.Experiment,
 			StateNames[t.State]+" Error").Inc()
 	}
 	term.Done()

--- a/state/state.go
+++ b/state/state.go
@@ -340,12 +340,14 @@ loop:
 			}
 		}
 	}
+	metrics.CompletedCount.WithLabelValues(t.Experiment, "").Inc()
 	if t.ErrMsg == "" {
 		// Only delete the state entry if it completed without error.
 		t.Delete(ctx)
-		metrics.CompletedCount.WithLabelValues("todo - add exp type").Inc()
 	} else {
-		metrics.CompletedCount.WithLabelValues(StateNames[t.State] + " Error").Inc()
+		// TODO Is this double counting?
+		metrics.FailCount.WithLabelValues(t.Experiment, "",
+			StateNames[t.State]+" Error").Inc()
 	}
 	term.Done()
 }

--- a/state/state.go
+++ b/state/state.go
@@ -221,7 +221,9 @@ func (t *Task) SourceAndDest(ds *dataset.Dataset) (bqiface.Table, bqiface.Table,
 	prefix, err := t.ParsePrefix()
 	if err != nil {
 		// If there is a parse error, log and skip request.
-		metrics.FailCount.WithLabelValues(ds.DatasetID(), "", "BadDedupPrefix")
+		// Datatype may be incorporated into Experiment, but this is legacy path, and
+		// will be deprecated soon.
+		metrics.FailCount.WithLabelValues(t.Experiment, "", "BadDedupPrefix")
 		return nil, nil, err
 	}
 
@@ -246,6 +248,8 @@ func (t *Task) Save(ctx context.Context) error {
 		return ErrNoSaver
 	}
 	t.UpdateTime = time.Now()
+	// Datatype may be incorporated into Experiment, but this is legacy path, and
+	// will be deprecated soon.
 	metrics.StateDate.WithLabelValues(t.Experiment, "", StateNames[t.State]).Set(float64(t.Date.Unix()))
 	return t.saver.SaveTask(ctx, *t)
 }
@@ -253,9 +257,13 @@ func (t *Task) Save(ctx context.Context) error {
 // Update updates the task state, and saves to the "saver".
 func (t *Task) Update(ctx context.Context, st State) error {
 	duration := time.Since(t.UpdateTime)
+	// Datatype may be incorporated into Experiment, but this is legacy path, and
+	// will be deprecated soon.
 	metrics.StateTimeHistogram.WithLabelValues(t.Experiment, "", StateNames[t.State]).Observe(duration.Seconds())
 	t.State = st
 	t.UpdateTime = time.Now()
+	// Datatype may be incorporated into Experiment, but this is legacy path, and
+	// will be deprecated soon.
 	metrics.StateDate.WithLabelValues(t.Experiment, "", StateNames[t.State]).Set(float64(t.Date.Unix()))
 	if t.saver == nil {
 		return ErrNoSaver
@@ -273,6 +281,8 @@ func (t *Task) Delete(ctx context.Context) error {
 
 // SetError adds error information and saves to the "saver"
 func (t *Task) SetError(ctx context.Context, err error, info string) error {
+	// Datatype may be incorporated into Experiment, but this is legacy path, and
+	// will be deprecated soon.
 	metrics.FailCount.WithLabelValues(t.Experiment, "", info)
 	if t.saver == nil {
 		return ErrNoSaver
@@ -340,11 +350,15 @@ loop:
 			}
 		}
 	}
+	// Datatype may be incorporated into Experiment, but this is legacy path, and
+	// will be deprecated soon.
 	metrics.CompletedCount.WithLabelValues(t.Experiment, "").Inc()
 	if t.ErrMsg == "" {
 		// Only delete the state entry if it completed without error.
 		t.Delete(ctx)
 	} else {
+		// Datatype may be incorporated into Experiment, but this is legacy path, and
+		// will be deprecated soon.
 		// TODO Is this double counting?
 		metrics.FailCount.WithLabelValues(t.Experiment, "",
 			StateNames[t.State]+" Error").Inc()

--- a/state/state.go
+++ b/state/state.go
@@ -221,7 +221,7 @@ func (t *Task) SourceAndDest(ds *dataset.Dataset) (bqiface.Table, bqiface.Table,
 	prefix, err := t.ParsePrefix()
 	if err != nil {
 		// If there is a parse error, log and skip request.
-		metrics.FailCount.WithLabelValues("BadDedupPrefix")
+		metrics.FailCount.WithLabelValues(ds.DatasetID(), "", "BadDedupPrefix")
 		return nil, nil, err
 	}
 
@@ -253,7 +253,7 @@ func (t *Task) Save(ctx context.Context) error {
 // Update updates the task state, and saves to the "saver".
 func (t *Task) Update(ctx context.Context, st State) error {
 	duration := time.Since(t.UpdateTime)
-	metrics.StateTimeHistogram.WithLabelValues(StateNames[t.State]).Observe(duration.Seconds())
+	metrics.StateTimeHistogram.WithLabelValues(t.Experiment, "", StateNames[t.State]).Observe(duration.Seconds())
 	t.State = st
 	t.UpdateTime = time.Now()
 	metrics.StateDate.WithLabelValues(t.Experiment, "", StateNames[t.State]).Set(float64(t.Date.Unix()))
@@ -273,7 +273,7 @@ func (t *Task) Delete(ctx context.Context) error {
 
 // SetError adds error information and saves to the "saver"
 func (t *Task) SetError(ctx context.Context, err error, info string) error {
-	metrics.FailCount.WithLabelValues(info)
+	metrics.FailCount.WithLabelValues(t.Experiment, "", info)
 	if t.saver == nil {
 		return ErrNoSaver
 	}
@@ -320,8 +320,8 @@ type Terminator interface {
 
 // Process handles all steps of processing a task.
 func (t Task) Process(ctx context.Context, ex Executor, doneWithQueue func(), term Terminator) {
-	metrics.TasksInFlight.Inc()
-	defer metrics.TasksInFlight.Dec()
+	metrics.TasksInFlight.WithLabelValues(t.Experiment, "").Inc()
+	defer metrics.TasksInFlight.WithLabelValues(t.Experiment, "").Dec()
 loop:
 	for t.State != Done { //&& t.ErrMsg == "" {
 		select {

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -454,6 +454,7 @@ func (tr *Tracker) GetStatus(job Job) (Status, error) {
 func (tr *Tracker) AddJob(job Job) error {
 	status := NewStatus()
 	status.UpdateTime = time.Now()
+	status.LastStateChangeTime = time.Now()
 
 	tr.lock.Lock()
 	defer tr.lock.Unlock()

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -367,6 +367,9 @@ func InitTracker(
 		log.Println(err, key)
 		jobMap = make(JobMap, 100)
 	}
+	for j := range jobMap {
+		metrics.TasksInFlight.WithLabelValues(j.Experiment).Inc()
+	}
 	t := Tracker{client: client, dsKey: key, lastModified: time.Now(), lastJob: lastJob, jobs: jobMap, expirationTime: expirationTime}
 	if client != nil && saveInterval > 0 {
 		t.saveEvery(saveInterval)

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -368,7 +368,7 @@ func InitTracker(
 		jobMap = make(JobMap, 100)
 	}
 	for j := range jobMap {
-		metrics.TasksInFlight.WithLabelValues(j.Experiment).Inc()
+		metrics.TasksInFlight.WithLabelValues(j.Experiment, j.Datatype).Inc()
 	}
 	t := Tracker{client: client, dsKey: key, lastModified: time.Now(), lastJob: lastJob, jobs: jobMap, expirationTime: expirationTime}
 	if client != nil && saveInterval > 0 {


### PR DESCRIPTION
This is 70% code tweaks to add experiment and datatype labels, and the remaining new code to impelement StartCount, FailCount, TasksInFlight, StateTimeHistogram in tracker and ops packages.

This will require updates to the dashboard to use the added labels correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/244)
<!-- Reviewable:end -->
