### PR TITLE
use copy on write on status history updates

### DIFF
--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -260,7 +260,7 @@ func TestEarlyWrapping(t *testing.T) {
 			job := tracker.Job{}
 			json.Unmarshal([]byte(expected[0].body), &job)
 			status, _ := tk.GetStatus(job)
-			status.Update(tracker.Complete, "")
+			status.NewState(tracker.Complete)
 			err := tk.UpdateJob(job, status)
 			if err != nil {
 				t.Error(err)

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -101,7 +101,7 @@ func TestOutcomeUpdate(t *testing.T) {
 
 	status, err := tk.GetStatus(job)
 	must(t, err)
-	if status.LastUpdate() != "foobar" {
-		t.Error(status.LastUpdate())
+	if status.Detail() != "foobar" {
+		t.Error(status.Detail())
 	}
 }

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -144,8 +144,8 @@ func TestErrorHandler(t *testing.T) {
 	postAndExpect(t, url, http.StatusOK)
 	stat, err := tk.GetStatus(job)
 	must(t, err)
-	if stat.LastUpdate() != "error" {
-		t.Error("Expected error:", stat.LastUpdate())
+	if stat.Detail() != "error" {
+		t.Error("Expected error:", stat.Detail())
 	}
 	if stat.State() != tracker.ParseError {
 		t.Error("Wrong state:", stat)

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -153,7 +153,15 @@ type StateInfo struct {
 	LastUpdate     string // status or error, e.g. last filename in Parsing state.
 }
 
+// NewStateInfo returns a properly initialized StateInfo
+func NewStateInfo(state State) StateInfo {
+	now := time.Now()
+	si := StateInfo{State: state, Start: now, LastUpdateTime: now}
+	return si
+}
+
 // Update changes the update time and detail string (if != "-").
+// NOT THREADSAFE.  Caller must control access.
 func (si *StateInfo) Update(detail string) {
 	si.LastUpdateTime = time.Now()
 	if detail != "-" {
@@ -171,13 +179,15 @@ type Status struct {
 
 	UpdateCount int // Number of updates
 
+	// History has shared backing store.  Copy on write is used to avoid
+	// changing the underlying StateInfo that is shared by the tracker
+	// JobMap and accessed concurrently by other goroutines.
 	History []StateInfo
 }
 
-// LastStateInfo returns the StateInfo for the most recent state.
-func (s *Status) LastStateInfo() *StateInfo {
-	// TODO check for no history, and create one on the fly?
-	return &s.History[len(s.History)-1]
+// LastStateInfo returns copy of the StateInfo for the most recent state.
+func (s *Status) LastStateInfo() StateInfo {
+	return s.History[len(s.History)-1]
 }
 
 // State returns the job State enum.
@@ -186,8 +196,15 @@ func (s *Status) State() State {
 }
 
 // LastUpdate returns the most recent update detail string.
+// NOTE: update field for Failed state is the error message, so
+// the previous StateInfo is used for LastUpdate.
+// TODO - is this the behavior we want?
 func (s *Status) LastUpdate() string {
-	return s.LastStateInfo().LastUpdate
+	lsi := s.LastStateInfo()
+	if lsi.State == Failed && len(s.History) > 1 {
+		lsi = s.History[len(s.History)-2]
+	}
+	return lsi.LastUpdate
 }
 
 // UpdateTime returns the timestamp of the most recent update.
@@ -205,9 +222,23 @@ func (s *Status) StartTime() time.Time {
 	return s.History[0].Start
 }
 
-// UpdateDetail changes the current state's detail
-func (s *Status) UpdateDetail(detail string) {
-	s.LastStateInfo().Update(detail)
+// UpdateDetail replaces the most recent StateInfo with copy containing new detail.
+// It returns the previous StateInfo value.
+func (s *Status) UpdateDetail(detail string) StateInfo {
+	result := s.LastStateInfo()
+	if detail != "-" {
+		// The History is not deep copied, so we do copy on write
+		// to avoid race.
+		h := make([]StateInfo, len(s.History), cap(s.History))
+		copy(h, s.History)
+
+		last := len(h) - 1
+		lsi := &h[last]
+		lsi.Update(detail)
+		// Replace the entire history
+		s.History = h
+	}
+	return result
 }
 
 func (s *Status) Error() string {
@@ -218,24 +249,24 @@ func (s *Status) Error() string {
 	return ""
 }
 
-// Update changes the current state and detail, and returns
-// the previous final StateInfo.
+// Update applies the detail as LastUpdate, and transitions to new State
+// if different from the previous state.
+// Returns the previous StateInfo
 func (s *Status) Update(state State, detail string) StateInfo {
-	target := s.LastStateInfo()
-	result := *target // Make a copy
-	if target.State != state {
-		s.History = append(s.History, StateInfo{State: state, Start: time.Now()})
-		target = s.LastStateInfo()
+	old := s.UpdateDetail(detail)
+	if old.State != state {
+		s.History = append(s.History, NewStateInfo(state))
+		// For failure, we want to record the error in the final state, too.
+		// TODO - deprecate ParseError?
+		if state == Failed || state == ParseError {
+			s.UpdateDetail(detail)
+		}
 	}
-	target.Update(detail)
-	return result
+	return old
 }
 
 func (s Status) String() string {
 	last := s.LastStateInfo()
-	if last == nil {
-		return "no state history"
-	}
 	return fmt.Sprintf("%s %s (%s)",
 		s.UpdateTime().Format("01/02~15:04:05"),
 		last.State,

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -196,9 +196,7 @@ func (s *Status) State() State {
 }
 
 // LastUpdate returns the most recent update detail string.
-// NOTE: update field for Failed state is the error message, so
-// the previous StateInfo is used for LastUpdate.
-// TODO - is this the behavior we want?
+// If the detail is empty, returns the previous state detail.
 func (s *Status) LastUpdate() string {
 	lsi := s.LastStateInfo()
 	if lsi.State == Failed && len(s.History) > 1 {

--- a/tracker/job_test.go
+++ b/tracker/job_test.go
@@ -1,0 +1,63 @@
+package tracker_test
+
+import (
+	"testing"
+
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+func TestStatusUpdate(t *testing.T) {
+	s := tracker.NewStatus()
+	s.Update(tracker.Parsing, "init done")
+	if s.History[0].LastUpdate != "init done" {
+		t.Error(s.History[0])
+	}
+	s.UpdateDetail("Still parsing")
+	if s.LastUpdate() != "Still parsing" {
+		t.Error(s.LastUpdate())
+	}
+
+	// Each Update with new State should result in empty LastUpdate field.
+	s.Update(tracker.Deduplicating, "Parsing complete")
+	if s.LastUpdate() != "" {
+		t.Error(s.LastUpdate())
+	}
+
+	s.Update(tracker.Complete, "Dedup took xxx")
+	if len(s.History) != 4 {
+		t.Error("length =", len(s.History))
+	}
+	last := s.LastStateInfo()
+	if last.LastUpdate != "" {
+		t.Error(last)
+	}
+	t.Log(s.LastUpdate())
+}
+
+func TestStatusFailure(t *testing.T) {
+	s := tracker.NewStatus()
+	s.Update(tracker.Parsing, "init done")
+	if s.History[0].LastUpdate != "init done" {
+		t.Error(s.History[0])
+	}
+	s.UpdateDetail("Still parsing")
+	if s.LastUpdate() != "Still parsing" {
+		t.Error(s.LastUpdate())
+	}
+
+	// Each Update with new State should result in empty LastUpdate field.
+	s.Update(tracker.Deduplicating, "Parsing complete")
+	if s.LastUpdate() != "" {
+		t.Error(s.LastUpdate())
+	}
+
+	s.Update(tracker.Failed, "failed")
+	if len(s.History) != 4 {
+		t.Error("length =", len(s.History))
+	}
+	last := s.LastStateInfo()
+	if last.LastUpdate != "failed" {
+		t.Error(last)
+	}
+	t.Log(s.LastUpdate())
+}

--- a/tracker/job_test.go
+++ b/tracker/job_test.go
@@ -8,64 +8,64 @@ import (
 
 func TestStatusUpdate(t *testing.T) {
 	s := tracker.NewStatus()
-	s.UpdateDetail("done")
+	s.SetDetail("done")
 	s.NewState(tracker.Parsing)
-	s.UpdateDetail("parsing")
-	if s.LastUpdate() != "parsing" {
-		t.Error(s.LastUpdate())
+	s.SetDetail("parsing")
+	if s.Detail() != "parsing" {
+		t.Error(s.Detail())
 	}
-	if s.History[0].LastUpdate != "done" {
+	if s.History[0].Detail != "done" {
 		t.Error(s.History[0])
 	}
 
-	s.UpdateDetail("Parsing complete")
-	// NewState should still return old LastUpdate.
+	s.SetDetail("Parsing complete")
+	// NewState should still return old Detail.
 	s.NewState(tracker.Deduplicating)
-	if s.LastUpdate() != "Parsing complete" {
-		t.Error(s.LastUpdate())
+	if s.Detail() != "Parsing complete" {
+		t.Error(s.Detail())
 	}
 
-	s.UpdateDetail("Dedup took xxx")
+	s.SetDetail("Dedup took xxx")
 	s.NewState(tracker.Complete)
 	if len(s.History) != 4 {
 		t.Error("length =", len(s.History))
 	}
 	last := s.LastStateInfo()
-	// LastStateInfo's update should be empty.
-	if last.LastUpdate != "" {
+	// LastStateInfo's detail should be empty.
+	if last.Detail != "" {
 		t.Error(last)
 	}
-	t.Log(s.LastUpdate())
+	t.Log(s.Detail())
 }
 
 func TestStatusFailure(t *testing.T) {
 	s := tracker.NewStatus()
-	s.UpdateDetail("done")
+	s.SetDetail("done")
 	s.NewState(tracker.Parsing)
-	s.UpdateDetail("parsing")
-	if s.LastUpdate() != "parsing" {
-		t.Error(s.LastUpdate())
+	s.SetDetail("parsing")
+	if s.Detail() != "parsing" {
+		t.Error(s.Detail())
 	}
 	// Original detail unchanged...
-	if s.History[0].LastUpdate != "done" {
+	if s.History[0].Detail != "done" {
 		t.Error(s.History[0])
 	}
 
-	// NewState should still return old LastUpdate.
+	// NewState should still return old Detail.
 	s.NewState(tracker.Deduplicating)
 	// Should still get old update.
-	if s.LastUpdate() != "parsing" {
-		t.Error(s.LastUpdate())
+	if s.Detail() != "parsing" {
+		t.Error(s.Detail())
 	}
 
 	s.NewState(tracker.Failed)
 	if len(s.History) != 4 {
 		t.Error("length =", len(s.History))
 	}
-	// LastStateInfo should have empty update.
+	// LastStateInfo should have empty Detail.
 	last := s.LastStateInfo()
-	if last.LastUpdate != "" {
+	if last.Detail != "" {
 		t.Error(last)
 	}
-	t.Log(s.LastUpdate())
+	t.Log(s.Detail())
 }

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -211,7 +211,7 @@ func (tr *Tracker) SetDetail(job Job, detail string) error {
 	if err != nil {
 		return err
 	}
-	status.UpdateDetail(detail)
+	status.SetDetail(detail)
 	status.UpdateCount++
 	return tr.UpdateJob(job, status)
 }
@@ -227,7 +227,7 @@ func (tr *Tracker) SetStatus(job Job, state State, detail string) error {
 		return err
 	}
 	last := status.LastStateInfo()
-	status.UpdateDetail(detail)
+	status.SetDetail(detail)
 
 	if state != last.State {
 		status.NewState(state)
@@ -264,7 +264,7 @@ func (tr *Tracker) SetJobError(job Job, errString string) error {
 	job.failureMetric(oldState, errString)
 	status.NewState(Failed)
 	// Set the final detail to include the prior state and error message.
-	status.UpdateDetail(fmt.Sprintf("%s: %s", oldState, errString))
+	status.SetDetail(fmt.Sprintf("%s: %s", oldState, errString))
 
 	return tr.UpdateJob(job, status)
 }
@@ -277,7 +277,7 @@ func (tr *Tracker) GetState() (JobMap, Job, time.Time) {
 	m := make(JobMap, len(tr.jobs))
 	for j, s := range tr.jobs {
 		// Remove any obsolete jobs.
-		updateTime := s.UpdateTime()
+		updateTime := s.DetailTime()
 		if (tr.expirationTime > 0 && time.Since(updateTime) > tr.expirationTime) ||
 			(s.isDone() && time.Since(updateTime) > tr.cleanupDelay) {
 			if !s.isDone() {

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -136,6 +136,8 @@ func (tr *Tracker) saveEvery(interval time.Duration) {
 }
 
 // GetStatus retrieves the status of an existing job.
+// Note that the returned object is a shallow copy, and the History
+// field shares the slice objects with the JobMap.
 func (tr *Tracker) GetStatus(job Job) (Status, error) {
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
@@ -211,6 +213,7 @@ func (tr *Tracker) SetDetail(job Job, detail string) error {
 
 // SetStatus updates a job's state in memory.
 func (tr *Tracker) SetStatus(job Job, newState State, detail string) error {
+	// NOTE: This is not a deep copy.  Shares the History elements.
 	status, err := tr.GetStatus(job)
 	if err != nil {
 		return err

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -188,7 +188,7 @@ func TestUpdates(t *testing.T) {
 	must(t, tk.SetDetail(job, "foobar"))
 	status, err = tk.GetStatus(job)
 	must(t, err)
-	if status.LastUpdate() != "foobar" {
+	if status.Detail() != "foobar" {
 		t.Error("Incorrect detail", status.LastStateInfo())
 	}
 

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -108,9 +108,9 @@ func TestTrackerAddDelete(t *testing.T) {
 		t.Fatal("nil Tracker")
 	}
 
-	numJobs := 500
-	createJobs(t, tk, "500Jobs", "type", numJobs)
-	if tk.NumJobs() != 500 {
+	numJobs := 100
+	createJobs(t, tk, "100Jobs", "type", numJobs)
+	if tk.NumJobs() != 100 {
 		t.Fatal("Incorrect number of jobs", tk.NumJobs())
 	}
 
@@ -123,7 +123,7 @@ func TestTrackerAddDelete(t *testing.T) {
 	restore, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 50*time.Millisecond)
 	must(t, err)
 
-	if restore.NumJobs() != 500 {
+	if restore.NumJobs() != 100 {
 		t.Fatal("Incorrect number of jobs", restore.NumJobs())
 	}
 
@@ -131,7 +131,7 @@ func TestTrackerAddDelete(t *testing.T) {
 		t.Error("Should not be any failed jobs")
 	}
 
-	completeJobs(t, tk, "500Jobs", "type", numJobs)
+	completeJobs(t, tk, "100Jobs", "type", numJobs)
 
 	// This tests proper behavior of cleanup with cleanupDelay.
 	jobs, _, _ := tk.GetState()


### PR DESCRIPTION
The items in history are modified concurrently, so this uses copy-on-write to avoid race conditions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/286)
<!-- Reviewable:end -->
