### PR TITLE
add load/dedup/copy/delete to state machine

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -73,10 +73,11 @@ var (
 	// metrics.TasksInFlight.WithLabelValues(exp, dt).Inc
 	TasksInFlight = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
+			// TODO - should call this JobsInFlight (gardener_jobs_in_flight), to avoid confusion with Tasks in parser.
 			Name: "gardener_tasks_in_flight",
 			Help: "Number of tasks in flight",
 		},
-		[]string{"experiment", "datatype"},
+		[]string{"experiment", "datatype", "state"},
 	)
 
 	// StateDate identifies the date of the most recent update to each state.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -70,7 +70,7 @@ var (
 	// Provides metrics:
 	//   gardener_tasks_in_flight
 	// Example usage:
-	// metrics.TasksInFlight.WithLabelValues(exp, dt).Inc
+	// metrics.TasksInFlight.WithLabelValues(exp, dt, state).Inc
 	TasksInFlight = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			// TODO - should call this JobsInFlight (gardener_jobs_in_flight), to avoid confusion with Tasks in parser.

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -46,13 +46,19 @@ func TestStandardMonitor(t *testing.T) {
 		newStateFunc("-"),
 		tracker.ParseComplete,
 		"Parsing")
+	// Hack for testing - deliberately skip Load function.
+	m.AddAction(tracker.ParseComplete,
+		nil,
+		newStateFunc("-"),
+		tracker.Copying,
+		"Copying")
 
 	// The real dedup action should fail on unknown datatype.
 	go m.Watch(ctx, 50*time.Millisecond)
 
 	failTime := time.Now().Add(30 * time.Second)
 
-	for time.Now().Before(failTime) && (tk.NumJobs() > 2 || tk.NumFailed() < 2) {
+	for time.Now().Before(failTime) && (tk.NumJobs() > 2 || tk.NumFailed() < 1) {
 		time.Sleep(time.Millisecond)
 	}
 	if tk.NumFailed() != 2 {

--- a/state/state.go
+++ b/state/state.go
@@ -330,8 +330,8 @@ type Terminator interface {
 
 // Process handles all steps of processing a task.
 func (t Task) Process(ctx context.Context, ex Executor, doneWithQueue func(), term Terminator) {
-	metrics.TasksInFlight.WithLabelValues(t.Experiment, t.Experiment).Inc()
-	defer metrics.TasksInFlight.WithLabelValues(t.Experiment, t.Experiment).Dec()
+	metrics.TasksInFlight.WithLabelValues(t.Experiment, t.Experiment, "").Inc()
+	defer metrics.TasksInFlight.WithLabelValues(t.Experiment, t.Experiment, "").Dec()
 loop:
 	for t.State != Done { //&& t.ErrMsg == "" {
 		select {

--- a/state/state.go
+++ b/state/state.go
@@ -330,8 +330,8 @@ type Terminator interface {
 
 // Process handles all steps of processing a task.
 func (t Task) Process(ctx context.Context, ex Executor, doneWithQueue func(), term Terminator) {
-	metrics.TasksInFlight.WithLabelValues(t.Experiment, t.Experiment, "").Inc()
-	defer metrics.TasksInFlight.WithLabelValues(t.Experiment, t.Experiment, "").Dec()
+	metrics.TasksInFlight.WithLabelValues(t.Experiment, t.Experiment, "processing").Inc()
+	defer metrics.TasksInFlight.WithLabelValues(t.Experiment, t.Experiment, "processing").Dec()
 loop:
 	for t.State != Done { //&& t.ErrMsg == "" {
 		select {

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -209,7 +209,7 @@ func (s *Status) Prev() State {
 // If the final state is Failed, it composes the previous and final state, e.g. Loading-Failed
 func (s *Status) Label() string {
 	if s.State() == Failed {
-		return string(s.Prev()) + "-Failed"
+		return strings.Join([]string{string(s.Prev()), string(Failed)}, "-")
 	}
 	return string(s.State())
 }


### PR DESCRIPTION
This PR requires the ETL parser to be configured in GCS output mode.

1. updates the ops state machine to include Load from GCS, Dedup, CopyTmpToRaw, and Delete.
2. adds improved error handling for action errors.
3. updates the status page and logs to include a bit more detail about each step.
4. Adds state information to the TasksInFlight metric.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/303)
<!-- Reviewable:end -->
