### PR TITLE
Initialize start date and index

### DIFF
--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -97,7 +97,22 @@ func NewJobService(tk *tracker.Tracker, bucket string, startDate time.Time) (*Se
 	specs := []tracker.JobWithTarget{j1, j2}
 
 	start := startDate.UTC().Truncate(24 * time.Hour)
-	return &Service{tracker: tk, startDate: start, date: start, jobSpecs: specs}, nil
+	date := start
+	index := 0
+	if tk != nil {
+		lastInit := tk.LastJob()
+		date := lastInit.Date
+		if lastInit == j1.Job {
+			index = 1
+		} else {
+			date = date.AddDate(0, 0, 1)
+		}
+		if date.Before(start) {
+			date = start
+			index = 0
+		}
+	}
+	return &Service{tracker: tk, startDate: start, date: date, nextIndex: index, jobSpecs: specs}, nil
 }
 
 func post(ctx context.Context, url url.URL) ([]byte, int, error) {

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -98,21 +98,21 @@ func NewJobService(tk *tracker.Tracker, bucket string, startDate time.Time) (*Se
 	specs := []tracker.JobWithTarget{j0, j1}
 
 	start := startDate.UTC().Truncate(24 * time.Hour)
-	resume := start // In case tk is nil
 	index := 0
 	if tk == nil {
+		resume := start
 		return &Service{tracker: tk, startDate: start, date: resume, nextIndex: index, jobSpecs: specs}, nil
 	}
 	lastJob := tk.LastJob()
 	log.Println("Last job was:", lastJob)
 	// TODO check for spec bucket change
-	resume = lastJob.Date
-	// Never resume before the specified start date.
+	resume := lastJob.Date
 	if resume.Before(start) {
+		// Never resume before the specified start date.
 		resume = start
 	}
 	// Ok to start here.  If there are repeated jobs, the job-service will skip
-	// them.  If they are already resolved, then ok to repeat them.
+	// them.  If they are already finished, then ok to repeat them, though a little inefficient.
 	svc := Service{tracker: tk, startDate: start, date: resume, nextIndex: index, jobSpecs: specs}
 	return &svc, nil
 }

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -76,6 +76,7 @@ func (svc *Service) JobHandler(resp http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	log.Println("Dispatching", job.Job)
 	_, err := resp.Write(job.Marshal())
 	if err != nil {
 		log.Println(err)
@@ -101,6 +102,7 @@ func NewJobService(tk *tracker.Tracker, bucket string, startDate time.Time) (*Se
 	index := 0
 	if tk != nil {
 		lastInit := tk.LastJob()
+		log.Println("Last job was:", lastInit)
 		date := lastInit.Date
 		if lastInit == j1.Job {
 			index = 1

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -541,3 +541,8 @@ func (tr *Tracker) WriteHTMLStatusTo(ctx context.Context, w io.Writer) error {
 
 	return jobs.WriteHTML(w)
 }
+
+// LastJob returns the last Job successfully added with AddJob
+func (tr *Tracker) LastJob() Job {
+	return tr.lastInit
+}

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -331,8 +331,8 @@ type Tracker struct {
 	lastModified time.Time
 
 	// These are the stored values.
-	lastInit Job    // The last job that was initialized.
-	jobs     JobMap // Map from Job to Status.
+	lastJob Job    // The last job that was added/initialized.
+	jobs    JobMap // Map from Job to Status.
 
 	// Time after which stale job should be ignored or replaced.
 	expirationTime time.Duration
@@ -345,12 +345,12 @@ func InitTracker(
 	client dsiface.Client, key *datastore.Key,
 	saveInterval time.Duration, expirationTime time.Duration) (*Tracker, error) {
 
-	jobMap, lastInit, err := loadJobMap(ctx, client, key)
+	jobMap, lastJob, err := loadJobMap(ctx, client, key)
 	if err != nil {
 		log.Println(err, key)
 		jobMap = make(JobMap, 100)
 	}
-	t := Tracker{client: client, dsKey: key, lastModified: time.Now(), lastInit: lastInit, jobs: jobMap, expirationTime: expirationTime}
+	t := Tracker{client: client, dsKey: key, lastModified: time.Now(), lastJob: lastJob, jobs: jobMap, expirationTime: expirationTime}
 	if client != nil && saveInterval > 0 {
 		t.saveEvery(saveInterval)
 	}
@@ -441,7 +441,7 @@ func (tr *Tracker) AddJob(job Job) error {
 		return ErrJobAlreadyExists
 	}
 
-	tr.lastInit = job
+	tr.lastJob = job
 	tr.lastModified = time.Now()
 	// TODO - should call this JobsInFlight, to avoid confusion with Tasks in parser.
 	metrics.TasksInFlight.Inc()
@@ -527,7 +527,7 @@ func (tr *Tracker) GetState() (JobMap, Job, time.Time) {
 			m[k] = v
 		}
 	}
-	return m, tr.lastInit, tr.lastModified
+	return m, tr.lastJob, tr.lastModified
 }
 
 // WriteHTMLStatusTo writes out the status of all jobs to the html writer.
@@ -544,5 +544,5 @@ func (tr *Tracker) WriteHTMLStatusTo(ctx context.Context, w io.Writer) error {
 
 // LastJob returns the last Job successfully added with AddJob
 func (tr *Tracker) LastJob() Job {
-	return tr.lastInit
+	return tr.lastJob
 }


### PR DESCRIPTION
This properly initializes the start date and index to pick up where the previous instance left off.
Because the state is only written to datastore periodically, this may repeat one or two jobs.  May need to do some additional work if concurrent identical parse jobs cause conflicts in gardener reporting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/245)
<!-- Reviewable:end -->
