### PR TITLE
Support standard column datatypes: ndt7 & annotation

### DIFF
--- a/cloud/bq/ops.go
+++ b/cloud/bq/ops.go
@@ -180,7 +180,7 @@ AND NOT EXISTS (
       {{range $k, $v := .Partition}}{{$v}}, {{end}}
 	  parser.Time,
       ROW_NUMBER() OVER (
-        PARTITION BY {{range $k, $v := .Partition}}{{$v}}, {{end}}parser.Time
+        PARTITION BY {{range $k, $v := .Partition}}{{$v}}, {{end}}date
         ORDER BY {{.Order}} parser.Time DESC
       ) row_number
       FROM (

--- a/cloud/bq/ops_test.go
+++ b/cloud/bq/ops_test.go
@@ -12,22 +12,19 @@ import (
 )
 
 func TestTemplate(t *testing.T) {
-	job := tracker.NewJob("bucket", "ndt", "tcpinfo", time.Date(2019, 3, 4, 0, 0, 0, 0, time.UTC))
+	job := tracker.NewJob("bucket", "ndt", "annotation", time.Date(2019, 3, 4, 0, 0, 0, 0, time.UTC))
 	q, err := bq.NewQuerier(job, "fake-project")
 	rtx.Must(err, "dedup.Query failed")
 	qs := q.QueryFor("dedup")
-	if !strings.Contains(qs, "uuid") {
+	if !strings.Contains(qs, "keep.id") {
 		t.Error("query should contain keep.uuid:\n", q)
 	}
 	if !strings.Contains(qs, `"2019-03-04"`) {
 		t.Error(`query should contain "2019-03-04":\n`, q)
 	}
-	if !strings.Contains(qs, "ParseInfo.TaskFileName") {
-		t.Error("query should contain ParseInfo.TaskFileName:\n", q)
-	}
 	// TODO check final WHERE clause.
-	if !strings.Contains(qs, "target.ParseInfo.ParseTime = keep.ParseTime") {
-		t.Error("query should contain target.ParseInfo.ParseTime = ... :\n", qs)
+	if !strings.Contains(qs, "target.parser.Time = keep.Time") {
+		t.Error("query should contain target.parser.Time = ... :\n", qs)
 	}
 }
 
@@ -38,7 +35,7 @@ func TestValidateQueries(t *testing.T) {
 		t.Log("Skipping test for --short")
 	}
 	ctx := context.Background()
-	dataTypes := []string{"tcpinfo", "annotation", "ndt7"}
+	dataTypes := []string{"annotation", "ndt7"}
 	keys := []string{"dedup", "cleanup"} // TODO Add "preserve" query
 	// Test for each datatype
 	for _, dataType := range dataTypes {
@@ -68,7 +65,7 @@ func TestValidateQueries(t *testing.T) {
 			}
 			status := j.LastStatus()
 			if status.Err() != nil {
-				t.Fatal(t.Name(), err)
+				t.Fatal(t.Name(), status.Err())
 			}
 		})
 	}

--- a/config/config.yml
+++ b/config/config.yml
@@ -13,7 +13,7 @@ sources:
   experiment: ndt
   datatype: annotation
   target: tmp_ndt.annotation
-- bucket: archive-measurement-lab
-  experiment: ndt
-  datatype: tcpinfo
-  target: tmp_ndt.tcpinfo
+#- bucket: archive-measurement-lab
+#  experiment: ndt
+#  datatype: tcpinfo
+#  target: tmp_ndt.tcpinfo

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -31,7 +31,7 @@ func TestStandardMonitor(t *testing.T) {
 	tk.AddJob(tracker.NewJob("bucket", "exp2", "tcpinfo", time.Now()))
 	// Valid experiment and datatype
 	// This does an actual dedup, so we need to allow enough time.
-	tk.AddJob(tracker.NewJob("bucket", "ndt", "tcpinfo", time.Now()))
+	tk.AddJob(tracker.NewJob("bucket", "ndt", "annotation", time.Now()))
 
 	m, err := ops.NewStandardMonitor(context.Background(), cloud.BQConfig{}, tk)
 	rtx.Must(err, "NewMonitor failure")


### PR DESCRIPTION
This change updates the default "Querier" config with support for ndt7 and annotation datatypes using standard columns.

Because this requires significant changes to the dedup query, the tcpinfo schema is no long supported. This change also updates the unit tests to prefer the annotation datatype and skip tcpinfo.

To support unit tests, I also updated the mlab-testing tables for ndt7 and annotation datatypes. The etl-gardener is running in the mlab-sandbox data-processing cluster.

Before merging, the ndt7 and annotation datatypes in mlab-staging must be deleted and recreated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/284)
<!-- Reviewable:end -->
