### PR TITLE
Start processing "yesterday" data around 10:30 UTC

### DIFF
--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -263,7 +263,7 @@ func NewJobService(ctx context.Context, tk jobAdder, startDate time.Time,
 		log.Fatal("No jobs specified")
 	}
 
-	yesterday, err := initYesterday(ctx, saver, 6*time.Hour, specs)
+	yesterday, err := initYesterday(ctx, saver, 10*time.Hour+30*time.Minute, specs)
 	if err != nil {
 		return nil, err
 	}

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -248,7 +248,8 @@ func TestYesterdayFromSaver(t *testing.T) {
 
 	// This allows predictable behavior from time.Since in the advanceDate function.
 	monkey.Patch(time.Now, func() time.Time {
-		return time.Date(2011, 2, 16, 6, 2, 3, 4, time.UTC)
+		// NOTE: must be later than the default "yesterday" delay.
+		return time.Date(2011, 2, 16, 11, 2, 3, 4, time.UTC)
 	})
 
 	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)

--- a/reproc/dispatch.go
+++ b/reproc/dispatch.go
@@ -276,10 +276,10 @@ queueLoop:
 	return maxDate, nil
 }
 
-// dailyDelay is set to 8:30 to allow time for the maximum
+// dailyDelay is set to 10:30 to allow time for the maximum
 // possible pusher delay for the previous day, plus several GCS transfer jobs to
 // complete.
-var dailyDelay = 8*time.Hour + 30*time.Minute
+var dailyDelay = 10*time.Hour + 30*time.Minute
 
 // findNextRecentDay finds an appropriate date to start daily processing.
 func findNextRecentDay(start time.Time, skip int) time.Time {


### PR DESCRIPTION
Update the gardener daily reprocessing start times.

Depends on https://github.com/m-lab/gcp-config/pull/33

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/299)
<!-- Reviewable:end -->
