### PR TITLE
Job Service persistence

### DIFF
--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m-lab/etl-gardener/config"
 	job "github.com/m-lab/etl-gardener/job-service"
 	"github.com/m-lab/etl-gardener/ops"
+	"github.com/m-lab/etl-gardener/persistence"
 	"github.com/m-lab/etl-gardener/reproc"
 	"github.com/m-lab/etl-gardener/rex"
 	"github.com/m-lab/etl-gardener/state"
@@ -380,12 +381,13 @@ func main() {
 		handler := tracker.NewHandler(globalTracker)
 		handler.Register(mux)
 
-		// For now, we just start in Aug 2019, and handle only new data.
-
+		saver, err := persistence.NewDatastoreSaver(context.Background(), os.Getenv("PROJECT"))
+		rtx.Must(err, "Could not initialize datastore saver")
 		svc, err := job.NewJobService(globalTracker, config.StartDate(),
-			os.Getenv("PROJECT"), config.Sources())
+			os.Getenv("PROJECT"), config.Sources(), saver)
 		rtx.Must(err, "Could not initialize job service")
 		mux.HandleFunc("/job", svc.JobHandler)
+
 		healthy = true
 		log.Println("Running as manager service")
 	case "legacy":

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -2,20 +2,18 @@
 package job
 
 import (
+	"context"
 	"errors"
 	"log"
 	"net/http"
+	"reflect"
 	"sync"
 	"time"
 
-	"github.com/m-lab/etl-gardener/client"
 	"github.com/m-lab/etl-gardener/config"
+	"github.com/m-lab/etl-gardener/persistence"
 	"github.com/m-lab/etl-gardener/tracker"
 )
-
-// NextJob is required until etl code migrates to client.NextJob
-// DEPRECATED
-var NextJob = client.NextJob
 
 // ErrMoreJSON is returned when response from gardener has unknown fields.
 var ErrMoreJSON = errors.New("JSON body not completely consumed")
@@ -24,25 +22,44 @@ var ErrMoreJSON = errors.New("JSON body not completely consumed")
 // It iterates through successive dates, processing that date from
 // all TypeSources in the source bucket.
 type Service struct {
-	lock sync.Mutex
+	jobSpecs []tracker.JobWithTarget // The job prefixes to be iterated through.
+
+	saverCtx context.Context
+	saver    persistence.Saver // This injected to implement persistence.
+
+	startDate time.Time // The date to restart at.
 
 	// Optional tracker to add jobs to.
 	tracker *tracker.Tracker
 
-	startDate time.Time // The date to restart at.
-	date      time.Time // The date currently being dispatched.
+	// All fields above are const after initialization.
+	// All fields below are protected by *lock*
+	lock sync.Mutex
 
-	jobSpecs  []tracker.JobWithTarget // The job prefixes to be iterated through.
-	nextIndex int                     // index of TypeSource to dispatch next.
+	// The Date is exported for persistence.  It is the only field
+	// that is recovered after restart.  All others are injected
+	// from config.
+	Date time.Time // The date currently being dispatched.
+
+	nextIndex int // index of TypeSource to dispatch next.
 }
 
 func (svc *Service) advanceDate() {
-	date := svc.date.UTC().Add(24 * time.Hour).Truncate(24 * time.Hour)
+	date := svc.Date.UTC().AddDate(0, 0, 1).Truncate(24 * time.Hour)
+	// Start over when we reach yesterday.
 	if time.Since(date) < 36*time.Hour {
 		date = svc.startDate
 	}
-	svc.date = date
+	svc.Date = date
 	svc.nextIndex = 0
+}
+
+// CurrentDate returns the date currently being processed.
+// Primarily used for testing.
+func (svc *Service) CurrentDate() time.Time {
+	svc.lock.Lock()
+	defer svc.lock.Unlock()
+	return svc.Date
 }
 
 // NextJob returns a tracker.Job to dispatch.
@@ -53,7 +70,7 @@ func (svc *Service) NextJob() tracker.JobWithTarget {
 		svc.advanceDate()
 	}
 	job := svc.jobSpecs[svc.nextIndex]
-	job.Date = svc.date
+	job.Date = svc.Date
 	svc.nextIndex++
 	return job
 }
@@ -91,12 +108,36 @@ func (svc *Service) JobHandler(resp http.ResponseWriter, req *http.Request) {
 	}
 }
 
+// Recover the processing date.
+// Not thread-safe - should be called before activating service.
+func (svc *Service) recoverDate() {
+	// Default to tracker.LastJob date.
+	if svc.tracker != nil {
+		svc.Date = svc.tracker.LastJob().Date
+	}
+
+	// If saver provided, try to recover date from saver.
+	if svc.saver != nil {
+		err := svc.saver.Fetch(svc.saverCtx, svc)
+		if err != nil {
+			log.Println(err)
+		}
+	}
+
+	// Adjust if Date is too early.
+	if svc.Date.Before(svc.startDate) {
+		svc.Date = svc.startDate
+	}
+}
+
 // ErrInvalidStartDate is returned if startDate is time.Time{}
 var ErrInvalidStartDate = errors.New("Invalid start date")
 
 // NewJobService creates the default job service.
 func NewJobService(tk *tracker.Tracker, startDate time.Time,
-	targetBase string, sources []config.SourceConfig) (*Service, error) {
+	targetBase string, sources []config.SourceConfig,
+	saver persistence.Saver,
+) (*Service, error) {
 	if startDate.Equal(time.Time{}) {
 		return nil, ErrInvalidStartDate
 	}
@@ -123,23 +164,27 @@ func NewJobService(tk *tracker.Tracker, startDate time.Time,
 		log.Fatal("No jobs specified")
 	}
 
-	resume := startDate
-
-	if tk == nil {
-		return &Service{tracker: tk, startDate: startDate, date: resume, nextIndex: 0, jobSpecs: specs}, nil
+	svc := Service{tracker: tk,
+		saverCtx:  context.Background(),
+		saver:     saver,
+		startDate: startDate,
+		nextIndex: 0,
+		jobSpecs:  specs,
 	}
 
-	// Last job from tracker recovery.  This may be empty Job{} if recovery failed.
-	lastJob := tk.LastJob()
-	log.Println("Last job was:", lastJob)
+	svc.recoverDate()
 
-	// TODO check for spec bucket change
-	if resume.Before(lastJob.Date) {
-		// override the resume date if lastJob was later.
-		resume = lastJob.Date
-	}
-	// Ok to start here.  If there are repeated jobs, the job-service will skip
-	// them.  If they are already finished, then ok to repeat them, though a little inefficient.
-	svc := Service{tracker: tk, startDate: startDate, date: resume, nextIndex: 0, jobSpecs: specs}
 	return &svc, nil
+}
+
+// ---------- Implement persistence.StateObject -------------
+
+// GetName implements StateObject.GetName
+func (svc *Service) GetName() string {
+	return "singleton" // There is only one job service.
+}
+
+// GetKind implements StateObject.GetKind
+func (svc *Service) GetKind() string {
+	return reflect.TypeOf(svc).Name()
 }

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -38,7 +38,7 @@ func TestService_NextJob(t *testing.T) {
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
 	}
 	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)
-	svc, _ := job.NewJobService(nil, start, "fakebucket", sources)
+	svc, _ := job.NewJobService(nil, start, "fakebucket", sources, nil)
 	j := svc.NextJob()
 	w, err := tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start.Truncate(24 * time.Hour)}.Target("fakebucket.tmp_ndt.ndt5")
 	rtx.Must(err, "")
@@ -83,7 +83,7 @@ func TestJobHandler(t *testing.T) {
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
 	}
 	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)
-	svc, _ := job.NewJobService(nil, start, "fakebucket", sources)
+	svc, _ := job.NewJobService(nil, start, "fakebucket", sources, nil)
 	req := httptest.NewRequest("", "/job", nil)
 	resp := httptest.NewRecorder()
 	svc.JobHandler(resp, req)
@@ -118,7 +118,7 @@ func TestResume(t *testing.T) {
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
 	}
-	svc, _ := job.NewJobService(tk, start, "fake-bucket", sources)
+	svc, _ := job.NewJobService(tk, start, "fake-bucket", sources, nil)
 	j := svc.NextJob()
 	if j.Date != last.Date {
 		t.Error(j, last)
@@ -141,7 +141,7 @@ func TestEarlyWrapping(t *testing.T) {
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
 	}
-	svc, _ := job.NewJobService(tk, start, "fake-bucket", sources)
+	svc, _ := job.NewJobService(tk, start, "fake-bucket", sources, nil)
 
 	// If a job is still present in the tracker when it wraps, /job returns an error.
 	expected := []struct {

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -51,7 +51,7 @@ func NewDatastoreSaver(ctx context.Context, project string) (*DatastoreSaver, er
 	if err != nil {
 		return nil, err
 	}
-	return &DatastoreSaver{Client: client, Namespace: "scoreboard"}, nil
+	return &DatastoreSaver{Client: client, Namespace: "gardener"}, nil
 }
 
 func (ds *DatastoreSaver) key(o StateObject) *datastore.Key {


### PR DESCRIPTION
This separates the persistence for job-service from tracker, to simplify and make it easier to extend.  The persistence package also allows easier unit testing by injecting an arbitrary "saver" object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/283)
<!-- Reviewable:end -->
