### PR TITLE
Table ops cleanup

### DIFF
--- a/cloud/bq/export_test.go
+++ b/cloud/bq/export_test.go
@@ -1,0 +1,3 @@
+package bq
+
+var DedupQuery = dedupQuery

--- a/cloud/bq/ops.go
+++ b/cloud/bq/ops.go
@@ -16,15 +16,6 @@ import (
 	"github.com/m-lab/etl-gardener/tracker"
 )
 
-// xTableOps provides the interface for running bigquery operations to modify table partitions.
-type xTableOps interface {
-	dedupQuery() string // Used for testing
-
-	Dedup(ctx context.Context, dryRun bool) (bqiface.Job, error)
-	CopyToRaw(ctx context.Context, dryRun bool) (bqiface.Job, error)
-	DeleteTmp(ctx context.Context) error
-}
-
 // TableOps is used to construct and execute table partition operations.
 type TableOps struct {
 	client  bqiface.Client

--- a/cloud/bq/ops.go
+++ b/cloud/bq/ops.go
@@ -118,13 +118,17 @@ func (params queryer) Dedup(ctx context.Context, dryRun bool) (bqiface.Job, erro
 	return q.Run(ctx)
 }
 
-// Copy copies the tmp_ job partition to the raw_ job partition.
+// CopyToRaw copies the tmp_ job partition to the raw_ job partition.
 func (params queryer) CopyToRaw(ctx context.Context, dryRun bool) (bqiface.Job, error) {
+	if dryRun {
+		return nil, errors.New("dryrun not implemented")
+	}
 	if params.client == nil {
 		return nil, dataset.ErrNilBqClient
 	}
-	src := params.client.Dataset("tmp_" + params.Job.Experiment).Table(params.Job.Datatype)
-	dest := params.client.Dataset("raw_" + params.Job.Experiment).Table(params.Job.Datatype)
+	tableName := params.Job.Datatype + "$" + params.Job.Date.Format("20060102")
+	src := params.client.Dataset("tmp_" + params.Job.Experiment).Table(tableName)
+	dest := params.client.Dataset("raw_" + params.Job.Experiment).Table(tableName)
 
 	copier := dest.CopierFrom(src)
 	config := bqiface.CopyConfig{}

--- a/cloud/bq/ops_test.go
+++ b/cloud/bq/ops_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestTemplate(t *testing.T) {
 	job := tracker.NewJob("bucket", "ndt", "annotation", time.Date(2019, 3, 4, 0, 0, 0, 0, time.UTC))
-	q, err := bq.NewQuerier(context.Background(), job, "fake-project")
+	q, err := bq.NewTableOps(context.Background(), job, "fake-project")
 	rtx.Must(err, "dedup.Query failed")
 	qs := q.QueryFor("dedup")
 	if !strings.Contains(qs, "keep.id") {
@@ -36,11 +36,11 @@ func TestValidateQueries(t *testing.T) {
 	}
 	ctx := context.Background()
 	dataTypes := []string{"annotation", "ndt7"}
-	keys := []string{"dedup", "cleanup"} // TODO Add "preserve" query
+	keys := []string{"dedup"} // TODO Add "preserve" query
 	// Test for each datatype
 	for _, dataType := range dataTypes {
 		job := tracker.NewJob("bucket", "ndt", dataType, time.Date(2019, 3, 4, 0, 0, 0, 0, time.UTC))
-		qp, err := bq.NewQuerier(ctx, job, "mlab-testing")
+		qp, err := bq.NewTableOps(ctx, job, "mlab-testing")
 		if err != nil {
 			t.Fatal(dataType, err)
 		}

--- a/cloud/bq/ops_test.go
+++ b/cloud/bq/ops_test.go
@@ -15,7 +15,7 @@ func TestTemplate(t *testing.T) {
 	job := tracker.NewJob("bucket", "ndt", "annotation", time.Date(2019, 3, 4, 0, 0, 0, 0, time.UTC))
 	q, err := bq.NewTableOps(context.Background(), job, "fake-project")
 	rtx.Must(err, "NewTableOps failed")
-	qs := q.DedupQuery()
+	qs := bq.DedupQuery(*q)
 	if !strings.Contains(qs, "keep.id") {
 		t.Error("query should contain keep.uuid:\n", q)
 	}
@@ -48,11 +48,11 @@ func TestValidateQueries(t *testing.T) {
 			t.Log(t.Name())
 			j, err := qp.Dedup(ctx, true)
 			if err != nil {
-				t.Fatal(t.Name(), err, qp.DedupQuery())
+				t.Fatal(t.Name(), err, bq.DedupQuery(*qp))
 			}
 			status := j.LastStatus()
 			if status.Err() != nil {
-				t.Fatal(t.Name(), err, qp.DedupQuery())
+				t.Fatal(t.Name(), err, bq.DedupQuery(*qp))
 			}
 		})
 	}

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
+	"github.com/m-lab/etl-gardener/cloud/bq"
+	"github.com/m-lab/etl-gardener/tracker"
+	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/rtx"
+)
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
+var (
+	exp  = flag.String("exp", "ndt7", "experiment")
+	date = flag.String("date", "2020/05/22", "date")
+)
+
+// TODO improve test coverage?
+func copyFunc(ctx context.Context, j tracker.Job) {
+	// This is the delay since entering the dedup state, due to monitor delay
+	// and retries.
+	//delay := time.Since(stateChangeTime).Round(time.Minute)
+
+	var bqJob bqiface.Job
+	qp, err := bq.NewTableOps(ctx, j, "mlab-sandbox")
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	bqJob, err = qp.CopyToRaw(ctx, false)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	status, err := bqJob.Wait(ctx)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	var msg string
+	stats := status.Statistics
+	if stats != nil {
+		opTime := stats.EndTime.Sub(stats.StartTime)
+		msg = fmt.Sprintf("Copy took %s (after %s waiting), %d MB Processed",
+			opTime.Round(100*time.Millisecond),
+			"xxx", //delay,
+			stats.TotalBytesProcessed/1000000)
+		log.Println(msg)
+	}
+	return
+}
+
+func main() {
+	ctx := context.Background()
+
+	flag.Parse()
+	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from env")
+
+	d, err := time.Parse("2006-01-02", *date)
+	if err != nil {
+		log.Fatal(err)
+	}
+	j := tracker.NewJob("bucket", "ndt", *exp, d)
+	log.Println(j)
+	copyFunc(ctx, j)
+}

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -103,7 +103,7 @@ func dedupFunc(ctx context.Context, j tracker.Job) *Outcome {
 	var bqJob bqiface.Job
 	var msg string
 	// TODO pass in the JobWithTarget, and get the base from the target.
-	qp, err := bq.NewQuerier(ctx, j, os.Getenv("PROJECT"))
+	qp, err := bq.NewTableOps(ctx, j, os.Getenv("PROJECT"))
 	if err != nil {
 		log.Println(err)
 		// This terminates this job.

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -109,7 +109,7 @@ func dedupFunc(ctx context.Context, j tracker.Job) *Outcome {
 		// This terminates this job.
 		return Failure(j, err, "-")
 	}
-	bqJob, err = qp.Run(ctx, "dedup", false)
+	bqJob, err = qp.Dedup(ctx, false)
 	if err != nil {
 		log.Println(err)
 		// Try again soon.


### PR DESCRIPTION
* cleans up the struct and field names
* removes some unneeded code
* fixes the broken copy func.
* Adds a command line copy utility

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/298)
<!-- Reviewable:end -->
