### PR TITLE
Use new bq ops in Monitor actions

### DIFF
--- a/cloud/bq/ops.go
+++ b/cloud/bq/ops.go
@@ -36,8 +36,8 @@ type queryer struct {
 // ErrDatatypeNotSupported is returned by Query for unsupported datatypes.
 var ErrDatatypeNotSupported = errors.New("Datatype not supported")
 
-// NewQueryParams creates a suitable QueryParams for a Job.
-func NewQueryParams(job tracker.Job, project string) (Queryer, error) {
+// NewQuerier creates a suitable QueryParams for a Job.
+func NewQuerier(job tracker.Job, project string) (Queryer, error) {
 	c, err := bigquery.NewClient(context.Background(), project)
 	if err != nil {
 		return nil, err

--- a/cloud/bq/ops.go
+++ b/cloud/bq/ops.go
@@ -43,11 +43,11 @@ func NewQuerier(job tracker.Job, project string) (Queryer, error) {
 		return nil, err
 	}
 	bqClient := bqiface.AdaptClient(c)
-	return NewQueryParamsWithClient(bqClient, job, project)
+	return NewQuerierWithClient(bqClient, job, project)
 }
 
-// NewQueryParamsWithClient creates a suitable QueryParams for a Job.
-func NewQueryParamsWithClient(client bqiface.Client, job tracker.Job, project string) (Queryer, error) {
+// NewQuerierWithClient creates a suitable QueryParams for a Job.
+func NewQuerierWithClient(client bqiface.Client, job tracker.Job, project string) (Queryer, error) {
 	switch job.Datatype {
 	case "annotation":
 		return &queryer{

--- a/cloud/bq/ops_test.go
+++ b/cloud/bq/ops_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestTemplate(t *testing.T) {
 	job := tracker.NewJob("bucket", "ndt", "tcpinfo", time.Date(2019, 3, 4, 0, 0, 0, 0, time.UTC))
-	q, err := bq.NewQueryParams(job, "fake-project")
+	q, err := bq.NewQuerier(job, "fake-project")
 	rtx.Must(err, "dedup.Query failed")
 	qs := q.QueryFor("dedup")
 	if !strings.Contains(qs, "uuid") {
@@ -43,7 +43,7 @@ func TestValidateQueries(t *testing.T) {
 	// Test for each datatype
 	for _, dataType := range dataTypes {
 		job := tracker.NewJob("bucket", "ndt", dataType, time.Date(2019, 3, 4, 0, 0, 0, 0, time.UTC))
-		qp, err := bq.NewQueryParams(job, "mlab-testing")
+		qp, err := bq.NewQuerier(job, "mlab-testing")
 		if err != nil {
 			t.Fatal(dataType, err)
 		}

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,17 +1,20 @@
 ---
-start_date: 2019-08-01
+start_date: 2020-03-12
 tracker:
   timeout: 5h
 monitor:
-  polling_interval: 5m
+  polling_interval: 1m
 sources:
 - bucket: archive-measurement-lab
   experiment: ndt
-  datatype: tcpinfo
-  filter: .*T??:??:00.*Z
-  target: tmp_ndt.tcpinfo
+  datatype: ndt7
+  target: tmp_ndt.ndt7
 - bucket: archive-measurement-lab
   experiment: ndt
-  datatype: ndt5
-  filter: .*T??:??:00.*Z
-  target: tmp_ndt.ndt5
+  datatype: annotation
+  target: tmp_ndt.annotation
+- bucket: archive-measurement-lab
+  experiment: ndt
+  datatype: tcpinfo
+  filter: .*T??:??:00.*Z  # Not yet used - just for illustration
+  target: tmp_ndt.tcpinfo

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -47,7 +47,7 @@ spec:
         - name: STATUS_PORT
           value: ":8081"
         - name: JOB_EXPIRATION_TIME
-          value: "3h"
+          value: "6h"
         - name: SHUTDOWN_TIMEOUT
           value: "5m"
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -160,4 +160,22 @@ var (
 		},
 		[]string{"experiment", "datatype", "year"},
 	)
+
+	// QueryCostHistogram tracks the costs of dedup and other queries.
+	QueryCostHistogram = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "query_cost_seconds",
+			Help: "bigquery query cost in slot seconds",
+			Buckets: []float64{
+				// 1, 1.39, 1.93, 2.68, 3.73, 5.18, 7.2,
+				1.0, 2.15, 4.64, 10, 21.5, 46.4,
+				100, 215, 464, 1000, 2150, 4640,
+				10000, 21500, 46400, 100000, 215000, 464000,
+				1000000, 2150000, 4640000, 10000000, 21500000, 46400000,
+			},
+		},
+		// Worker type, e.g. ndt, sidestream, ptr, etc.
+		// TODO(soltesz): support a status field based on HTTP status.
+		[]string{"datatype", "query"},
+	)
 )

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -167,15 +167,15 @@ var (
 			Name: "query_cost_seconds",
 			Help: "bigquery query cost in slot seconds",
 			Buckets: []float64{
-				// 1, 1.39, 1.93, 2.68, 3.73, 5.18, 7.2,
 				1.0, 2.15, 4.64, 10, 21.5, 46.4,
 				100, 215, 464, 1000, 2150, 4640,
-				10000, 21500, 46400, 100000, 215000, 464000,
-				1000000, 2150000, 4640000, 10000000, 21500000, 46400000,
+				10000, 21500, 46400, 100000, 215000, 464000, // ~120 hours
+				1000000, 2150000, 4640000, 10000000, 21500000, 46400000, // ~12K hours
+				// Some queries may run 100s of slot hours.  10K hours is likely
+				// excessive, but it would be annoying if the top end were missed.
 			},
 		},
 		// Worker type, e.g. ndt, sidestream, ptr, etc.
-		// TODO(soltesz): support a status field based on HTTP status.
 		[]string{"datatype", "query"},
 	)
 )

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -89,12 +89,19 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 			if typedErr.Code == http.StatusBadRequest &&
 				strings.Contains(typedErr.Error(), "streaming buffer") {
 				// Wait a while and try again.
+				log.Println(err)
+				metrics.WarningCount.WithLabelValues(
+					j.Experiment, j.DataType,
+					"StreamingBufferBackoff").Inc()
 				s.UpdateDetail("Dedup waiting for empty streaming buffer.")
 				tk.UpdateJob(j, s)
 			}
 		default:
 			// We don't know the problem...
 			log.Println(err)
+			metrics.WarningCount.WithLabelValues(
+				j.Experiment, j.DataType,
+				"UnknownBigqueryError").Inc()
 		}
 		time.Sleep(2 * time.Minute)
 		return // Try again later.

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -2,7 +2,6 @@ package ops
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -20,11 +19,6 @@ import (
 	"github.com/m-lab/etl-gardener/tracker"
 )
 
-// PartitionedTable creates BQ Table for legacy source templated table
-func isTest() bool {
-	return flag.Lookup("test.v") != nil
-}
-
 func newStateFunc(state tracker.State, detail string) ActionFunc {
 	return func(ctx context.Context, tk *tracker.Tracker, j tracker.Job, unused tracker.Status) {
 		log.Println(j, state)
@@ -37,7 +31,6 @@ func newStateFunc(state tracker.State, detail string) ActionFunc {
 }
 
 // NewStandardMonitor creates the standard monitor that handles several state transitions.
-// TODO Finishing action is incomplete.
 func NewStandardMonitor(ctx context.Context, config cloud.BQConfig, tk *tracker.Tracker) (*Monitor, error) {
 	m, err := NewMonitor(ctx, config, tk)
 	if err != nil {

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -69,7 +69,7 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 	var bqJob bqiface.Job
 	var msg string
 	// TODO pass in the JobWithTarget, and get the base from the target.
-	qp, err := bq.NewQueryParams(j, os.Getenv("PROJECT"))
+	qp, err := bq.NewQuerier(j, os.Getenv("PROJECT"))
 	if err != nil {
 		log.Println(err)
 		// This terminates this job.

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -3,57 +3,25 @@ package ops
 import (
 	"context"
 	"flag"
-	"io"
+	"fmt"
 	"log"
+	"net/http"
+	"os"
 	"strings"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
-	"github.com/m-lab/go/dataset"
+	"google.golang.org/api/googleapi"
 
 	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/cloud/bq"
 	"github.com/m-lab/etl-gardener/metrics"
 	"github.com/m-lab/etl-gardener/state"
 	"github.com/m-lab/etl-gardener/tracker"
-	"github.com/m-lab/etl/etl"
 )
 
 // PartitionedTable creates BQ Table for legacy source templated table
-func PartitionedTable(j tracker.Job, ds *dataset.Dataset) bqiface.Table {
-	tableName := etl.DirToTablename(j.Datatype)
-	log.Println(ds.Dataset, tableName)
-
-	src := ds.Table(tableName + "$" + j.Date.Format("20060102"))
-	return src
-}
-
-// TemplateTable creates BQ Table for legacy source templated table
-func TemplateTable(j tracker.Job, ds *dataset.Dataset) bqiface.Table {
-	tableName := etl.DirToTablename(j.Datatype)
-	log.Println(ds.Dataset, tableName)
-
-	src := ds.Table(tableName + "_" + j.Date.Format("20060102"))
-	return src
-}
-
-// This is a function I didn't want to port to the new architecture.  8-(
-func (m *Monitor) waitForStableTable(ctx context.Context, j tracker.Job) error {
-	log.Println("Stabilizing:", j)
-	// Wait for the streaming buffer to be nil.
-
-	src := TemplateTable(j, &m.batchDS)
-	err := bq.WaitForStableTable(ctx, src)
-	if err != nil {
-		// When testing, we expect to get ErrTableNotFound here.
-		if err != state.ErrTableNotFound {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func isTest() bool {
 	return flag.Lookup("test.v") != nil
 }
@@ -78,91 +46,114 @@ func NewStandardMonitor(ctx context.Context, config cloud.BQConfig, tk *tracker.
 	}
 	m.AddAction(tracker.ParseComplete,
 		nil,
-		newStateFunc(tracker.Stabilizing, "-"),
-		"Changing to Stabilizing")
-	m.AddAction(tracker.Stabilizing,
-		// TODO - determine whether we need to stabilize or can just go ahead with the dedup
-		// query, which should capture the streaming buffer.
-		func(ctx context.Context, j tracker.Job) bool {
-			return m.waitForStableTable(ctx, j) == nil
-		},
 		newStateFunc(tracker.Deduplicating, "-"),
-		"Stabilizing")
+		"Changing to Deduplicating")
+	// Hack to handle old jobs from previous gardener implementations
+	m.AddAction(tracker.Stabilizing,
+		nil,
+		newStateFunc(tracker.Deduplicating, "-"),
+		"Changing to Deduplicating")
 	m.AddAction(tracker.Deduplicating,
-		// HACK
 		nil,
-		func(ctx context.Context, tk *tracker.Tracker, j tracker.Job, unused tracker.Status) {
-			start := time.Now()
-			// TODO - pass tracker to dedup, so dedup can record the JobID.
-			err := m.dedup(ctx, j)
-			if err != nil {
-				if err == state.ErrBQRateLimitExceeded {
-					// If BQ is rate limited, this basically results in jobs queuing up
-					// and executing later.
-					// Since there is no job update, the tracker may eventually kill
-					// this job if it doesn't succeed within the stale job time limit.
-					// TODO should this use exponential backoff?
-					time.Sleep(2 * time.Minute)
-					return // Try again later
-				}
-				log.Println(err)
-				tk.SetJobError(j, err.Error())
-				return
-			}
-			log.Println(j, tracker.Finishing)
-			metrics.StateDate.WithLabelValues(j.Experiment, j.Datatype, string(tracker.Finishing)).Set(float64(j.Date.Unix()))
-			err = tk.SetStatus(j, tracker.Finishing, "dedup took "+time.Since(start).Round(100*time.Millisecond).String())
-			if err != nil {
-				log.Println(err)
-			}
-		},
+		dedupFunc,
 		"Deduplicating")
-	m.AddAction(tracker.Finishing,
-		nil,
-		func(ctx context.Context, tk *tracker.Tracker, j tracker.Job, unused tracker.Status) {
-			start := time.Now()
-			// TODO - need to copy partition to final location.
-			// For now, we just change the state to Complete.
-			log.Println(j, tracker.Complete, time.Since(start).Round(100*time.Millisecond))
-			err = tk.SetStatus(j, tracker.Complete, "delete took "+time.Since(start).Round(100*time.Millisecond).String())
-			if err != nil {
-				log.Println(err)
-			}
-		},
-		"Finishing (table copy and cleanup)")
 	return m, nil
 }
 
-func (m *Monitor) deleteSrc(ctx context.Context, j tracker.Job) error {
-	src := TemplateTable(j, &m.batchDS)
+// TODO figure out how to test this code?
+func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker.Status) {
+	start := time.Now()
+	// This is the delay since entering the dedup state.
+	delay := time.Since(s.LastStateChangeTime()).Round(time.Minute)
 
-	delCtx, cf := context.WithTimeout(ctx, time.Minute)
-	defer cf()
-	return src.Delete(delCtx)
-}
-
-func (m *Monitor) dedup(ctx context.Context, j tracker.Job) error {
-	// Launch the dedup request, and save the JobID
-	src := TemplateTable(j, &m.batchDS)
-	dest := PartitionedTable(j, &m.batchDS)
-
-	log.Println("Dedupping", src.FullyQualifiedName())
-	// TODO move Dedup??
-	// TODO - implement backoff?
-	bqJob, err := bq.Dedup(ctx, &m.batchDS, src.TableID(), dest)
+	var bqJob bqiface.Job
+	var msg string
+	// TODO pass in the JobWithTarget, and get the base from the target.
+	qp, err := bq.NewQueryParams(j, os.Getenv("PROJECT"))
 	if err != nil {
-		if err == io.EOF {
-			if isTest() {
-				bqJob, err = m.batchDS.BqClient.JobFromID(ctx, "fakeJobID")
-				return nil
-			}
-		} else {
-			log.Println(err, src.FullyQualifiedName())
-			//t.SetError(ctx, err, "DedupFailed")
-			return err
-		}
+		log.Println(err)
+		// This terminates this job.
+		tk.SetJobError(j, err.Error())
+		return
 	}
-	return waitForJob(ctx, j, bqJob, time.Minute)
+	bqJob, err = qp.Run(ctx, "dedup", false)
+	if err != nil {
+		log.Println(err)
+		// Try again soon.
+		return
+	}
+	status, err := bqJob.Wait(ctx)
+	if err != nil {
+		switch typedErr := err.(type) {
+		case *googleapi.Error:
+			if typedErr.Code == http.StatusBadRequest &&
+				strings.Contains(typedErr.Error(), "streaming buffer") {
+				// Wait a while and try again.
+				s.UpdateDetail("Dedup waiting for empty streaming buffer.")
+				tk.UpdateJob(j, s)
+			}
+		default:
+			// We don't know the problem...
+			log.Println(err)
+		}
+		time.Sleep(2 * time.Minute)
+		return // Try again later.
+	}
+	if status.Err() != nil {
+		err := status.Err()
+		switch typedErr := err.(type) {
+		case *googleapi.Error:
+			log.Println(err)
+			if typedErr.Code == http.StatusBadRequest &&
+				strings.Contains(typedErr.Error(), "streaming buffer") {
+				// Wait a while and try again.
+				// Since there is no job update, the tracker may eventually kill
+				// this job if it doesn't succeed within the stale job time limit.
+				s.UpdateDetail("Dedup waiting for empty streaming buffer.")
+				tk.UpdateJob(j, s)
+				time.Sleep(2 * time.Minute)
+				return // Try again later.
+			}
+		default:
+			log.Println(err)
+			if err == state.ErrBQRateLimitExceeded {
+				// If BQ is rate limited, this basically results in jobs queuing up
+				// and executing later.
+				// Since there is no job update, the tracker may eventually kill
+				// this job if it doesn't succeed within the stale job time limit.
+				// TODO should this use exponential backoff?
+				s.UpdateDetail("Dedup waiting because of BQ Rate Limit Exceeded.")
+				tk.UpdateJob(j, s)
+				time.Sleep(5 * time.Minute)
+				return // Try again later.
+			}
+		}
+
+		// This will terminate this job.
+		tk.SetJobError(j, err.Error())
+		return
+	}
+
+	// Dedup job was successful.  Handle the statistics, metrics, tracker update.
+	switch details := status.Statistics.Details.(type) {
+	case *bigquery.QueryStatistics:
+		metrics.QueryCostHistogram.WithLabelValues(j.Datatype, "dedup").Observe(float64(details.SlotMillis) / 1000.0)
+		msg = fmt.Sprintf("Dedup took %s (after %s waiting), %5.2f Slot Minutes, %d Rows affected, %d MB Processed, %d MB Billed",
+			time.Since(start).Round(100*time.Millisecond).String(),
+			delay,
+			float64(details.SlotMillis)/60000, details.NumDMLAffectedRows,
+			details.TotalBytesProcessed/1000000, details.TotalBytesBilled/1000000)
+		log.Println(msg)
+		log.Printf("Dedup %s: %+v\n", j, details)
+	default:
+		log.Printf("Could not convert to QueryStatistics: %+v\n", status.Statistics.Details)
+		msg = "Could not convert Detail to QueryStatistics"
+	}
+	metrics.StateDate.WithLabelValues(j.Experiment, j.Datatype, string(tracker.Complete)).Set(float64(j.Date.Unix()))
+	err = tk.SetStatus(j, tracker.Complete, msg)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 // WaitForJob waits for job to complete.  Uses fibonacci backoff until the backoff

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -61,19 +61,20 @@ func waitAndCheck(ctx context.Context, tk *tracker.Tracker, bqJob bqiface.Job, j
 		case *googleapi.Error:
 			if typedErr.Code == http.StatusBadRequest &&
 				strings.Contains(typedErr.Error(), "streaming buffer") {
-				// Wait a while and try again.
 				log.Println(typedErr)
 				metrics.WarningCount.WithLabelValues(
 					j.Experiment, j.Datatype,
 					label+"WaitingForStreamingBuffer").Inc()
 				s.UpdateDetail("waiting for empty streaming buffer")
 				tk.UpdateJob(j, s)
+				// Leave in current state, Wait a while and try again.
 				time.Sleep(2 * time.Minute)
 				return nil
 			}
 		default:
 			// We don't know the problem...
 		}
+		// Not googleapi.Error, OR not streaming buffer problem.
 		log.Println(label, err)
 		metrics.WarningCount.WithLabelValues(
 			j.Experiment, j.Datatype,

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -5,47 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/bigquery"
-	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
 	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/ops"
 	"github.com/m-lab/etl-gardener/tracker"
-	"github.com/m-lab/go/dataset"
 	"github.com/m-lab/go/logx"
 	"github.com/m-lab/go/rtx"
-	"google.golang.org/api/option"
 )
-
-func TestTableUtils(t *testing.T) {
-	ctx := context.Background()
-
-	project := "fakeProject"
-	dryRun, _ := cloud.DryRunClient()
-	config := cloud.Config{
-		Project: project,
-		Client:  nil,
-		Options: []option.ClientOption{option.WithHTTPClient(dryRun)},
-	}
-	bqConfig := cloud.BQConfig{Config: config, BQFinalDataset: "final", BQBatchDataset: "batch"}
-
-	c, err := bigquery.NewClient(ctx, bqConfig.BQProject, bqConfig.Options...)
-	rtx.Must(err, "client")
-	bqClient := bqiface.AdaptClient(c)
-	ds := dataset.Dataset{Dataset: bqClient.Dataset(bqConfig.BQBatchDataset), BqClient: bqClient}
-
-	j := tracker.NewJob(
-		"bucket", "exp", "type", time.Date(2019, 12, 1, 0, 0, 0, 0, time.UTC))
-	src := ops.TemplateTable(j, &ds)
-	dest := ops.PartitionedTable(j, &ds)
-
-	if src.DatasetID() != "batch" {
-		t.Error(src)
-	}
-	if dest.DatasetID() != "batch" {
-		t.Error(src)
-	}
-
-}
 
 func TestStandardMonitor(t *testing.T) {
 	logx.LogxDebug.Set("true")
@@ -69,11 +34,7 @@ func TestStandardMonitor(t *testing.T) {
 		newStateFunc(tracker.ParseComplete),
 		"Parsing")
 
-	// Substitute, since we don't want to use real bq backend.
-	m.AddAction(tracker.Stabilizing,
-		nil,
-		newStateFunc(tracker.Deduplicating),
-		"Checking for stability")
+	// The real dedup action should fail on unknown datatype.
 	go m.Watch(ctx, 10*time.Millisecond)
 
 	failTime := time.Now().Add(10 * time.Second)

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -9,18 +9,29 @@ import (
 	"github.com/m-lab/etl-gardener/ops"
 	"github.com/m-lab/etl-gardener/tracker"
 	"github.com/m-lab/go/logx"
+	"github.com/m-lab/go/osx"
 	"github.com/m-lab/go/rtx"
 )
 
+// TODO consider rewriting to use a go/cloud/bqfake client.  This is a fair
+// bit of work, though.
 func TestStandardMonitor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test that uses BQ backend")
+	}
 	logx.LogxDebug.Set("true")
+	cleanup := osx.MustSetenv("PROJECT", "mlab-testing")
+	defer cleanup()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0, 0)
 	rtx.Must(err, "tk init")
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now()))
+	// Bad experiment type
+	tk.AddJob(tracker.NewJob("bucket", "exp2", "tcpinfo", time.Now()))
+	// Valid experiment and datatype
+	// This does an actual dedup, so we need to allow enough time.
+	tk.AddJob(tracker.NewJob("bucket", "ndt", "tcpinfo", time.Now()))
 
 	m, err := ops.NewStandardMonitor(context.Background(), cloud.BQConfig{}, tk)
 	rtx.Must(err, "NewMonitor failure")
@@ -35,15 +46,18 @@ func TestStandardMonitor(t *testing.T) {
 		"Parsing")
 
 	// The real dedup action should fail on unknown datatype.
-	go m.Watch(ctx, 10*time.Millisecond)
+	go m.Watch(ctx, 50*time.Millisecond)
 
-	failTime := time.Now().Add(10 * time.Second)
+	failTime := time.Now().Add(30 * time.Second)
 
-	for time.Now().Before(failTime) && tk.NumFailed() < 3 {
+	for time.Now().Before(failTime) && (tk.NumJobs() > 2 || tk.NumFailed() < 2) {
 		time.Sleep(time.Millisecond)
 	}
-	if tk.NumFailed() != 3 {
-		t.Error(tk.NumFailed())
+	if tk.NumFailed() != 2 {
+		t.Error("Expected NumFailed = 2:", tk.NumFailed())
+	}
+	if tk.NumJobs() != 2 {
+		t.Error("Expected NumJobs = 2:", tk.NumJobs())
 	}
 	cancel()
 }

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -62,9 +62,9 @@ func TestMonitor_Watch(t *testing.T) {
 		nil,
 		newStateFunc(tracker.Complete),
 		"Deduplicating")
-	go m.Watch(ctx, 10*time.Millisecond)
+	go m.Watch(ctx, 50*time.Millisecond)
 
-	failTime := time.Now().Add(10 * time.Second)
+	failTime := time.Now().Add(5 * time.Second)
 
 	for time.Now().Before(failTime) && tk.NumJobs() > 0 {
 	}


### PR DESCRIPTION
This uses the bq ops to implement dedup in the Monitor actions.

The next PR will add the copy and cleanup actions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/264)
<!-- Reviewable:end -->
