### PR TITLE
Add action to join with annotations

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -5,14 +5,15 @@ tracker:
 monitor:
   polling_interval: 1m
 sources:
-- bucket: archive-measurement-lab
-  experiment: ndt
-  datatype: ndt7
-  target: tmp_ndt.ndt7
+# NOTE: It now matters what order these are in.
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: annotation
   target: tmp_ndt.annotation
+- bucket: archive-measurement-lab
+  experiment: ndt
+  datatype: ndt7
+  target: tmp_ndt.ndt7
 #- bucket: archive-measurement-lab
 #  experiment: ndt
 #  datatype: tcpinfo

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -77,7 +77,7 @@ func NewStandardMonitor(ctx context.Context, config cloud.BQConfig, tk *tracker.
 		deleteFunc,
 		tracker.Joining)
 	m.AddAction(tracker.Joining,
-		newCondFunc(tk, "Join condition"),
+		newJoinConditionFunc(tk, "Join condition"),
 		joinFunc,
 		tracker.Complete)
 	return m, nil

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -39,19 +39,16 @@ func TestStandardMonitor(t *testing.T) {
 	m.AddAction(tracker.Init,
 		nil,
 		newStateFunc("-"),
-		tracker.Parsing,
-		"Init")
+		tracker.Parsing)
 	m.AddAction(tracker.Parsing,
 		nil,
 		newStateFunc("-"),
-		tracker.ParseComplete,
-		"Parsing")
+		tracker.ParseComplete)
 	// Hack for testing - deliberately skip Load function.
 	m.AddAction(tracker.ParseComplete,
 		nil,
 		newStateFunc("-"),
-		tracker.Copying,
-		"Copying")
+		tracker.Copying)
 
 	// The real dedup action should fail on unknown datatype.
 	go m.Watch(ctx, 50*time.Millisecond)

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -31,6 +31,8 @@ func TestStandardMonitor(t *testing.T) {
 	tk.AddJob(tracker.NewJob("bucket", "exp2", "tcpinfo", time.Now()))
 	// Valid experiment and datatype
 	// This does an actual dedup, so we need to allow enough time.
+	tk.AddJob(tracker.NewJob("bucket", "ndt", "ndt7", time.Now()))
+
 	tk.AddJob(tracker.NewJob("bucket", "ndt", "annotation", time.Now()))
 
 	m, err := ops.NewStandardMonitor(context.Background(), cloud.BQConfig{}, tk)

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -44,13 +44,15 @@ func TestStandardMonitor(t *testing.T) {
 		nil,
 		newStateFunc("-"),
 		tracker.ParseComplete)
-	// Hack for testing - deliberately skip Load function.
+	// Hack for testing - deliberately skip Load and Dedup functions.
 	m.AddAction(tracker.ParseComplete,
 		nil,
 		newStateFunc("-"),
 		tracker.Copying)
 
-	// The real dedup action should fail on unknown datatype.
+	// The rest of the standard state machine picks up from here,
+	// with Copying, Joining, ...
+
 	go m.Watch(ctx, 50*time.Millisecond)
 
 	failTime := time.Now().Add(30 * time.Second)

--- a/ops/export_test.go
+++ b/ops/export_test.go
@@ -1,0 +1,4 @@
+package ops
+
+var NewJoinConditionFunc = newJoinConditionFunc
+var JoinFunc = joinFunc

--- a/ops/ops.go
+++ b/ops/ops.go
@@ -81,8 +81,6 @@ type Action struct {
 	// action performs an action on the job, and
 	// updates the state when complete.  It may place the job into an error state.
 	action ActionFunc
-
-	annotation string // Annotation to be used for UpdateDetail while applying Op
 }
 
 // Name returns the name of the state that the action applies to.
@@ -126,13 +124,13 @@ func (m *Monitor) tryClaimJob(j tracker.Job) func() {
 
 // AddAction adds a specific action to the Monitor.
 func (m *Monitor) AddAction(state tracker.State, cond ConditionFunc, op ActionFunc,
-	successState tracker.State, annotation string) {
+	successState tracker.State) {
 	m.actions[state] = Action{
-		fromState:  state,
-		nextState:  successState,
-		condition:  cond,
-		action:     op,
-		annotation: annotation}
+		fromState: state,
+		nextState: successState,
+		condition: cond,
+		action:    op,
+	}
 }
 
 // UpdateJob updates the tracker state with the outcome.

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -49,28 +49,23 @@ func TestMonitor_Watch(t *testing.T) {
 	m.AddAction(tracker.Init,
 		nil,
 		newStateFunc(""),
-		tracker.Parsing,
-		"Init")
+		tracker.Parsing)
 	m.AddAction(tracker.Parsing,
 		nil,
 		newStateFunc(""),
-		tracker.ParseComplete,
-		"Parsing")
+		tracker.ParseComplete)
 	m.AddAction(tracker.ParseComplete,
 		nil,
 		newStateFunc(""),
-		tracker.Stabilizing,
-		"PostProcessing")
+		tracker.Stabilizing)
 	m.AddAction(tracker.Stabilizing,
 		nil,
 		newStateFunc(""),
-		tracker.Deduplicating,
-		"Checking for stability")
+		tracker.Deduplicating)
 	m.AddAction(tracker.Deduplicating,
 		nil,
 		newStateFunc(""),
-		tracker.Complete,
-		"Deduplicating")
+		tracker.Complete)
 	go m.Watch(ctx, 50*time.Millisecond)
 
 	failTime := time.Now().Add(5 * time.Second)


### PR DESCRIPTION
This adds the action to join each table (except annotation) with the annotation table.
It imposes a condition that delays the join until the annotation table processing has completed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/314)
<!-- Reviewable:end -->
