### PR TITLE
Prioritize processing of "yesterday" in universal

### DIFF
--- a/cloud/ds/ds.go
+++ b/cloud/ds/ds.go
@@ -1,0 +1,15 @@
+package ds
+
+import (
+	"context"
+
+	"cloud.google.com/go/datastore"
+	"github.com/googleapis/google-cloud-go-testing/datastore/dsiface"
+)
+
+// Context holds a context for datastore operations
+type Context struct {
+	Ctx    context.Context
+	Client dsiface.Client
+	Key    *datastore.Key
+}

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -185,7 +185,7 @@ func NewJobService(
 	}
 
 	dsSaver := saver{
-		Context: dsCtx,
+		dsCtx: dsCtx,
 	}
 	err := dsSaver.loadFromDatastore()
 	if err == nil {
@@ -254,25 +254,25 @@ type saver struct {
 	CurrentDate   time.Time // Date we should resume processing
 	YesterdayDate time.Time // Current YesterdayDate that should be processed at 0600 UTC.
 
-	ds.Context
+	dsCtx ds.Context
 }
 
 func (ss *saver) save() {
-	if ss.Client == nil {
+	if ss.dsCtx.Client == nil {
 		log.Println("saver not configured")
 		return
 	}
-	ctx, cf := context.WithTimeout(ss.Ctx, 10*time.Second)
+	ctx, cf := context.WithTimeout(ss.dsCtx.Ctx, 10*time.Second)
 	defer cf()
-	_, err := ss.Context.Client.Put(ctx, ss.Key, ss)
+	_, err := ss.dsCtx.Client.Put(ctx, ss.dsCtx.Key, ss)
 	if err != nil {
 		log.Println(err)
 	}
 }
 
 func (ss *saver) loadFromDatastore() error {
-	if ss.Client == nil {
+	if ss.dsCtx.Client == nil {
 		return tracker.ErrClientIsNil
 	}
-	return ss.Client.Get(ss.Ctx, ss.Key, ss)
+	return ss.dsCtx.Client.Get(ss.dsCtx.Ctx, ss.dsCtx.Key, ss)
 }

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -78,6 +78,12 @@ func TestService_NextJob(t *testing.T) {
 }
 
 func TestJobHandler(t *testing.T) {
+	// This allows predictable behavior w.r.t. yesterday processing.
+	monkey.Patch(time.Now, func() time.Time {
+		return time.Date(2011, 2, 6, 1, 2, 3, 4, time.UTC)
+	})
+	defer monkey.Unpatch(time.Now)
+
 	sources := []config.SourceConfig{
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
@@ -105,6 +111,12 @@ func TestJobHandler(t *testing.T) {
 }
 
 func TestResume(t *testing.T) {
+	// This allows predictable behavior w.r.t. yesterday processing.
+	monkey.Patch(time.Now, func() time.Time {
+		return time.Date(2011, 2, 6, 1, 2, 3, 4, time.UTC)
+	})
+	defer monkey.Unpatch(time.Now)
+
 	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)
 	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0, 0) // Only using jobmap.
 	if err != nil {

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -254,18 +254,19 @@ func TestYesterday(t *testing.T) {
 			t.Error(k, "Got:", resp.Body.String(), "!=", result.body)
 		}
 
-		if k == 2 {
+		if k == 200 {
 			job := tracker.Job{}
 			json.Unmarshal([]byte(expected[0].body), &job)
-			status, _ := tk.GetStatus(job)
+			status, err := tk.GetStatus(job)
+			rtx.Must(err, job.String())
 			status.Update(tracker.Complete, "")
-			err := tk.UpdateJob(job, status)
+			err = tk.UpdateJob(job, status)
 			if err != nil {
 				t.Error(err)
 			}
 		}
 
-		// On each cycle, advance the monkey time.
+		// On each cycle, advance the monkey time by a bit over 4 hours.
 		mt = mt.Add(250 * time.Minute)
 
 	}

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -155,7 +155,14 @@ func (tr *Tracker) AddJob(job Job) error {
 		return ErrJobAlreadyExists
 	}
 
-	tr.lastJob = job
+	// With the introduction of yesterday processing, we need to
+	// ignore AddJob for yesterday, so that we don't lose track of
+	// the resume date.
+	// This is a bit hacky mechanism to do that.
+	if time.Since(job.Date) < 48*time.Hour {
+		tr.lastJob = job
+	}
+
 	tr.lastModified = time.Now()
 	metrics.StartedCount.WithLabelValues(job.Experiment, job.Datatype).Inc()
 	// TODO - should call this JobsInFlight, to avoid confusion with Tasks in parser.


### PR DESCRIPTION
This prioritizes the processing of yesterday's data at 0600 UTC each day.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/277)
<!-- Reviewable:end -->
