### PR TITLE
fix Retry handling

### DIFF
--- a/ops/ops.go
+++ b/ops/ops.go
@@ -149,7 +149,7 @@ func (m *Monitor) UpdateJob(o *Outcome, state tracker.State) (string, error) {
 		}
 		return "done", nil
 	case o.ShouldRetry():
-		if err := m.tk.SetStatus(o.job, state, detail); err != nil {
+		if err := m.tk.SetDetail(o.job, detail); err != nil {
 			return "set status error", err
 		}
 		return "retry", nil

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -189,6 +189,18 @@ func (tr *Tracker) UpdateJob(job Job, state Status) error {
 	return nil
 }
 
+// SetDetail updates a job's detail message in memory.
+func (tr *Tracker) SetDetail(job Job, detail string) error {
+	// NOTE: This is not a deep copy.  Shares the History elements.
+	status, err := tr.GetStatus(job)
+	if err != nil {
+		return err
+	}
+	status.UpdateDetail(detail)
+	status.UpdateCount++
+	return tr.UpdateJob(job, status)
+}
+
 // SetStatus updates a job's state in memory.
 func (tr *Tracker) SetStatus(job Job, newState State, detail string) error {
 	status, err := tr.GetStatus(job)

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -164,9 +164,7 @@ func TestTrackerAddDelete(t *testing.T) {
 
 }
 
-// This tests basic Add and update of one jobs, and verifies
-// correct error returned when trying to update a non-existent job.
-func TestUpdate(t *testing.T) {
+func TestUpdates(t *testing.T) {
 	client := dsfake.NewClient()
 	dsKey := datastore.NameKey("TestUpdate", "jobs", nil)
 	dsKey.Namespace = "gardener"
@@ -178,15 +176,20 @@ func TestUpdate(t *testing.T) {
 	createJobs(t, tk, "JobToUpdate", "type", 1)
 
 	job := tracker.Job{"bucket", "JobToUpdate", "type", startDate, ""}
-	must(t, tk.SetStatus(job, tracker.Parsing, ""))
-	must(t, tk.SetStatus(job, tracker.Stabilizing, ""))
+	must(t, tk.SetStatus(job, tracker.Parsing, "foo"))
+	must(t, tk.SetStatus(job, tracker.Stabilizing, "bar"))
 
 	status, err := tk.GetStatus(job)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	if status.State() != tracker.Stabilizing {
 		t.Error("Incorrect job state", job)
+	}
+
+	must(t, tk.SetDetail(job, "foobar"))
+	status, err = tk.GetStatus(job)
+	must(t, err)
+	if status.LastUpdate() != "foobar" {
+		t.Error("Incorrect detail", status.LastStateInfo())
 	}
 
 	err = tk.SetStatus(tracker.Job{"bucket", "JobToUpdate", "other-type", startDate, ""}, tracker.Stabilizing, "")


### PR DESCRIPTION
Found a bug in handling tracker updates from Outcome.  Retry was advancing the state, rather than doing the retry.

This adds a unit test and fixes the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/282)
<!-- Reviewable:end -->
