### PR TITLE
Add copy and cleanup actions

### DIFF
--- a/ops/actions.go
+++ b/ops/actions.go
@@ -53,6 +53,10 @@ func NewStandardMonitor(ctx context.Context, config cloud.BQConfig, tk *tracker.
 		nil,
 		copyFunc,
 		"Copying")
+	m.AddAction(tracker.Cleaning,
+		nil,
+		cleanupFunc,
+		"Cleaning")
 	return m, nil
 }
 
@@ -102,7 +106,6 @@ func waitAndCheck(ctx context.Context, tk *tracker.Tracker, bqJob bqiface.Job, j
 	return status
 }
 
-// TODO figure out how to test this code?
 func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker.Status) {
 	start := time.Now()
 	// This is the delay since entering the dedup state, due to monitor delay
@@ -148,8 +151,59 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 		msg = "Could not convert Detail to QueryStatistics"
 	}
 
-	metrics.StateDate.WithLabelValues(j.Experiment, j.Datatype, string(tracker.Copying)).Set(float64(j.Date.Unix()))
 	err = tk.SetStatus(j, tracker.Copying, msg)
+	if err != nil {
+		log.Println(err)
+	}
+}
+
+// TODO figure out how to test this code?
+func cleanupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker.Status) {
+	start := time.Now()
+	// This is the delay since entering the dedup state, due to monitor delay
+	// and retries.
+	delay := time.Since(s.LastStateChangeTime()).Round(time.Minute)
+
+	var bqJob bqiface.Job
+	var msg string
+	// TODO pass in the JobWithTarget, and get the base from the target.
+	qp, err := bq.NewQuerier(j, os.Getenv("PROJECT"))
+	if err != nil {
+		log.Println(err)
+		// This terminates this job.
+		tk.SetJobError(j, err.Error())
+		return
+	}
+	bqJob, err = qp.Run(ctx, "cleanup", false)
+	if err != nil {
+		log.Println(err)
+		// Try again soon.
+		return
+	}
+	status := waitAndCheck(ctx, tk, bqJob, j, s, "Cleanup")
+
+	if status == nil {
+		// Nil status means the job failed.
+		return
+	}
+
+	// Dedup job was successful.  Handle the statistics, metrics, tracker update.
+	switch details := status.Statistics.Details.(type) {
+	case *bigquery.QueryStatistics:
+		metrics.QueryCostHistogram.WithLabelValues(j.Datatype, "cleanup").Observe(float64(details.SlotMillis) / 1000.0)
+		msg = fmt.Sprintf("Cleanup took %s (after %s waiting), %5.2f Slot Minutes, %d Rows affected, %d MB Processed, %d MB Billed",
+			time.Since(start).Round(100*time.Millisecond).String(),
+			delay,
+			float64(details.SlotMillis)/60000, details.NumDMLAffectedRows,
+			details.TotalBytesProcessed/1000000, details.TotalBytesBilled/1000000)
+		log.Println(msg)
+		log.Printf("Cleanup %s: %+v\n", j, details)
+	default:
+		log.Printf("Could not convert to QueryStatistics: %+v\n", status.Statistics.Details)
+		msg = "Could not convert Detail to QueryStatistics"
+	}
+
+	err = tk.SetStatus(j, tracker.Complete, msg)
 	if err != nil {
 		log.Println(err)
 	}
@@ -185,7 +239,6 @@ func copyFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker
 	if status.Err() != nil {
 		log.Println(status.Err())
 		tk.SetJobError(j, status.Err().Error())
-		metrics.StateDate.WithLabelValues(j.Experiment, j.Datatype, string(tracker.Failed)).Set(float64(j.Date.Unix()))
 		return
 	}
 	var msg string
@@ -199,8 +252,7 @@ func copyFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker
 		log.Println(msg)
 	}
 
-	metrics.StateDate.WithLabelValues(j.Experiment, j.Datatype, string(tracker.Complete)).Set(float64(j.Date.Unix()))
-	err = tk.SetStatus(j, tracker.Complete, msg)
+	err = tk.SetStatus(j, tracker.Cleaning, msg)
 	if err != nil {
 		log.Println(err)
 	}

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -49,6 +49,10 @@ func NewStandardMonitor(ctx context.Context, config cloud.BQConfig, tk *tracker.
 		nil,
 		dedupFunc,
 		"Deduplicating")
+	m.AddAction(tracker.Copying,
+		nil,
+		copyFunc,
+		"Copying")
 	return m, nil
 }
 
@@ -137,6 +141,57 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 			details.TotalBytesProcessed/1000000, details.TotalBytesBilled/1000000)
 		log.Println(msg)
 		log.Printf("Dedup %s: %+v\n", j, details)
+	default:
+		log.Printf("Could not convert to QueryStatistics: %+v\n", status.Statistics.Details)
+		msg = "Could not convert Detail to QueryStatistics"
+	}
+	metrics.StateDate.WithLabelValues(j.Experiment, j.Datatype, string(tracker.Complete)).Set(float64(j.Date.Unix()))
+	err = tk.SetStatus(j, tracker.Copying, msg)
+	if err != nil {
+		log.Println(err)
+	}
+}
+
+// TODO figure out how to test this code?
+func copyFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker.Status) {
+	start := time.Now()
+	// This is the delay since entering the dedup state, due to monitor delay
+	// and retries.
+	delay := time.Since(s.LastStateChangeTime()).Round(time.Minute)
+
+	var bqJob bqiface.Job
+	var msg string
+	// TODO pass in the JobWithTarget, and get the base from the target.
+	qp, err := bq.NewQuerier(j, os.Getenv("PROJECT"))
+	if err != nil {
+		log.Println(err)
+		// This terminates this job.
+		tk.SetJobError(j, err.Error())
+		return
+	}
+	bqJob, err = qp.Run(ctx, "copy", false)
+	if err != nil {
+		log.Println(err)
+		// Try again soon.
+		return
+	}
+	status := waitAndCheck(ctx, tk, bqJob, j, s, "Copy")
+
+	if status == nil {
+		return
+	}
+
+	// Dedup job was successful.  Handle the statistics, metrics, tracker update.
+	switch details := status.Statistics.Details.(type) {
+	case *bigquery.QueryStatistics:
+		metrics.QueryCostHistogram.WithLabelValues(j.Datatype, "dedup").Observe(float64(details.SlotMillis) / 1000.0)
+		msg = fmt.Sprintf("Copy took %s (after %s waiting), %5.2f Slot Minutes, %d Rows affected, %d MB Processed, %d MB Billed",
+			time.Since(start).Round(100*time.Millisecond).String(),
+			delay,
+			float64(details.SlotMillis)/60000, details.NumDMLAffectedRows,
+			details.TotalBytesProcessed/1000000, details.TotalBytesBilled/1000000)
+		log.Println(msg)
+		log.Printf("Copy %s: %+v\n", j, details)
 	default:
 		log.Printf("Could not convert to QueryStatistics: %+v\n", status.Statistics.Details)
 		msg = "Could not convert Detail to QueryStatistics"

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -106,6 +106,7 @@ func waitAndCheck(ctx context.Context, tk *tracker.Tracker, bqJob bqiface.Job, j
 	return status
 }
 
+// TODO improve test coverage?
 func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker.Status) {
 	start := time.Now()
 	// This is the delay since entering the dedup state, due to monitor delay
@@ -157,7 +158,8 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracke
 	}
 }
 
-// TODO figure out how to test this code?
+// TODO This is costly.  Consider using decorated table delete.
+// TODO improve test coverage?
 func cleanupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker.Status) {
 	start := time.Now()
 	// This is the delay since entering the dedup state, due to monitor delay
@@ -209,7 +211,7 @@ func cleanupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s trac
 	}
 }
 
-// TODO figure out how to test this code?
+// TODO improve test coverage?
 func copyFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker.Status) {
 	delay := time.Since(s.LastStateChangeTime()).Round(time.Minute)
 

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -50,7 +50,7 @@ func TestStandardMonitor(t *testing.T) {
 
 	failTime := time.Now().Add(30 * time.Second)
 
-	for time.Now().Before(failTime) && (tk.NumJobs() > 2 || tk.NumFailed() < 2) {
+	for time.Now().Before(failTime) && tk.NumFailed() < 3 && (tk.NumJobs() > 2 || tk.NumFailed() < 2) {
 		time.Sleep(time.Millisecond)
 	}
 	if tk.NumFailed() != 2 {

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 // TODO consider rewriting to use a go/cloud/bqfake client.  This is a fair
-// bit of work, though.
+// bit of work, though.  Might be practical to improve test coverage.
 func TestStandardMonitor(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test that uses BQ backend")

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -140,6 +140,7 @@ const (
 	Deduplicating State = "deduplicating"
 	Joining       State = "joining"
 	Copying       State = "copying"
+	Cleaning      State = "cleaning"
 	Finishing     State = "finishing"
 	Failed        State = "failed"
 	Complete      State = "complete"

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -231,12 +231,12 @@ func (tr *Tracker) SetJobError(job Job, errString string) error {
 		return err
 	}
 	// For now, we set state to failed.  We may want something different in future.
-	status.Update(Failed, errString)
+	old := status.Update(Failed, errString)
 	job.failureMetric(errString)
 
 	timeInState := time.Since(status.LastStateChangeTime())
-	metrics.StateTimeHistogram.WithLabelValues(job.Experiment, job.Datatype, string(status.State())).Observe(timeInState.Seconds())
-	metrics.StateDate.WithLabelValues(job.Experiment, job.Datatype, string(status.State())).Set(float64(job.Date.Unix()))
+	metrics.StateTimeHistogram.WithLabelValues(job.Experiment, job.Datatype, string(old.State)).Observe(timeInState.Seconds())
+	metrics.StateDate.WithLabelValues(job.Experiment, job.Datatype, string(old.State)).Set(float64(job.Date.Unix()))
 
 	return tr.UpdateJob(job, status)
 }


### PR DESCRIPTION
This adds two more actions, to copy the deduped partition to raw_ndt, and to delete the rows from the tmp_ndt partition.

There is some code redundancy, and also opportunity for unit test improvement with bqfake.  However, I think it is better to get this checked in, and do that work later.  Feel free to offer opinion about how high priority those improvements should be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/270)
<!-- Reviewable:end -->
