### PR TITLE
Add dedup action for tcpinfo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ deploy:
 
 - provider: script
   script:
-    TARGET_BASE="gs://etl-mlab-sandbox"
+    TARGET_BASE="mlab-sandbox"
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing ./apply-cluster.sh
   skip_cleanup: true
   on:
@@ -143,7 +143,7 @@ deploy:
   script:
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing-cluster ./apply-cluster.sh
     &&
-    TARGET_BASE="gs://etl-mlab-staging"
+    TARGET_BASE="mlab-staging"
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-staging data-processing ./apply-cluster.sh
   on:
     repo: m-lab/etl-gardener

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,89 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/m-lab/go/logx"
+
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+// ErrMoreJSON is returned
+var ErrMoreJSON = errors.New("JSON body not completely consumed")
+
+var decodeLogEvery = logx.NewLogEvery(nil, 30*time.Second)
+
+// ClientErrorTotal measures the different type of RPC client errors.
+var ClientErrorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "gardener_client_error_total",
+	Help: "The total number client annotation RPC errors.",
+}, []string{"type"})
+
+func post(ctx context.Context, url url.URL) ([]byte, int, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	req, reqErr := http.NewRequestWithContext(ctx, "POST", url.String(), nil)
+	if reqErr != nil {
+		return nil, 0, reqErr
+	}
+	resp, postErr := http.DefaultClient.Do(req)
+	if postErr != nil {
+		return nil, 0, postErr // Documentation says we can ignore body.
+	}
+
+	// Guaranteed to have a non-nil response and body.
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body) // Documentation recommends reading body.
+	return b, resp.StatusCode, err
+}
+
+// NextJob is used by clients to get a new job from Gardener.
+func NextJob(ctx context.Context, base url.URL) (tracker.JobWithTarget, error) {
+	jobURL := base
+	jobURL.Path = "job"
+
+	job := tracker.JobWithTarget{}
+
+	b, status, err := post(ctx, jobURL)
+	if err != nil {
+		return job, err
+	}
+	if status != http.StatusOK {
+		return job, errors.New(http.StatusText(status))
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.DisallowUnknownFields()
+
+	err = decoder.Decode(&job)
+	if err != nil {
+		// TODO add metric, but in the correct namespace???
+		// When this happens, it is likely to be very spammy.
+		decodeLogEvery.Println("Decode error:", err)
+
+		// Try again but ignore unknown fields.
+		decoder = json.NewDecoder(bytes.NewReader(b))
+		err = decoder.Decode(&job)
+		if err != nil {
+			// This is a more serious error.
+			log.Println(err)
+			ClientErrorTotal.WithLabelValues("json decode error").Inc()
+			return job, err
+		}
+		if decoder.More() {
+			decodeLogEvery.Println("Decode error:", ErrMoreJSON)
+		}
+	}
+	return job, err
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,89 @@
+package client_test
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m-lab/etl-gardener/client"
+	"github.com/m-lab/etl-gardener/tracker"
+	"github.com/m-lab/go/rtx"
+)
+
+type fakeGardener struct {
+	t *testing.T // for logging
+
+	lock       sync.Mutex
+	jobs       []tracker.JobWithTarget
+	heartbeats int
+	updates    int
+}
+
+func (g *fakeGardener) AddJob(job tracker.Job, target string) error {
+	jt, err := job.Target(target)
+	if err != nil {
+		return err
+	}
+	g.jobs = append(g.jobs, jt)
+	return nil
+}
+
+func (g *fakeGardener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rtx.Must(r.ParseForm(), "bad request")
+	if r.Method != http.MethodPost {
+		log.Fatal("Should be POST") // Not t.Fatal because this is asynchronous.
+	}
+	g.lock.Lock()
+	g.lock.Unlock()
+	switch r.URL.Path {
+	case "/job":
+		if len(g.jobs) < 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		j := g.jobs[0]
+		g.jobs = g.jobs[1:]
+		w.Write(j.Marshal())
+	case "/heartbeat":
+		g.t.Log(r.URL.Path, r.URL.Query())
+		g.heartbeats++
+
+	case "/update":
+		g.t.Log(r.URL.Path, r.URL.Query())
+		g.updates++
+
+	default:
+		log.Fatal(r.URL) // Not t.Fatal because this is asynchronous.
+	}
+}
+func TestJobClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// set up a fake gardener service.
+	fg := fakeGardener{t: t, jobs: make([]tracker.JobWithTarget, 0)}
+	spec := tracker.NewJob(
+		"foobar", "ndt", "ndt5", time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC))
+	rtx.Must(fg.AddJob(spec, "a.b.c"), "add job")
+	gardener := httptest.NewServer(&fg)
+	defer gardener.Close()
+	gURL, err := url.Parse(gardener.URL)
+	rtx.Must(err, "bad url")
+
+	j, err := client.NextJob(ctx, *gURL)
+	rtx.Must(err, "next job")
+
+	if j.Path() != "gs://foobar/ndt/ndt5/2019/01/01/" {
+		t.Error(j.Path())
+	}
+
+	j, err = client.NextJob(ctx, *gURL)
+	if err.Error() != "Internal Server Error" {
+		t.Fatal("Should be internal server error", err)
+	}
+}

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -42,6 +42,7 @@ import (
 
 var (
 	jobExpirationTime = flag.Duration("job_expiration_time", 24*time.Hour, "Time after which stale jobs will be purged")
+	jobCleanupDelay   = flag.Duration("job_cleanup_delay", 1*time.Hour, "Time after which completed jobs will be removed from tracker")
 	shutdownTimeout   = flag.Duration("shutdown_timeout", 1*time.Minute, "Graceful shutdown time allowance")
 	statusPort        = flag.String("status_port", ":0", "The public interface port where status (and pprof) will be published")
 
@@ -311,7 +312,7 @@ func mustStandardTracker() *tracker.Tracker {
 	tk, err := tracker.InitTracker(
 		context.Background(),
 		dsiface.AdaptClient(client), dsKey,
-		time.Minute, *jobExpirationTime)
+		time.Minute, *jobExpirationTime, *jobCleanupDelay)
 	rtx.Must(err, "tracker init")
 	if tk == nil {
 		log.Fatal("nil tracker")

--- a/dedup/dedup.go
+++ b/dedup/dedup.go
@@ -62,13 +62,13 @@ func (params QueryParams) String() string {
 	return out.String()
 }
 
-func tcpinfoQuery(job tracker.Job, project string) string {
+func TCPInfoQuery(job tracker.Job, project string) QueryParams {
 	return QueryParams{
 		Project: project,
 		Job:     job,
 		Key:     "uuid",
 		Order:   "ARRAY_LENGTH(Snapshots) DESC, ParseInfo.TaskFileName, ParseInfo.ParseTime DESC",
-	}.String()
+	}
 }
 
 // Dedup executes a query that deletes duplicates from the destination table.

--- a/dedup/dedup.go
+++ b/dedup/dedup.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"html/template"
+	"log"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
@@ -26,49 +27,62 @@ var dedupTemplate = template.Must(template.New("").Parse(`
 # The query is very cheap if there are no duplicates.
 DELETE
 FROM ` + table + ` AS target
-  WHERE Date(TestTime) = "{{.Job.Date.Format "2006-01-02"}}"
+  WHERE Date({{.TestTime}}) = "{{.Job.Date.Format "2006-01-02"}}"
   # This identifies all rows that don't match rows to preserve.
   AND NOT EXISTS (
     # This creates list of rows to preserve, based on key and priority.
     WITH keep AS (
     SELECT * EXCEPT(row_number) FROM (
-      SELECT {{.Key}}, ParseInfo.ParseTime,
-        ROW_NUMBER() OVER (PARTITION BY {{.Key}} ORDER BY {{.Order}}) row_number
+      SELECT
+        {{range $k, $v := .Partition}}{{$v}}, {{end}}
+        {{range $k, $v := .Select}}{{$v}}, {{end}}
+        ROW_NUMBER() OVER (
+          PARTITION BY {{range $k, $v := .Partition}}{{$v}}, {{end}}TRUE
+          ORDER BY {{.Order}}
+        ) row_number
         FROM (
           SELECT * FROM ` + table + `
-          WHERE Date(TestTime) = "{{.Job.Date.Format "2006-01-02"}}"
+          WHERE Date({{.TestTime}}) = "{{.Job.Date.Format "2006-01-02"}}"
         )
       )
       WHERE row_number = 1
     )
     SELECT * FROM keep
-    # This matches against the keep table based on key and parsetime, so it should retain
-    # only the rows that were selected in the keep table.  Parsetime is used in lieu of
-    # any other distinguishing traits that create different row numbers in the keep query.
-    # Without the parsetime, it keeps all the rows.
-    WHERE target.{{.Key}} = keep.{{.Key}} AND target.ParseInfo.ParseTime = keep.ParseTime
+    # This matches against the keep table based on keys.  Sufficient select keys must be
+    # used to distinguish the preferred row from the others.
+    WHERE
+      {{range $k, $v := .Partition}}target.{{$v}} = keep.{{$k}} AND {{end}}
+      {{range $k, $v := .Select}}target.{{$v}} = keep.{{$k}} AND {{end}}TRUE
   )`))
 
 // QueryParams is used to construct a dedup query.
 type QueryParams struct {
-	Project string
-	Job     tracker.Job
-	Key     string
-	Order   string
+	Project  string
+	TestTime string // Name of the partition field
+	Job      tracker.Job
+	// map key is the single field name, value is fully qualified name
+	Partition map[string]string
+	Order     string
+	Select    map[string]string // Derived from Order.
 }
 
 func (params QueryParams) String() string {
 	out := bytes.NewBuffer(nil)
-	dedupTemplate.Execute(out, params)
+	err := dedupTemplate.Execute(out, params)
+	if err != nil {
+		log.Println(err)
+	}
 	return out.String()
 }
 
 func TCPInfoQuery(job tracker.Job, project string) QueryParams {
 	return QueryParams{
-		Project: project,
-		Job:     job,
-		Key:     "uuid",
-		Order:   "ARRAY_LENGTH(Snapshots) DESC, ParseInfo.TaskFileName, ParseInfo.ParseTime DESC",
+		Project:   project,
+		TestTime:  "TestTime",
+		Job:       job,
+		Partition: map[string]string{"uuid": "uuid", "Timestamp": "FinalSnapshot.Timestamp"},
+		Order:     "ARRAY_LENGTH(Snapshots) DESC, ParseInfo.TaskFileName, ParseInfo.ParseTime DESC",
+		Select:    map[string]string{"ParseTime": "ParseInfo.ParseTime"},
 	}
 }
 

--- a/dedup/dedup.go
+++ b/dedup/dedup.go
@@ -15,9 +15,8 @@ import (
 	"github.com/m-lab/etl-gardener/tracker"
 )
 
-// TODO remove _tmp when we are ready to transition.
-// TODO update to use _tmp once tables are copied.
-const table = "`{{.Project}}.{{.Job.Experiment}}_raw.{{.Job.Datatype}}`"
+// TODO get the tmp_ from the job Target.
+const table = "`{{.Project}}.tmp_{{.Job.Experiment}}.{{.Job.Datatype}}`"
 
 var dedupTemplate = template.Must(template.New("").Parse(`
 #standardSQL

--- a/dedup/dedup.go
+++ b/dedup/dedup.go
@@ -3,28 +3,35 @@ package dedup
 
 import (
 	"bytes"
+	"context"
 	"html/template"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
+
+	"github.com/m-lab/go/dataset"
 
 	"github.com/m-lab/etl-gardener/tracker"
 )
 
 // TODO remove _tmp when we are ready to transition.
-const table = "`{{.Project}}.{{.Job.Experiment}}_tmp.{{.Job.Datatype}}`"
+const table = "`{{.Project}}.{{.Job.Experiment}}_raw.{{.Job.Datatype}}`"
 
 var dedupTemplate = template.Must(template.New("").Parse(`
 #standardSQL
 # Delete all duplicate rows based on key and prefered priority ordering.
 # This is resource intensive for tcpinfo - 20 slot hours for 12M rows with 250M snapshots,
 # roughly proportional to the memory footprint of the table partition.
+# The query is very cheap if there are no duplicates.
 DELETE
 FROM ` + table + ` AS target
   WHERE Date(TestTime) = "{{.Job.Date.Format "2006-01-02"}}"
   # This identifies all rows that don't match rows to preserve.
   AND NOT EXISTS (
-	# This creates list of rows to preserve, based on key and priority.
+    # This creates list of rows to preserve, based on key and priority.
     WITH keep AS (
     SELECT * EXCEPT(row_number) FROM (
-      SELECT {{.Key}}, ParseInfo.ParseTime
+      SELECT {{.Key}}, ParseInfo.ParseTime,
         ROW_NUMBER() OVER (PARTITION BY {{.Key}} ORDER BY {{.Order}}) row_number
         FROM (
           SELECT * FROM ` + table + `
@@ -33,11 +40,11 @@ FROM ` + table + ` AS target
       )
       WHERE row_number = 1
     )
-	SELECT * FROM keep
-	# This matches against the keep table based on key and parsetime, so it should retain
-	# only the rows that were selected in the keep table.  Parsetime is used in lieu of
-	# any other distinguishing traits that create different row numbers in the keep query.
-	# Without the parsetime, it keeps all the rows.
+    SELECT * FROM keep
+    # This matches against the keep table based on key and parsetime, so it should retain
+    # only the rows that were selected in the keep table.  Parsetime is used in lieu of
+    # any other distinguishing traits that create different row numbers in the keep query.
+    # Without the parsetime, it keeps all the rows.
     WHERE target.{{.Key}} = keep.{{.Key}} AND target.ParseInfo.ParseTime = keep.ParseTime
   )`))
 
@@ -62,4 +69,21 @@ func tcpinfoQuery(job tracker.Job, project string) string {
 		Key:     "uuid",
 		Order:   "ARRAY_LENGTH(Snapshots) DESC, ParseInfo.TaskFileName, ParseInfo.ParseTime DESC",
 	}.String()
+}
+
+// Dedup executes a query that deletes duplicates from the destination table.
+// It derives the table name from the dsExt project and the job fields.
+// TODO add cost accounting to status page?
+// TODO inject fake bqclient for testing?
+func (params QueryParams) Dedup(ctx context.Context) (bqiface.Job, error) {
+	c, err := bigquery.NewClient(ctx, params.Project)
+	if err != nil {
+		return nil, err
+	}
+	bqClient := bqiface.AdaptClient(c)
+	q := bqClient.Query(params.String())
+	if q == nil {
+		return nil, dataset.ErrNilQuery
+	}
+	return q.Run(ctx)
 }

--- a/dedup/dedup.go
+++ b/dedup/dedup.go
@@ -15,6 +15,7 @@ import (
 )
 
 // TODO remove _tmp when we are ready to transition.
+// TODO update to use _tmp once tables are copied.
 const table = "`{{.Project}}.{{.Job.Experiment}}_raw.{{.Job.Datatype}}`"
 
 var dedupTemplate = template.Must(template.New("").Parse(`

--- a/dedup/dedup_test.go
+++ b/dedup/dedup_test.go
@@ -25,7 +25,6 @@ func TestTemplate(t *testing.T) {
 	if !strings.Contains(q, "target.ParseInfo.ParseTime = keep.ParseTime AND") {
 		t.Error("query should contain target.ParseInfo.ParseTime = ... :\n", q)
 	}
-	t.Error(q)
 }
 
 // This runs a real dedup on a real partition in mlab-sandbox for manual testing.

--- a/dedup/dedup_test.go
+++ b/dedup/dedup_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestTemplate(t *testing.T) {
-	job := tracker.NewJob("bucket", "exp", "type", time.Date(2019, 3, 4, 0, 0, 0, 0, time.UTC))
+	job := tracker.NewJob("bucket", "ndt", "tcpinfo", time.Date(2019, 3, 4, 0, 0, 0, 0, time.UTC))
 	q := TCPInfoQuery(job, "mlab-sandbox").String()
 	if !strings.Contains(q, "uuid") {
 		t.Error("query should contain keep.uuid:\n", q)
@@ -21,6 +21,11 @@ func TestTemplate(t *testing.T) {
 	if !strings.Contains(q, "ParseInfo.TaskFileName") {
 		t.Error("query should contain ParseInfo.TaskFileName:\n", q)
 	}
+	// TODO check final WHERE clause.
+	if !strings.Contains(q, "target.ParseInfo.ParseTime = keep.ParseTime AND") {
+		t.Error("query should contain target.ParseInfo.ParseTime = ... :\n", q)
+	}
+	t.Error(q)
 }
 
 // This runs a real dedup on a real partition in mlab-sandbox for manual testing.
@@ -28,10 +33,12 @@ func TestTemplate(t *testing.T) {
 func xTestDedup(t *testing.T) {
 	job := tracker.NewJob("foobar", "ndt", "tcpinfo", time.Date(2019, 8, 12, 0, 0, 0, 0, time.UTC))
 	qp := QueryParams{
-		Project: "mlab-sandbox",
-		Job:     job,
-		Key:     "uuid",
-		Order:   "ARRAY_LENGTH(Snapshots) DESC, ParseInfo.TaskFileName, ParseInfo.ParseTime DESC",
+		Project:   "mlab-sandbox",
+		TestTime:  "TestTime",
+		Job:       job,
+		Partition: map[string]string{"uuid": "uuid", "ParseTime": "ParseInfo.ParseTime"},
+		Order:     "ARRAY_LENGTH(Snapshots) DESC, ParseInfo.TaskFileName, ParseInfo.ParseTime DESC",
+		Select:    map[string]string{"ParseTime": "ParseInfo.ParseTime"},
 	}
 	bqjob, err := qp.Dedup(context.Background())
 	if err != nil {

--- a/dedup/dedup_test.go
+++ b/dedup/dedup_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestTemplate(t *testing.T) {
 	job := tracker.NewJob("bucket", "exp", "type", time.Date(2019, 3, 4, 0, 0, 0, 0, time.UTC))
-	q := tcpinfoQuery(job, "mlab-sandbox")
+	q := TCPInfoQuery(job, "mlab-sandbox").String()
 	if !strings.Contains(q, "uuid") {
 		t.Error("query should contain keep.uuid:\n", q)
 	}

--- a/dedup/dedup_test.go
+++ b/dedup/dedup_test.go
@@ -1,6 +1,7 @@
 package dedup
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -20,4 +21,25 @@ func TestTemplate(t *testing.T) {
 	if !strings.Contains(q, "ParseInfo.TaskFileName") {
 		t.Error("query should contain ParseInfo.TaskFileName:\n", q)
 	}
+}
+
+// This runs a real dedup on a real partition in mlab-sandbox for manual testing.
+// It takes about 5 minutes to run.
+func xTestDedup(t *testing.T) {
+	job := tracker.NewJob("foobar", "ndt", "tcpinfo", time.Date(2019, 8, 12, 0, 0, 0, 0, time.UTC))
+	qp := QueryParams{
+		Project: "mlab-sandbox",
+		Job:     job,
+		Key:     "uuid",
+		Order:   "ARRAY_LENGTH(Snapshots) DESC, ParseInfo.TaskFileName, ParseInfo.ParseTime DESC",
+	}
+	bqjob, err := qp.Dedup(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := bqjob.Wait(context.Background())
+	if err != nil {
+		t.Fatal(err, qp.String())
+	}
+	t.Error(status)
 }

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -105,11 +105,10 @@ func NewJobService(tk *tracker.Tracker, bucket string, startDate time.Time) (*Se
 		j1, _ := tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "tcpinfo"}.Target(targetBase + "/ndt/tcpinfo")
 		specs = append(specs, j1)
 	} else {
-		j0, _ := tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "ndt5"}.Target(targetBase + ".ndt_raw.ndt5")
+		j0, _ := tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "ndt5"}.Target(targetBase + ".tmp_ndt.ndt5")
 		specs = append(specs, j0)
-		j1, _ := tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "tcpinfo"}.Target(targetBase + ".ndt_raw.tcpinfo")
+		j1, _ := tracker.Job{Bucket: bucket, Experiment: "ndt", Datatype: "tcpinfo"}.Target(targetBase + ".tmp_ndt.tcpinfo")
 		specs = append(specs, j1)
-
 	}
 
 	start := startDate.UTC().Truncate(24 * time.Hour)

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -7,18 +7,17 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
 	"bou.ke/monkey"
 	"github.com/go-test/deep"
-	"github.com/m-lab/etl-gardener/job-service"
-	jobservice "github.com/m-lab/etl-gardener/job-service"
-	"github.com/m-lab/etl-gardener/tracker"
+
 	"github.com/m-lab/go/rtx"
+
+	"github.com/m-lab/etl-gardener/job-service"
+	"github.com/m-lab/etl-gardener/tracker"
 )
 
 func init() {
@@ -35,7 +34,7 @@ func TestService_NextJob(t *testing.T) {
 	defer monkey.Unpatch(time.Now)
 
 	start := time.Date(2011, 2, 3, 5, 6, 7, 8, time.UTC)
-	svc, _ := jobservice.NewJobService(nil, "fake-bucket", start)
+	svc, _ := job.NewJobService(nil, "fake-bucket", start)
 	j := svc.NextJob()
 	w, err := tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Truncate(24 * time.Hour)}.Target("gs://fakebucket/ndt/ndt5")
 	rtx.Must(err, "")
@@ -161,79 +160,5 @@ func TestEarlyWrapping(t *testing.T) {
 				t.Error(err)
 			}
 		}
-	}
-}
-
-type fakeGardener struct {
-	t *testing.T // for logging
-
-	lock       sync.Mutex
-	jobs       []tracker.JobWithTarget
-	heartbeats int
-	updates    int
-}
-
-func (g *fakeGardener) AddJob(job tracker.Job, target string) error {
-	jt, err := job.Target(target)
-	if err != nil {
-		return err
-	}
-	g.jobs = append(g.jobs, jt)
-	return nil
-}
-
-func (g *fakeGardener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rtx.Must(r.ParseForm(), "bad request")
-	if r.Method != http.MethodPost {
-		log.Fatal("Should be POST") // Not t.Fatal because this is asynchronous.
-	}
-	g.lock.Lock()
-	g.lock.Unlock()
-	switch r.URL.Path {
-	case "/job":
-		if len(g.jobs) < 1 {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		j := g.jobs[0]
-		g.jobs = g.jobs[1:]
-		w.Write(j.Marshal())
-	case "/heartbeat":
-		g.t.Log(r.URL.Path, r.URL.Query())
-		g.heartbeats++
-
-	case "/update":
-		g.t.Log(r.URL.Path, r.URL.Query())
-		g.updates++
-
-	default:
-		log.Fatal(r.URL) // Not t.Fatal because this is asynchronous.
-	}
-}
-
-func TestJobClient(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// set up a fake gardener service.
-	fg := fakeGardener{t: t, jobs: make([]tracker.JobWithTarget, 0)}
-	spec := tracker.NewJob(
-		"foobar", "ndt", "ndt5", time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC))
-	rtx.Must(fg.AddJob(spec, "a.b.c"), "add job")
-	gardener := httptest.NewServer(&fg)
-	defer gardener.Close()
-	gURL, err := url.Parse(gardener.URL)
-	rtx.Must(err, "bad url")
-
-	j, err := jobservice.NextJob(ctx, *gURL)
-	rtx.Must(err, "next job")
-
-	if j.Path() != "gs://foobar/ndt/ndt5/2019/01/01/" {
-		t.Error(j.Path())
-	}
-
-	j, err = jobservice.NextJob(ctx, *gURL)
-	if err.Error() != "Internal Server Error" {
-		t.Fatal("Should be internal server error", err)
 	}
 }

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -98,7 +98,7 @@ func TestJobHandler(t *testing.T) {
 
 func TestResume(t *testing.T) {
 	start := time.Date(2011, 2, 3, 5, 6, 7, 8, time.UTC)
-	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0) // Only using jobmap.
+	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0, 0) // Only using jobmap.
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestEarlyWrapping(t *testing.T) {
 	})
 	defer monkey.Unpatch(time.Now)
 	start := time.Date(2011, 2, 3, 5, 6, 7, 8, time.UTC)
-	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0) // Only using jobmap.
+	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0, 0) // Only using jobmap.
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -53,7 +53,7 @@ spec:
         - name: STATUS_PORT
           value: ":8081"
         - name: JOB_EXPIRATION_TIME
-          value: "3h"
+          value: "6h"
         - name: SHUTDOWN_TIMEOUT
           value: "5m"
 

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -72,6 +72,12 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 		}
 		status, err := bqJob.Wait(ctx)
 		if err != nil {
+			log.Println(err)
+			// Try again soon.
+			return
+		}
+		if status.Err() != nil {
+			err := status.Err()
 			switch typedErr := err.(type) {
 			case *googleapi.Error:
 				if typedErr.Code == http.StatusBadRequest &&

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -112,8 +112,8 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 		return
 	}
 
-	s.State = tracker.Complete
 	metrics.StateDate.WithLabelValues(j.Experiment, j.Datatype, string(tracker.Complete)).Set(float64(j.Date.Unix()))
+	log.Println("Completed dedup for", j)
 	err := tk.SetStatus(j, tracker.Complete, "dedup took "+time.Since(start).Round(100*time.Millisecond).String())
 	if err != nil {
 		log.Println(err)

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"flag"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
+	"google.golang.org/api/googleapi"
 
 	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/dedup"
@@ -63,9 +65,25 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 		qp := dedup.TCPInfoQuery(j, os.Getenv("TARGET_BASE"))
 		bqJob, err := qp.Dedup(ctx)
 		if err != nil {
-			if err == state.ErrBQRateLimitExceeded {
-				return // Should try again
+			switch typedErr := err.(type) {
+			case *googleapi.Error:
+				if typedErr.Code == http.StatusBadRequest &&
+					strings.Contains(typedErr.Error(), "streaming buffer") {
+					// Wait a while and try again.
+					s.UpdateDetail = "Dedup waiting for empty streaming buffer."
+					tk.UpdateJob(j, s)
+					time.Sleep(5 * time.Minute)
+					return // Try again later.
+				}
+			default:
+				if err == state.ErrBQRateLimitExceeded {
+					s.UpdateDetail = "Dedup waiting because of BQ Rate Limit Exceeded."
+					tk.UpdateJob(j, s)
+					time.Sleep(5 * time.Minute)
+					return // Try again later.
+				}
 			}
+
 			log.Println(err)
 			tk.SetJobError(j, err.Error())
 			return

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -49,7 +49,8 @@ func NewStandardMonitor(ctx context.Context, config cloud.BQConfig, tk *tracker.
 		func(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker.Status) {
 			start := time.Now()
 			if j.Datatype == "tcpinfo" {
-				qp := dedup.TCPInfoQuery(j, os.Getenv("BQPROJECT"))
+				// TODO fix this HACK
+				qp := dedup.TCPInfoQuery(j, os.Getenv("TARGET_BASE"))
 				bqJob, err := qp.Dedup(ctx)
 				if err != nil {
 					if err == state.ErrBQRateLimitExceeded {

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -67,10 +67,10 @@ func NewStandardMonitor(ctx context.Context, config cloud.BQConfig, tk *tracker.
 				}
 				log.Println(status.Statistics)
 			} else if j.Datatype == "ndt5" {
-				err = tk.SetJobError(j, "dedup not implemented for ndt5")
+				tk.SetJobError(j, "dedup not implemented for ndt5")
 				return
 			} else {
-				err = tk.SetJobError(j, "unknown datatype")
+				tk.SetJobError(j, "unknown datatype")
 				return
 			}
 			s.State = tracker.Complete

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -58,12 +58,19 @@ func NewStandardMonitor(ctx context.Context, config cloud.BQConfig, tk *tracker.
 	return m, nil
 }
 
+// TODO figure out how to test this code?
 func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker.Status) {
 	start := time.Now()
 	if j.Datatype == "tcpinfo" {
 		// TODO fix this HACK
 		qp := dedup.TCPInfoQuery(j, os.Getenv("TARGET_BASE"))
 		bqJob, err := qp.Dedup(ctx)
+		if err != nil {
+			log.Println(err)
+			// Try again soon.
+			return
+		}
+		status, err := bqJob.Wait(ctx)
 		if err != nil {
 			switch typedErr := err.(type) {
 			case *googleapi.Error:
@@ -85,16 +92,11 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 			}
 
 			log.Println(err)
+			// This will terminate this job.
 			tk.SetJobError(j, err.Error())
 			return
 		}
-		status, err := bqJob.Wait(ctx)
-		if err != nil {
-			log.Println(err)
-			err = tk.SetJobError(j, "dedup failed"+err.Error())
-			return
-		}
-		log.Printf("%+v\n", status.Statistics.Details)
+		log.Printf("Dedup %s: %+v\n", j, status.Statistics.Details)
 	} else if j.Datatype == "ndt5" {
 		tk.SetJobError(j, "dedup not implemented for ndt5")
 		return
@@ -102,6 +104,7 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 		tk.SetJobError(j, "unknown datatype")
 		return
 	}
+
 	s.State = tracker.Complete
 	metrics.StateDate.WithLabelValues(j.Experiment, j.Datatype, string(tracker.Complete)).Set(float64(j.Date.Unix()))
 	err := tk.SetStatus(j, tracker.Complete, "dedup took "+time.Since(start).Round(100*time.Millisecond).String())

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -76,7 +76,7 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 			err = tk.SetJobError(j, "dedup failed"+err.Error())
 			return
 		}
-		log.Println(status.Statistics)
+		log.Printf("%+v\n", status.Statistics.Details)
 	} else if j.Datatype == "ndt5" {
 		tk.SetJobError(j, "dedup not implemented for ndt5")
 		return

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -102,6 +102,7 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 			tk.SetJobError(j, err.Error())
 			return
 		}
+		log.Println(status)
 		log.Printf("Dedup %s: %+v\n", j, status.Statistics.Details)
 	} else if j.Datatype == "ndt5" {
 		tk.SetJobError(j, "dedup not implemented for ndt5")

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -37,9 +37,10 @@ func TestStandardMonitor(t *testing.T) {
 	// The real dedup action should fail on unknown datatype.
 	go m.Watch(ctx, 10*time.Millisecond)
 
-	failTime := time.Now().Add(2 * time.Second)
+	failTime := time.Now().Add(10 * time.Second)
 
 	for time.Now().Before(failTime) && tk.NumFailed() < 3 {
+		time.Sleep(time.Millisecond)
 	}
 	if tk.NumFailed() != 3 {
 		t.Error(tk.NumFailed())

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -16,7 +16,7 @@ func TestStandardMonitor(t *testing.T) {
 	logx.LogxDebug.Set("true")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0)
+	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0, 0)
 	rtx.Must(err, "tk init")
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
 	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -5,47 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/bigquery"
-	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
 	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/ops"
 	"github.com/m-lab/etl-gardener/tracker"
-	"github.com/m-lab/go/dataset"
 	"github.com/m-lab/go/logx"
 	"github.com/m-lab/go/rtx"
-	"google.golang.org/api/option"
 )
-
-func TestTableUtils(t *testing.T) {
-	ctx := context.Background()
-
-	project := "fakeProject"
-	dryRun, _ := cloud.DryRunClient()
-	config := cloud.Config{
-		Project: project,
-		Client:  nil,
-		Options: []option.ClientOption{option.WithHTTPClient(dryRun)},
-	}
-	bqConfig := cloud.BQConfig{Config: config, BQFinalDataset: "final", BQBatchDataset: "batch"}
-
-	c, err := bigquery.NewClient(ctx, bqConfig.BQProject, bqConfig.Options...)
-	rtx.Must(err, "client")
-	bqClient := bqiface.AdaptClient(c)
-	ds := dataset.Dataset{Dataset: bqClient.Dataset(bqConfig.BQBatchDataset), BqClient: bqClient}
-
-	j := tracker.NewJob(
-		"bucket", "exp", "type", time.Date(2019, 12, 1, 0, 0, 0, 0, time.UTC))
-	src := ops.TemplateTable(j, &ds)
-	dest := ops.PartitionedTable(j, &ds)
-
-	if src.DatasetID() != "batch" {
-		t.Error(src)
-	}
-	if dest.DatasetID() != "batch" {
-		t.Error(src)
-	}
-
-}
 
 func TestStandardMonitor(t *testing.T) {
 	logx.LogxDebug.Set("true")
@@ -69,14 +34,10 @@ func TestStandardMonitor(t *testing.T) {
 		newStateFunc(tracker.ParseComplete),
 		"Parsing")
 
-	// Substitute, since we don't want to use real bq backend.
-	m.AddAction(tracker.Stabilizing,
-		nil,
-		newStateFunc(tracker.Deduplicating),
-		"Checking for stability")
+	// The real dedup action should fail on unknown datatype.
 	go m.Watch(ctx, 10*time.Millisecond)
 
-	failTime := time.Now().Add(10 * time.Second)
+	failTime := time.Now().Add(2 * time.Second)
 
 	for time.Now().Before(failTime) && tk.NumFailed() < 3 {
 	}

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -62,9 +62,9 @@ func TestMonitor_Watch(t *testing.T) {
 		nil,
 		newStateFunc(tracker.Complete),
 		"Deduplicating")
-	go m.Watch(ctx, 10*time.Millisecond)
+	go m.Watch(ctx, 50*time.Millisecond)
 
-	failTime := time.Now().Add(10 * time.Second)
+	failTime := time.Now().Add(5 * time.Second)
 
 	for time.Now().Before(failTime) && tk.NumJobs() > 0 {
 	}

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -34,7 +34,7 @@ func TestMonitor_Watch(t *testing.T) {
 	logx.LogxDebug.Set("true")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0)
+	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0, 0)
 	rtx.Must(err, "tk init")
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
 	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -27,7 +27,7 @@ func testSetup(t *testing.T) (url.URL, *tracker.Tracker, tracker.Job) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -146,9 +146,7 @@ const (
 	Joining       State = "joining"
 	Finishing     State = "finishing"
 	Failed        State = "failed"
-	// Note that GetStatus will never return Complete, as the
-	// Job is removed when SetJobState is called with Complete.
-	Complete State = "complete"
+	Complete      State = "complete"
 )
 
 // A Status describes the state of a bucket/exp/type/YYYY/MM/DD job.

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -359,6 +359,8 @@ type Tracker struct {
 
 	// Time after which stale job should be ignored or replaced.
 	expirationTime time.Duration
+	// Delay before removing Complete jobs.
+	cleanupDelay time.Duration
 }
 
 // InitTracker recovers the Tracker state from a Client object.
@@ -366,7 +368,7 @@ type Tracker struct {
 func InitTracker(
 	ctx context.Context,
 	client dsiface.Client, key *datastore.Key,
-	saveInterval time.Duration, expirationTime time.Duration) (*Tracker, error) {
+	saveInterval time.Duration, expirationTime time.Duration, cleanupDelay time.Duration) (*Tracker, error) {
 
 	jobMap, lastJob, err := loadJobMap(ctx, client, key)
 	if err != nil {
@@ -377,7 +379,10 @@ func InitTracker(
 		metrics.StartedCount.WithLabelValues(j.Experiment, j.Datatype).Inc()
 		metrics.TasksInFlight.WithLabelValues(j.Experiment, j.Datatype).Inc()
 	}
-	t := Tracker{client: client, dsKey: key, lastModified: time.Now(), lastJob: lastJob, jobs: jobMap, expirationTime: expirationTime}
+	t := Tracker{
+		client: client, dsKey: key, lastModified: time.Now(),
+		lastJob: lastJob, jobs: jobMap,
+		expirationTime: expirationTime, cleanupDelay: cleanupDelay}
 	if client != nil && saveInterval > 0 {
 		t.saveEvery(saveInterval)
 	}
@@ -491,9 +496,11 @@ func (tr *Tracker) UpdateJob(job Job, state Status) error {
 
 	tr.lastModified = time.Now()
 	if state.isDone() {
-		delete(tr.jobs, job)
 		metrics.CompletedCount.WithLabelValues(job.Experiment, job.Datatype).Inc()
 		metrics.TasksInFlight.WithLabelValues(job.Experiment, job.Datatype).Dec()
+		if tr.cleanupDelay == 0 {
+			delete(tr.jobs, job)
+		}
 	} else {
 		tr.jobs[job] = state
 	}
@@ -564,7 +571,8 @@ func (tr *Tracker) GetState() (JobMap, Job, time.Time) {
 	defer tr.lock.Unlock()
 	m := make(JobMap, len(tr.jobs))
 	for j, s := range tr.jobs {
-		if tr.expirationTime > 0 && time.Since(s.UpdateTime) > tr.expirationTime {
+		if (tr.expirationTime > 0 && time.Since(s.UpdateTime) > tr.expirationTime) ||
+			s.isDone() && time.Since(s.UpdateTime) > tr.cleanupDelay {
 			// Remove any obsolete jobs.
 			metrics.CompletedCount.WithLabelValues(j.Experiment, j.Datatype).Inc()
 			metrics.TasksInFlight.WithLabelValues(j.Experiment, j.Datatype).Dec()

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -570,7 +570,7 @@ func (tr *Tracker) GetState() (JobMap, Job, time.Time) {
 	m := make(JobMap, len(tr.jobs))
 	for j, s := range tr.jobs {
 		if (tr.expirationTime > 0 && time.Since(s.UpdateTime) > tr.expirationTime) ||
-			s.isDone() && time.Since(s.UpdateTime) > tr.cleanupDelay {
+			(s.isDone() && time.Since(s.UpdateTime) > tr.cleanupDelay) {
 			// Remove any obsolete jobs.
 			metrics.CompletedCount.WithLabelValues(j.Experiment, j.Datatype).Inc()
 			metrics.TasksInFlight.WithLabelValues(j.Experiment, j.Datatype).Dec()

--- a/tracker/tracker_integration_test.go
+++ b/tracker/tracker_integration_test.go
@@ -27,7 +27,7 @@ func TestWithDatastore(t *testing.T) {
 	// quite a while to propogate.
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")
@@ -43,7 +43,7 @@ func TestWithDatastore(t *testing.T) {
 	_, err = tk.Sync(time.Time{})
 	must(t, err)
 	// Check that the sync (and InitTracker) work.
-	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 
 	if restore.NumJobs() != 500 {

--- a/tracker/tracker_race_test.go
+++ b/tracker/tracker_race_test.go
@@ -32,7 +32,7 @@ func TestConcurrentUpdates(t *testing.T) {
 
 	// For testing, push to the saver every 5 milliseconds.
 	saverInterval := 5 * time.Millisecond
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, saverInterval, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, saverInterval, 0, 0)
 	must(t, err)
 
 	jobs := 20
@@ -76,7 +76,7 @@ func TestConcurrentUpdates(t *testing.T) {
 	if testing.Verbose() {
 		_, err := tk.Sync(time.Time{})
 		must(t, err)
-		restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+		restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 		must(t, err)
 
 		status, _, _ := restore.GetState()

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -102,7 +102,7 @@ func TestTrackerAddDelete(t *testing.T) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")
@@ -119,7 +119,7 @@ func TestTrackerAddDelete(t *testing.T) {
 		must(t, err)
 	}
 	// Check that the sync (and InitTracker) work.
-	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 
 	if restore.NumJobs() != 500 {
@@ -150,7 +150,7 @@ func TestUpdate(t *testing.T) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 
 	createJobs(t, tk, "JobToUpdate", "type", 1)
@@ -190,7 +190,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 
 	job := tracker.Job{}
@@ -221,7 +221,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 }
 
 func TestJobMapHTML(t *testing.T) {
-	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0, 0)
 	must(t, err)
 
 	job := tracker.Job{}
@@ -246,7 +246,7 @@ func TestExpiration(t *testing.T) {
 	defer must(t, cleanup(client, dsKey))
 
 	// Expire jobs after 1 second of monkey time.
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 5*time.Millisecond, 10*time.Millisecond)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 5*time.Millisecond, 10*time.Millisecond, 1*time.Millisecond)
 	must(t, err)
 
 	job := tracker.NewJob("bucket", "exp", "type", startDate)


### PR DESCRIPTION
This adds a dedup action, using DML DELETE, for tcpinfo tables.
It uses a template with enough flexibility to handle dedup for other datatypes in future PRs.

Note:  DML DELETE fails immediately if the partition has rows in the streaming buffer.  Not clear whether this is good, or whether we will want to move back to a dedup query that writes to a separate table, and includes rows in the streaming buffer.  That might be more expensive as there may be a LOT of rows in the streaming buffer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/248)
<!-- Reviewable:end -->
