### PR TITLE
Cleanup delay

### DIFF
--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -42,6 +42,7 @@ import (
 
 var (
 	jobExpirationTime = flag.Duration("job_expiration_time", 24*time.Hour, "Time after which stale jobs will be purged")
+	jobCleanupDelay   = flag.Duration("job_cleanup_delay", 3*time.Hour, "Time after which completed jobs will be removed from tracker")
 	shutdownTimeout   = flag.Duration("shutdown_timeout", 1*time.Minute, "Graceful shutdown time allowance")
 	statusPort        = flag.String("status_port", ":0", "The public interface port where status (and pprof) will be published")
 
@@ -311,7 +312,7 @@ func mustStandardTracker() *tracker.Tracker {
 	tk, err := tracker.InitTracker(
 		context.Background(),
 		dsiface.AdaptClient(client), dsKey,
-		time.Minute, *jobExpirationTime)
+		time.Minute, *jobExpirationTime, *jobCleanupDelay)
 	rtx.Must(err, "tracker init")
 	if tk == nil {
 		log.Fatal("nil tracker")
@@ -372,10 +373,10 @@ func main() {
 		globalTracker = mustStandardTracker()
 
 		// TODO - refactor this block.
-		config := cloud.Config{
+		cloudCfg := cloud.Config{
 			Project: env.Project,
 			Client:  nil}
-		bqConfig := NewBQConfig(config)
+		bqConfig := NewBQConfig(cloudCfg)
 		bqConfig.BQFinalDataset = "base_tables"
 		bqConfig.BQBatchDataset = "batch"
 		monitor, err := ops.NewStandardMonitor(mainCtx, bqConfig, globalTracker)

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -98,7 +98,7 @@ func TestJobHandler(t *testing.T) {
 
 func TestResume(t *testing.T) {
 	start := time.Date(2011, 2, 3, 5, 6, 7, 8, time.UTC)
-	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0) // Only using jobmap.
+	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0, 0) // Only using jobmap.
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestEarlyWrapping(t *testing.T) {
 	})
 	defer monkey.Unpatch(time.Now)
 	start := time.Date(2011, 2, 3, 5, 6, 7, 8, time.UTC)
-	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0) // Only using jobmap.
+	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0, 0) // Only using jobmap.
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -51,7 +51,7 @@ func TestStandardMonitor(t *testing.T) {
 	logx.LogxDebug.Set("true")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0)
+	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0, 0)
 	rtx.Must(err, "tk init")
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
 	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))
@@ -79,6 +79,7 @@ func TestStandardMonitor(t *testing.T) {
 	failTime := time.Now().Add(10 * time.Second)
 
 	for time.Now().Before(failTime) && tk.NumFailed() < 3 {
+		time.Sleep(time.Millisecond)
 	}
 	if tk.NumFailed() != 3 {
 		t.Error(tk.NumFailed())

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -34,7 +34,7 @@ func TestMonitor_Watch(t *testing.T) {
 	logx.LogxDebug.Set("true")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0)
+	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0, 0)
 	rtx.Must(err, "tk init")
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
 	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -3,6 +3,7 @@ package tracker
 import (
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/url"
 
@@ -105,6 +106,7 @@ func (h *Handler) update(resp http.ResponseWriter, req *http.Request) {
 	detail := req.Form.Get("detail")
 
 	if err := h.tracker.SetStatus(job, State(state), detail); err != nil {
+		log.Printf("Not found %+v\n", job)
 		resp.WriteHeader(http.StatusGone)
 		return
 	}

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -27,7 +27,7 @@ func testSetup(t *testing.T) (url.URL, *tracker.Tracker, tracker.Job) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -133,9 +133,7 @@ const (
 	Joining       State = "joining"
 	Finishing     State = "finishing"
 	Failed        State = "failed"
-	// Note that GetStatus will never return Complete, as the
-	// Job is removed when SetJobState is called with Complete.
-	Complete State = "complete"
+	Complete      State = "complete"
 )
 
 // StateInfo describes each state in processing history.
@@ -169,6 +167,7 @@ type Status struct {
 
 // LastStateInfo returns the StateInfo for the most recent state.
 func (s *Status) LastStateInfo() *StateInfo {
+	// TODO check for no history, and create one on the fly?
 	return &s.History[len(s.History)-1]
 }
 
@@ -202,6 +201,14 @@ func (s *Status) UpdateDetail(detail string) {
 	s.LastStateInfo().Update(detail)
 }
 
+func (s *Status) Error() string {
+	ls := s.LastStateInfo()
+	if ls.State == Failed {
+		return ls.LastUpdate
+	}
+	return ""
+}
+
 // Update changes the current state and detail, and returns
 // the previous final StateInfo.
 func (s *Status) Update(state State, detail string) StateInfo {
@@ -217,6 +224,11 @@ func (s *Status) Update(state State, detail string) StateInfo {
 
 func (s Status) String() string {
 	last := s.LastStateInfo()
+	if last == nil {
+		return fmt.Sprintf("%s %s (---)",
+			s.UpdateTime().Format("01/02~15:04:05"),
+			last.State)
+	}
 	return fmt.Sprintf("%s %s (%s)",
 		s.UpdateTime().Format("01/02~15:04:05"),
 		last.State,
@@ -260,53 +272,6 @@ func (jobs JobMap) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&pairs)
 }
 
-// A OldStatus describes the state of a bucket/exp/type/YYYY/MM/DD job.
-// Completed jobs are removed from the persistent store.
-// Errored jobs are maintained in the persistent store for debugging.
-// Status should be updated only by the Tracker, which will
-// ensure correct serialization and Saver updates.
-type OldStatus struct {
-	HeartbeatTime time.Time // Time of last ETL heartbeat.
-
-	StartTime    time.Time // Time the job was initialized.
-	UpdateTime   time.Time // Time of last update.
-	UpdateDetail string    // Note from last update
-	UpdateCount  int       // Number of updates
-
-	State               State     // String defining the current state.
-	LastStateChangeTime time.Time // Used for computing time in state.
-	LastError           string    // The most recent error encountered.
-
-	// Note that these are not persisted
-	errors []string // all errors related to the job.
-}
-
-// LegacyUnmarshalJSON unmarshals from the previous jobmap format.
-// jobs and data should be non-nil.
-func (jobs *JobMap) LegacyUnmarshalJSON(data []byte) error {
-	type Pair struct {
-		Job   Job
-		State OldStatus
-	}
-	pairs := make([]Pair, 0, 100)
-	err := json.Unmarshal(data, &pairs)
-	if err != nil {
-		return err
-	}
-
-	for i := range pairs {
-		job := pairs[i].Job
-		old := pairs[i].State
-		s := NewStatus()
-		s.Update(old.State, old.UpdateDetail)
-		last := s.LastStateInfo()
-		last.Start = old.LastStateChangeTime
-		last.LastUpdateTime = old.UpdateTime
-		(*jobs)[job] = s
-	}
-	return nil
-}
-
 // UnmarshalJSON implements json.UnmarshalJSON
 // jobs and data should be non-nil.
 func (jobs *JobMap) UnmarshalJSON(data []byte) error {
@@ -317,10 +282,10 @@ func (jobs *JobMap) UnmarshalJSON(data []byte) error {
 	pairs := make([]Pair, 0, 100)
 	err := json.Unmarshal(data, &pairs)
 	if err != nil {
-		// Try using the legacy unmarshal
-		return jobs.LegacyUnmarshalJSON(data)
+		return err
 	}
 
+	log.Printf("Unmarshalling %d job/status pairs.\n", len(pairs))
 	for i := range pairs {
 		(*jobs)[pairs[i].Job] = pairs[i].State
 	}
@@ -356,7 +321,7 @@ var jobsTemplate = template.Must(template.New("").Parse(
 			  {{.Status.State}} </td>
 			<td> {{.Status.LastUpdate}} </td>
 			<td> {{.Status.UpdateCount}} </td>
-			<td> {{.Status.LastUpdate}} </td>
+			<td> {{.Status.Error}} </td>
 		</tr>
 	    {{end}}
 	</table>`, Init, ParseComplete)))
@@ -415,12 +380,19 @@ func loadJobMap(ctx context.Context, client dsiface.Client, key *datastore.Key) 
 	if err != nil {
 		return nil, Job{}, err
 	}
+	log.Println("Last save:", state.SaveTime.Format("01/02T15:04"))
+	log.Println(string(state.Jobs))
 
 	jobMap := make(JobMap, 100)
 	log.Println("Unmarshalling", len(state.Jobs))
 	err = json.Unmarshal(state.Jobs, &jobMap)
 	if err != nil {
 		log.Fatal("loadJobMap failed", err)
+	}
+	for j, s := range jobMap {
+		if len(s.History) < 1 {
+			log.Fatalf("Empty State history %+v : %+v\n", j, s)
+		}
 	}
 	return jobMap, state.LastInit, nil
 

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -225,9 +225,7 @@ func (s *Status) Update(state State, detail string) StateInfo {
 func (s Status) String() string {
 	last := s.LastStateInfo()
 	if last == nil {
-		return fmt.Sprintf("%s %s (---)",
-			s.UpdateTime().Format("01/02~15:04:05"),
-			last.State)
+		return "no state history"
 	}
 	return fmt.Sprintf("%s %s (%s)",
 		s.UpdateTime().Format("01/02~15:04:05"),

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -178,6 +178,7 @@ func (tr *Tracker) UpdateJob(job Job, state Status) error {
 	tr.lastModified = time.Now()
 	if state.isDone() {
 		metrics.CompletedCount.WithLabelValues(job.Experiment, job.Datatype).Inc()
+		// This could be done by GetStatus, but would change behaviors slightly.
 		if tr.cleanupDelay == 0 {
 			metrics.TasksInFlight.WithLabelValues(job.Experiment, job.Datatype).Dec()
 			delete(tr.jobs, job)
@@ -196,7 +197,7 @@ func (tr *Tracker) SetStatus(job Job, newState State, detail string) error {
 	}
 	old := status.Update(newState, detail)
 	if newState != old.State {
-		log.Println(job, status.State(), "->", newState)
+		log.Println(job, old, "->", newState)
 
 		timeInState := time.Since(old.Start)
 		metrics.StateTimeHistogram.WithLabelValues(job.Experiment, job.Datatype, string(old.State)).Observe(timeInState.Seconds())

--- a/tracker/tracker_integration_test.go
+++ b/tracker/tracker_integration_test.go
@@ -27,7 +27,7 @@ func TestWithDatastore(t *testing.T) {
 	// quite a while to propogate.
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")
@@ -43,7 +43,7 @@ func TestWithDatastore(t *testing.T) {
 	_, err = tk.Sync(time.Time{})
 	must(t, err)
 	// Check that the sync (and InitTracker) work.
-	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 
 	if restore.NumJobs() != 500 {

--- a/tracker/tracker_race_test.go
+++ b/tracker/tracker_race_test.go
@@ -32,7 +32,7 @@ func TestConcurrentUpdates(t *testing.T) {
 
 	// For testing, push to the saver every 5 milliseconds.
 	saverInterval := 5 * time.Millisecond
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, saverInterval, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, saverInterval, 0, 0)
 	must(t, err)
 
 	jobs := 20
@@ -76,7 +76,7 @@ func TestConcurrentUpdates(t *testing.T) {
 	if testing.Verbose() {
 		_, err := tk.Sync(time.Time{})
 		must(t, err)
-		restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+		restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 		must(t, err)
 
 		status, _, _ := restore.GetState()

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -102,7 +102,7 @@ func TestTrackerAddDelete(t *testing.T) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, time.Second)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")
@@ -119,7 +119,8 @@ func TestTrackerAddDelete(t *testing.T) {
 		must(t, err)
 	}
 	// Check that the sync (and InitTracker) work.
-	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	// Jobs will be removed by GetStatus 50 milliseconds after Complete.
+	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 50*time.Millisecond)
 	must(t, err)
 
 	if restore.NumJobs() != 500 {
@@ -132,6 +133,27 @@ func TestTrackerAddDelete(t *testing.T) {
 
 	completeJobs(t, tk, "500Jobs", "type", numJobs)
 
+	// This tests proper behavior of cleanup with cleanupDelay.
+	jobs, _, _ := tk.GetState()
+	if len(jobs) < numJobs {
+		t.Error("Too few jobs:", len(jobs), "<", numJobs)
+	}
+	active := 0
+	for _, s := range jobs {
+		if s.State() != tracker.Complete {
+			active++
+		}
+	}
+	if active > 0 {
+		t.Error("Should be zero active jobs")
+	}
+
+	// It will take up to 50 milliseconds to delete the jobs.
+	deadline := time.Now().Add(time.Second)
+	for tk.NumJobs() != 0 && time.Since(deadline) < 0 {
+		time.Sleep(time.Millisecond)
+		tk.GetState()
+	}
 	if _, err := tk.Sync(time.Time{}); err != nil {
 		must(t, err)
 	}
@@ -150,7 +172,7 @@ func TestUpdate(t *testing.T) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 
 	createJobs(t, tk, "JobToUpdate", "type", 1)
@@ -190,7 +212,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 	dsKey.Namespace = "gardener"
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
 	must(t, err)
 
 	job := tracker.Job{}
@@ -221,7 +243,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 }
 
 func TestJobMapHTML(t *testing.T) {
-	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0)
+	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0, 0)
 	must(t, err)
 
 	job := tracker.Job{}
@@ -246,7 +268,7 @@ func TestExpiration(t *testing.T) {
 	defer must(t, cleanup(client, dsKey))
 
 	// Expire jobs after 1 second of monkey time.
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 5*time.Millisecond, 10*time.Millisecond)
+	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 5*time.Millisecond, 10*time.Millisecond, 1*time.Millisecond)
 	must(t, err)
 
 	job := tracker.NewJob("bucket", "exp", "type", startDate)


### PR DESCRIPTION
Adds a delay before removing completed jobs, so that the status page can present info about recently completed jobs.
If also:
* Removes temporary code for state history migration
* Adds a sanity check on loading jobmap from datastore.
* Tweaks a couple status/state functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/257)
<!-- Reviewable:end -->
