### PR TITLE
Custom error

### DIFF
--- a/ops/actions.go
+++ b/ops/actions.go
@@ -22,7 +22,7 @@ import (
 
 func newStateFunc(detail string) ActionFunc {
 	return func(ctx context.Context, tk *tracker.Tracker, j tracker.Job) *Outcome {
-		return Done(j, detail)
+		return Success(j, detail)
 	}
 }
 
@@ -78,7 +78,7 @@ func waitAndCheck(ctx context.Context, tk *tracker.Tracker, bqJob bqiface.Job, j
 			j.Experiment, j.Datatype,
 			label+"UnknownError").Inc()
 		// This will terminate this job.
-		return status, Fail(j, err, "unknown error")
+		return status, Failure(j, err, "unknown error")
 	}
 	if status.Err() != nil {
 		err := status.Err()
@@ -88,9 +88,9 @@ func waitAndCheck(ctx context.Context, tk *tracker.Tracker, bqJob bqiface.Job, j
 			label+"UnknownStatusError").Inc()
 
 		// This will terminate this job.
-		return status, Fail(j, err, "unknown error")
+		return status, Failure(j, err, "unknown error")
 	}
-	return status, Done(j, "-")
+	return status, Success(j, "-")
 }
 
 // TODO improve test coverage?
@@ -107,7 +107,7 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job) *Outcome
 	if err != nil {
 		log.Println(err)
 		// This terminates this job.
-		return Fail(j, err, "-")
+		return Failure(j, err, "-")
 	}
 	bqJob, err = qp.Run(ctx, "dedup", false)
 	if err != nil {
@@ -121,7 +121,7 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job) *Outcome
 	}
 	if status == nil {
 		// Nil status means the job failed.
-		return Fail(j, errors.New("nil status"), "-")
+		return Failure(j, errors.New("nil status"), "-")
 	}
 
 	// Dedup job was successful.  Handle the statistics, metrics, tracker update.
@@ -140,6 +140,5 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job) *Outcome
 		msg = "Could not convert Detail to QueryStatistics"
 	}
 
-	return Done(j, msg)
+	return Success(j, msg)
 }
-

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -21,7 +21,7 @@ import (
 )
 
 func newStateFunc(detail string) ActionFunc {
-	return func(ctx context.Context, tk *tracker.Tracker, j tracker.Job) *Outcome {
+	return func(ctx context.Context, j tracker.Job) *Outcome {
 		return Success(j, detail)
 	}
 }
@@ -53,7 +53,7 @@ func NewStandardMonitor(ctx context.Context, config cloud.BQConfig, tk *tracker.
 
 // Waits for bqjob to complete, handles backoff and job updates.
 // Returns non-nil status if successful.
-func waitAndCheck(ctx context.Context, tk *tracker.Tracker, bqJob bqiface.Job, j tracker.Job, label string) (*bigquery.JobStatus, *Outcome) {
+func waitAndCheck(ctx context.Context, bqJob bqiface.Job, j tracker.Job, label string) (*bigquery.JobStatus, *Outcome) {
 	status, err := bqJob.Wait(ctx)
 	if err != nil {
 		switch typedErr := err.(type) {
@@ -94,7 +94,7 @@ func waitAndCheck(ctx context.Context, tk *tracker.Tracker, bqJob bqiface.Job, j
 }
 
 // TODO improve test coverage?
-func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job) *Outcome {
+func dedupFunc(ctx context.Context, j tracker.Job) *Outcome {
 	start := time.Now()
 	// This is the delay since entering the dedup state, due to monitor delay
 	// and retries.
@@ -115,7 +115,7 @@ func dedupFunc(ctx context.Context, tk *tracker.Tracker, j tracker.Job) *Outcome
 		// Try again soon.
 		return Retry(j, err, "-")
 	}
-	status, outcome := waitAndCheck(ctx, tk, bqJob, j, "Dedup")
+	status, outcome := waitAndCheck(ctx, bqJob, j, "Dedup")
 	if !errors.Is(outcome, IsDone) {
 		return outcome
 	}

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -116,7 +116,7 @@ func dedupFunc(ctx context.Context, j tracker.Job) *Outcome {
 		return Retry(j, err, "-")
 	}
 	status, outcome := waitAndCheck(ctx, bqJob, j, "Dedup")
-	if !errors.Is(outcome, IsDone) {
+	if !outcome.IsDone() {
 		return outcome
 	}
 	if status == nil {

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -38,11 +38,13 @@ func TestStandardMonitor(t *testing.T) {
 	// We add some new actions in place of the Parser activity.
 	m.AddAction(tracker.Init,
 		nil,
-		newStateFunc(tracker.Parsing),
+		newStateFunc("-"),
+		tracker.Parsing,
 		"Init")
 	m.AddAction(tracker.Parsing,
 		nil,
-		newStateFunc(tracker.ParseComplete),
+		newStateFunc("-"),
+		tracker.ParseComplete,
 		"Parsing")
 
 	// The real dedup action should fail on unknown datatype.

--- a/ops/errors.go
+++ b/ops/errors.go
@@ -1,0 +1,62 @@
+package ops
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+type Outcome struct {
+	job    tracker.Job
+	error  // possibly nil
+	retry  bool
+	detail string
+}
+
+var fakeError = errors.New("")
+var ShouldRetry = &Outcome{retry: true, error: fakeError}
+var ShouldFail = &Outcome{retry: false, error: fakeError}
+var IsDone = &Outcome{retry: false}
+
+func (o *Outcome) Is(target error) bool {
+	t, ok := target.(*Outcome)
+	if !ok {
+		return false
+	}
+	if o.error == nil {
+
+	}
+	return (t.retry == o.retry) &&
+		(t.detail == o.detail || t.detail == "")
+}
+
+func (o Outcome) Error() string {
+	if o.retry {
+		return fmt.Sprintf("%v (Retry: %s)", o.error, o.detail)
+	}
+	return fmt.Sprintf("%v (Fail: %s)", o.error, o.detail)
+}
+
+func (o *Outcome) Unwrap() error {
+	return o.error
+}
+
+func (o *Outcome) Update(tr *tracker.Tracker, state tracker.State) error {
+	if o.error != nil {
+		return tr.SetJobError(o.job, o.detail) // TODO - is this correct?
+	}
+	return tr.SetStatus(o.job, state, o.detail)
+}
+
+func Fail(job tracker.Job, err error, detail string) *Outcome {
+	return &Outcome{job, err, false, detail}
+}
+
+func Retry(job tracker.Job, err error, detail string) *Outcome {
+	return &Outcome{job, err, true, detail}
+}
+
+func Done(job tracker.Job, detail string) *Outcome {
+	return &Outcome{job: job, detail: detail}
+}

--- a/ops/errors.go
+++ b/ops/errors.go
@@ -62,12 +62,12 @@ func (o *Outcome) Update(tr *tracker.Tracker, state tracker.State) error {
 
 // Failure creates a failure Outcome
 func Failure(job tracker.Job, err error, detail string) *Outcome {
-	return &Outcome{job, err, false, detail}
+	return &Outcome{job: job, error: err, retry: false, detail: detail}
 }
 
 // Retry creates a retry type Outcome
 func Retry(job tracker.Job, err error, detail string) *Outcome {
-	return &Outcome{job, err, true, detail}
+	return &Outcome{job: job, error: err, retry: true, detail: detail}
 }
 
 // Success returns a successful outcome.

--- a/ops/errors.go
+++ b/ops/errors.go
@@ -1,7 +1,6 @@
 package ops
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/m-lab/etl-gardener/tracker"
@@ -17,26 +16,14 @@ type Outcome struct {
 	detail string
 }
 
-// Specific errors for errors.Is
-var (
-	errEmpty = errors.New("")
+// ShouldRetry indicates of the operation should be retried later.
+func (o Outcome) ShouldRetry() bool {
+	return o.error != nil && o.retry
+}
 
-	ShouldRetry = &Outcome{retry: true, error: errEmpty} // Non-nil error.
-	ShouldFail  = &Outcome{retry: false, error: errEmpty}
-	IsDone      = &Outcome{retry: false} // nil error
-)
-
-// Is implements errors.Is
-func (o *Outcome) Is(target error) bool {
-	t, ok := target.(*Outcome)
-	if !ok {
-		return false
-	}
-	if (o.error == nil) != (t.error == nil) {
-		return false
-	}
-	return (t.retry == o.retry) &&
-		(t.detail == o.detail || t.detail == "")
+// IsDone indicates if the operation was successful.
+func (o Outcome) IsDone() bool {
+	return o.error == nil
 }
 
 func (o Outcome) Error() string {

--- a/ops/errors_test.go
+++ b/ops/errors_test.go
@@ -2,6 +2,7 @@ package ops_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/m-lab/etl-gardener/ops"
@@ -18,27 +19,42 @@ func TestRetry(t *testing.T) {
 	if errors.Unwrap(r) != base {
 		t.Error("Should be base:", errors.Unwrap(r))
 	}
+	if !strings.Contains(r.Error(), "Retry") {
+		t.Error("Should contain Retry:", r)
+	}
+	if !errors.Is(r, base) {
+		t.Error("Should be a base:", r)
+	}
+	if errors.Is(r, errors.New("other")) {
+		t.Error("Should not be other:", r)
+	}
 }
 
 func TestFail(t *testing.T) {
 	job := tracker.Job{}
 	base := errors.New("base")
-	r := ops.Failure(job, base, "detail")
-	if !errors.Is(r, ops.ShouldFail) {
-		t.Error(r)
+	f := ops.Failure(job, base, "detail")
+	if !errors.Is(f, ops.ShouldFail) {
+		t.Error(f)
 	}
-	if errors.Unwrap(r) != base {
-		t.Error("Should be base:", errors.Unwrap(r))
+	if errors.Unwrap(f) != base {
+		t.Error("Should be base:", errors.Unwrap(f))
+	}
+	if !strings.Contains(f.Error(), "Fail") {
+		t.Error("Should contain Fail:", f)
+	}
+	if !errors.Is(f, base) {
+		t.Error("Should be a base:", f)
 	}
 }
 
 func TestDone(t *testing.T) {
 	job := tracker.Job{}
-	r := ops.Success(job, "detail")
-	if !errors.Is(r, ops.IsDone) {
-		t.Error(r)
+	s := ops.Success(job, "detail")
+	if !errors.Is(s, ops.IsDone) {
+		t.Error(s)
 	}
-	if errors.Unwrap(r) != nil {
-		t.Error("Should be nil:", errors.Unwrap(r))
+	if errors.Unwrap(s) != nil {
+		t.Error("Should be nil:", errors.Unwrap(s))
 	}
 }

--- a/ops/errors_test.go
+++ b/ops/errors_test.go
@@ -1,0 +1,44 @@
+package ops_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/m-lab/etl-gardener/ops"
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+func TestRetry(t *testing.T) {
+	job := tracker.Job{}
+	base := errors.New("base")
+	r := ops.Retry(job, base, "detail")
+	if !errors.Is(r, ops.ShouldRetry) {
+		t.Error(r)
+	}
+	if errors.Unwrap(r) != base {
+		t.Error("Should be base:", errors.Unwrap(r))
+	}
+}
+
+func TestFail(t *testing.T) {
+	job := tracker.Job{}
+	base := errors.New("base")
+	r := ops.Fail(job, base, "detail")
+	if !errors.Is(r, ops.ShouldFail) {
+		t.Error(r)
+	}
+	if errors.Unwrap(r) != base {
+		t.Error("Should be base:", errors.Unwrap(r))
+	}
+}
+
+func TestDone(t *testing.T) {
+	job := tracker.Job{}
+	r := ops.Done(job, "detail")
+	if !errors.Is(r, ops.IsDone) {
+		t.Error(r)
+	}
+	if errors.Unwrap(r) != nil {
+		t.Error("Should be nil:", errors.Unwrap(r))
+	}
+}

--- a/ops/errors_test.go
+++ b/ops/errors_test.go
@@ -46,6 +46,9 @@ func TestFail(t *testing.T) {
 	if !errors.Is(f, base) {
 		t.Error("Should be a base:", f)
 	}
+	if errors.Is(f, ops.IsDone) {
+		t.Error("Should NOT be IsDone:", f)
+	}
 }
 
 func TestDone(t *testing.T) {

--- a/ops/errors_test.go
+++ b/ops/errors_test.go
@@ -23,7 +23,7 @@ func TestRetry(t *testing.T) {
 func TestFail(t *testing.T) {
 	job := tracker.Job{}
 	base := errors.New("base")
-	r := ops.Fail(job, base, "detail")
+	r := ops.Failure(job, base, "detail")
 	if !errors.Is(r, ops.ShouldFail) {
 		t.Error(r)
 	}
@@ -34,7 +34,7 @@ func TestFail(t *testing.T) {
 
 func TestDone(t *testing.T) {
 	job := tracker.Job{}
-	r := ops.Done(job, "detail")
+	r := ops.Success(job, "detail")
 	if !errors.Is(r, ops.IsDone) {
 		t.Error(r)
 	}

--- a/ops/errors_test.go
+++ b/ops/errors_test.go
@@ -13,7 +13,7 @@ func TestRetry(t *testing.T) {
 	job := tracker.Job{}
 	base := errors.New("base")
 	r := ops.Retry(job, base, "detail")
-	if !errors.Is(r, ops.ShouldRetry) {
+	if !r.ShouldRetry() {
 		t.Error(r)
 	}
 	if errors.Unwrap(r) != base {
@@ -34,8 +34,8 @@ func TestFail(t *testing.T) {
 	job := tracker.Job{}
 	base := errors.New("base")
 	f := ops.Failure(job, base, "detail")
-	if !errors.Is(f, ops.ShouldFail) {
-		t.Error(f)
+	if f.ShouldRetry() || f.IsDone() {
+		t.Error("Incorrect:", f)
 	}
 	if errors.Unwrap(f) != base {
 		t.Error("Should be base:", errors.Unwrap(f))
@@ -46,7 +46,7 @@ func TestFail(t *testing.T) {
 	if !errors.Is(f, base) {
 		t.Error("Should be a base:", f)
 	}
-	if errors.Is(f, ops.IsDone) {
+	if f.IsDone() {
 		t.Error("Should NOT be IsDone:", f)
 	}
 }
@@ -54,7 +54,7 @@ func TestFail(t *testing.T) {
 func TestDone(t *testing.T) {
 	job := tracker.Job{}
 	s := ops.Success(job, "detail")
-	if !errors.Is(s, ops.IsDone) {
+	if !s.IsDone() {
 		t.Error(s)
 	}
 	if errors.Unwrap(s) != nil {

--- a/ops/ops.go
+++ b/ops/ops.go
@@ -4,6 +4,7 @@ package ops
 
 import (
 	"context"
+	"errors"
 	"log"
 	"sync"
 	"time"
@@ -62,7 +63,7 @@ type ConditionFunc = func(ctx context.Context, job tracker.Job) bool
 
 // An ActionFunc performs an operation on a job, and updates its state.
 // These functions may take a long time to complete, and may be resource intensive.
-type ActionFunc = func(ctx context.Context, tr *tracker.Tracker, job tracker.Job) *Outcome
+type ActionFunc = func(ctx context.Context, job tracker.Job) *Outcome
 
 // An Action describes an operation to be applied to jobs that meet the required condition.
 type Action struct {
@@ -140,7 +141,10 @@ func (m *Monitor) tryApplyAction(ctx context.Context, a Action, j tracker.Job, s
 			// The op should also update the job state, detail, and error.
 			if a.action != nil {
 				start := time.Now()
-				outcome := a.action(ctx, m.tk, j)
+				outcome := a.action(ctx, j)
+				if errors.Is(outcome, ShouldRetry) {
+					time.Sleep(2 * time.Minute)
+				}
 				outcome.Update(m.tk, a.nextState)
 				// TODO - do we still want this?
 				actionDuration.WithLabelValues(a.Name()).Observe(time.Since(start).Seconds())

--- a/ops/ops.go
+++ b/ops/ops.go
@@ -137,13 +137,19 @@ func (m *Monitor) AddAction(state tracker.State, cond ConditionFunc, op ActionFu
 
 // UpdateJob updates the tracker state with the outcome.
 func (m *Monitor) UpdateJob(o *Outcome, state tracker.State) (string, error) {
+	// Allow error to override implicit (-) detail.
+	detail := o.detail
+	if detail == "-" && o.error != nil {
+		detail = o.error.Error()
+	}
+
 	if errors.Is(o, ShouldFail) {
-		if err := m.tk.SetJobError(o.job, o.detail); err != nil {
+		if err := m.tk.SetJobError(o.job, detail); err != nil {
 			return "set status error", err
 		}
 		return "fail", nil
 	}
-	if err := m.tk.SetStatus(o.job, state, o.detail); err != nil {
+	if err := m.tk.SetStatus(o.job, state, detail); err != nil {
 		return "set status error", err
 	}
 	if errors.Is(o, ShouldRetry) {

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -20,13 +20,9 @@ func init() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
 
-func newStateFunc(state tracker.State) ops.ActionFunc {
-	return func(ctx context.Context, tk *tracker.Tracker, j tracker.Job, s tracker.Status) {
-		log.Println(j, state)
-		err := tk.SetStatus(j, state, "")
-		if err != nil {
-			log.Println(err)
-		}
+func newStateFunc(detail string) ops.ActionFunc {
+	return func(ctx context.Context, tk *tracker.Tracker, j tracker.Job) *ops.Outcome {
+		return ops.Done(j, detail)
 	}
 }
 
@@ -44,23 +40,28 @@ func TestMonitor_Watch(t *testing.T) {
 	rtx.Must(err, "NewMonitor failure")
 	m.AddAction(tracker.Init,
 		nil,
-		newStateFunc(tracker.Parsing),
+		newStateFunc(""),
+		tracker.Parsing,
 		"Init")
 	m.AddAction(tracker.Parsing,
 		nil,
-		newStateFunc(tracker.ParseComplete),
+		newStateFunc(""),
+		tracker.ParseComplete,
 		"Parsing")
 	m.AddAction(tracker.ParseComplete,
 		nil,
-		newStateFunc(tracker.Stabilizing),
+		newStateFunc(""),
+		tracker.Stabilizing,
 		"PostProcessing")
 	m.AddAction(tracker.Stabilizing,
 		nil,
-		newStateFunc(tracker.Deduplicating),
+		newStateFunc(""),
+		tracker.Deduplicating,
 		"Checking for stability")
 	m.AddAction(tracker.Deduplicating,
 		nil,
-		newStateFunc(tracker.Complete),
+		newStateFunc(""),
+		tracker.Complete,
 		"Deduplicating")
 	go m.Watch(ctx, 50*time.Millisecond)
 

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -22,7 +22,7 @@ func init() {
 
 func newStateFunc(detail string) ops.ActionFunc {
 	return func(ctx context.Context, tk *tracker.Tracker, j tracker.Job) *ops.Outcome {
-		return ops.Done(j, detail)
+		return ops.Success(j, detail)
 	}
 }
 

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 func newStateFunc(detail string) ops.ActionFunc {
-	return func(ctx context.Context, tk *tracker.Tracker, j tracker.Job) *ops.Outcome {
+	return func(ctx context.Context, j tracker.Job) *ops.Outcome {
 		return ops.Success(j, detail)
 	}
 }

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -255,7 +255,7 @@ func (s *Status) Elapsed() time.Duration {
 func NewStatus() Status {
 	now := time.Now()
 	return Status{
-		History: []StateInfo{StateInfo{State: Init, Start: now, LastUpdateTime: now}},
+		History: []StateInfo{{State: Init, Start: now, LastUpdateTime: now}},
 	}
 }
 

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -231,12 +231,12 @@ func (tr *Tracker) SetJobError(job Job, errString string) error {
 		return err
 	}
 	// For now, we set state to failed.  We may want something different in future.
-	status.Update(Failed, errString)
+	old := status.Update(Failed, errString)
 	job.failureMetric(errString)
 
 	timeInState := time.Since(status.LastStateChangeTime())
-	metrics.StateTimeHistogram.WithLabelValues(job.Experiment, job.Datatype, string(status.State())).Observe(timeInState.Seconds())
-	metrics.StateDate.WithLabelValues(job.Experiment, job.Datatype, string(status.State())).Set(float64(job.Date.Unix()))
+	metrics.StateTimeHistogram.WithLabelValues(job.Experiment, job.Datatype, string(old.State)).Observe(timeInState.Seconds())
+	metrics.StateDate.WithLabelValues(job.Experiment, job.Datatype, string(old.State)).Set(float64(job.Date.Unix()))
 
 	return tr.UpdateJob(job, status)
 }


### PR DESCRIPTION
This introduces a custom Outcome error type, used to simplify the implementation of actions, and make actions independent of tracker.

It also fixes a small bug in tracker.SetJobError.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/271)
<!-- Reviewable:end -->
