### PR TITLE
remove kubectl describe

### DIFF
--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -36,7 +36,5 @@ kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
     > ${CFG}
 cat ${CFG}
 
-kubectl describe configmaps gardener-config
-
 # This triggers deployment of the pod.
 kubectl apply -f ${CFG}


### PR DESCRIPTION
A describe command causes failure in master, because the config didn't exist yet.  Removed the describe command, and tested by deleting the config in sandbox and redeploying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/251)
<!-- Reviewable:end -->
