### PR TITLE
reduce to 4 traceroute queues

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
@@ -62,7 +62,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-traceroute-batch-"
         - name: NUM_QUEUES
-          value: "16"
+          value: "4"
 
         ports:
         - name: prometheus-port


### PR DESCRIPTION
Traceroute is currently processing much faster than the other data-types.  Reducing to 4 queues to slow it down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/312)
<!-- Reviewable:end -->
