### PR TITLE
Refactor NextJob to client.NextJob

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,89 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/m-lab/go/logx"
+
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+// ErrMoreJSON is returned
+var ErrMoreJSON = errors.New("JSON body not completely consumed")
+
+var decodeLogEvery = logx.NewLogEvery(nil, 30*time.Second)
+
+// ClientErrorTotal measures the different type of RPC client errors.
+var ClientErrorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "gardener_client_error_total",
+	Help: "The total number client annotation RPC errors.",
+}, []string{"type"})
+
+func post(ctx context.Context, url url.URL) ([]byte, int, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	req, reqErr := http.NewRequestWithContext(ctx, "POST", url.String(), nil)
+	if reqErr != nil {
+		return nil, 0, reqErr
+	}
+	resp, postErr := http.DefaultClient.Do(req)
+	if postErr != nil {
+		return nil, 0, postErr // Documentation says we can ignore body.
+	}
+
+	// Guaranteed to have a non-nil response and body.
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body) // Documentation recommends reading body.
+	return b, resp.StatusCode, err
+}
+
+// NextJob is used by clients to get a new job from Gardener.
+func NextJob(ctx context.Context, base url.URL) (tracker.JobWithTarget, error) {
+	jobURL := base
+	jobURL.Path = "job"
+
+	job := tracker.JobWithTarget{}
+
+	b, status, err := post(ctx, jobURL)
+	if err != nil {
+		return job, err
+	}
+	if status != http.StatusOK {
+		return job, errors.New(http.StatusText(status))
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.DisallowUnknownFields()
+
+	err = decoder.Decode(&job)
+	if err != nil {
+		// TODO add metric, but in the correct namespace???
+		// When this happens, it is likely to be very spammy.
+		decodeLogEvery.Println("Decode error:", err)
+
+		// Try again but ignore unknown fields.
+		decoder = json.NewDecoder(bytes.NewReader(b))
+		err = decoder.Decode(&job)
+		if err != nil {
+			// This is a more serious error.
+			log.Println(err)
+			ClientErrorTotal.WithLabelValues("json decode error").Inc()
+			return job, err
+		}
+		if decoder.More() {
+			decodeLogEvery.Println("Decode error:", ErrMoreJSON)
+		}
+	}
+	return job, err
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,89 @@
+package client_test
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m-lab/etl-gardener/client"
+	"github.com/m-lab/etl-gardener/tracker"
+	"github.com/m-lab/go/rtx"
+)
+
+type fakeGardener struct {
+	t *testing.T // for logging
+
+	lock       sync.Mutex
+	jobs       []tracker.JobWithTarget
+	heartbeats int
+	updates    int
+}
+
+func (g *fakeGardener) AddJob(job tracker.Job, target string) error {
+	jt, err := job.Target(target)
+	if err != nil {
+		return err
+	}
+	g.jobs = append(g.jobs, jt)
+	return nil
+}
+
+func (g *fakeGardener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rtx.Must(r.ParseForm(), "bad request")
+	if r.Method != http.MethodPost {
+		log.Fatal("Should be POST") // Not t.Fatal because this is asynchronous.
+	}
+	g.lock.Lock()
+	g.lock.Unlock()
+	switch r.URL.Path {
+	case "/job":
+		if len(g.jobs) < 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		j := g.jobs[0]
+		g.jobs = g.jobs[1:]
+		w.Write(j.Marshal())
+	case "/heartbeat":
+		g.t.Log(r.URL.Path, r.URL.Query())
+		g.heartbeats++
+
+	case "/update":
+		g.t.Log(r.URL.Path, r.URL.Query())
+		g.updates++
+
+	default:
+		log.Fatal(r.URL) // Not t.Fatal because this is asynchronous.
+	}
+}
+func TestJobClient(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// set up a fake gardener service.
+	fg := fakeGardener{t: t, jobs: make([]tracker.JobWithTarget, 0)}
+	spec := tracker.NewJob(
+		"foobar", "ndt", "ndt5", time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC))
+	rtx.Must(fg.AddJob(spec, "a.b.c"), "add job")
+	gardener := httptest.NewServer(&fg)
+	defer gardener.Close()
+	gURL, err := url.Parse(gardener.URL)
+	rtx.Must(err, "bad url")
+
+	j, err := client.NextJob(ctx, *gURL)
+	rtx.Must(err, "next job")
+
+	if j.Path() != "gs://foobar/ndt/ndt5/2019/01/01/" {
+		t.Error(j.Path())
+	}
+
+	j, err = client.NextJob(ctx, *gURL)
+	if err.Error() != "Internal Server Error" {
+		t.Fatal("Should be internal server error", err)
+	}
+}

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -7,18 +7,17 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
 	"bou.ke/monkey"
 	"github.com/go-test/deep"
-	"github.com/m-lab/etl-gardener/job-service"
-	jobservice "github.com/m-lab/etl-gardener/job-service"
-	"github.com/m-lab/etl-gardener/tracker"
+
 	"github.com/m-lab/go/rtx"
+
+	"github.com/m-lab/etl-gardener/job-service"
+	"github.com/m-lab/etl-gardener/tracker"
 )
 
 func init() {
@@ -35,7 +34,7 @@ func TestService_NextJob(t *testing.T) {
 	defer monkey.Unpatch(time.Now)
 
 	start := time.Date(2011, 2, 3, 5, 6, 7, 8, time.UTC)
-	svc, _ := jobservice.NewJobService(nil, "fake-bucket", start)
+	svc, _ := job.NewJobService(nil, "fake-bucket", start)
 	j := svc.NextJob()
 	w, err := tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Truncate(24 * time.Hour)}.Target("gs://fakebucket/ndt/ndt5")
 	rtx.Must(err, "")
@@ -161,79 +160,5 @@ func TestEarlyWrapping(t *testing.T) {
 				t.Error(err)
 			}
 		}
-	}
-}
-
-type fakeGardener struct {
-	t *testing.T // for logging
-
-	lock       sync.Mutex
-	jobs       []tracker.JobWithTarget
-	heartbeats int
-	updates    int
-}
-
-func (g *fakeGardener) AddJob(job tracker.Job, target string) error {
-	jt, err := job.Target(target)
-	if err != nil {
-		return err
-	}
-	g.jobs = append(g.jobs, jt)
-	return nil
-}
-
-func (g *fakeGardener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rtx.Must(r.ParseForm(), "bad request")
-	if r.Method != http.MethodPost {
-		log.Fatal("Should be POST") // Not t.Fatal because this is asynchronous.
-	}
-	g.lock.Lock()
-	g.lock.Unlock()
-	switch r.URL.Path {
-	case "/job":
-		if len(g.jobs) < 1 {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		j := g.jobs[0]
-		g.jobs = g.jobs[1:]
-		w.Write(j.Marshal())
-	case "/heartbeat":
-		g.t.Log(r.URL.Path, r.URL.Query())
-		g.heartbeats++
-
-	case "/update":
-		g.t.Log(r.URL.Path, r.URL.Query())
-		g.updates++
-
-	default:
-		log.Fatal(r.URL) // Not t.Fatal because this is asynchronous.
-	}
-}
-
-func TestJobClient(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// set up a fake gardener service.
-	fg := fakeGardener{t: t, jobs: make([]tracker.JobWithTarget, 0)}
-	spec := tracker.NewJob(
-		"foobar", "ndt", "ndt5", time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC))
-	rtx.Must(fg.AddJob(spec, "a.b.c"), "add job")
-	gardener := httptest.NewServer(&fg)
-	defer gardener.Close()
-	gURL, err := url.Parse(gardener.URL)
-	rtx.Must(err, "bad url")
-
-	j, err := jobservice.NextJob(ctx, *gURL)
-	rtx.Must(err, "next job")
-
-	if j.Path() != "gs://foobar/ndt/ndt5/2019/01/01/" {
-		t.Error(j.Path())
-	}
-
-	j, err = jobservice.NextJob(ctx, *gURL)
-	if err.Error() != "Internal Server Error" {
-		t.Fatal("Should be internal server error", err)
 	}
 }


### PR DESCRIPTION
This moves the client api code to its own package.  The job.NextJob alias is required until etl parser code migrates to client.NextJob.

This also makes a small improvement to the unmarshalling code to allow successful decoding even if gardener has introduced new fields that etl doesn't use yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/250)
<!-- Reviewable:end -->
