### PR TITLE
Prioritize processing yesterday's data.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ script:
 
 # Combine coverage of unit tests and integration tests and send the results to coveralls.
 - $HOME/gopath/bin/gocovmerge _*.cov > _merge.cov
-- $HOME/gopath/bin/goveralls -coverprofile=_merge.cov -service=travis-ci
+- $HOME/gopath/bin/goveralls -coverprofile=_merge.cov -service=travis-ci || true  # Ignore failure
 
 # Docker build is done in google cloud builer
 
@@ -119,9 +119,6 @@ deploy:
   script:
     DATE_SKIP="2" TASK_FILE_SKIP="4"
     $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing-cluster ./apply-cluster.sh
-    &&
-    DATE_SKIP="2" TASK_FILE_SKIP="4"
-    $TRAVIS_BUILD_DIR/travis/kubectl.sh mlab-sandbox data-processing ./apply-cluster.sh
   on:
     repo: m-lab/etl-gardener
     all_branches: true

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -78,6 +78,12 @@ func TestService_NextJob(t *testing.T) {
 }
 
 func TestJobHandler(t *testing.T) {
+	// This allows predictable behavior w.r.t. yesterday processing.
+	monkey.Patch(time.Now, func() time.Time {
+		return time.Date(2011, 2, 6, 1, 2, 3, 4, time.UTC)
+	})
+	defer monkey.Unpatch(time.Now)
+
 	sources := []config.SourceConfig{
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
@@ -105,6 +111,12 @@ func TestJobHandler(t *testing.T) {
 }
 
 func TestResume(t *testing.T) {
+	// This allows predictable behavior w.r.t. yesterday processing.
+	monkey.Patch(time.Now, func() time.Time {
+		return time.Date(2011, 2, 6, 1, 2, 3, 4, time.UTC)
+	})
+	defer monkey.Unpatch(time.Now)
+
 	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)
 	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0, 0) // Only using jobmap.
 	if err != nil {


### PR DESCRIPTION
This adds prioritization of yesterday's data at 6:00 UTC each day.

It also tweaks travis, so that universal is NOT deployed on sandbox-*, only on u-sandbox-*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/278)
<!-- Reviewable:end -->
