### PR TITLE
fix updatetime

### DIFF
--- a/tracker/job.go
+++ b/tracker/job.go
@@ -135,6 +135,7 @@ const (
 	Stabilizing   State = "stabilizing"
 	Deduplicating State = "deduplicating"
 	Joining       State = "joining"
+	Copying       State = "copying"
 	Finishing     State = "finishing"
 	Failed        State = "failed"
 	Complete      State = "complete"
@@ -248,8 +249,9 @@ func (s *Status) Elapsed() time.Duration {
 
 // NewStatus creates a new Status with provided parameters.
 func NewStatus() Status {
+	now := time.Now()
 	return Status{
-		History: []StateInfo{StateInfo{State: Init, Start: time.Now()}},
+		History: []StateInfo{StateInfo{State: Init, Start: now, LastUpdateTime: now}},
 	}
 }
 


### PR DESCRIPTION
state history PR introduced a bug  that causes premature cleanup.  This fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/268)
<!-- Reviewable:end -->
