### PR TITLE
reduce most queues by half, to slow down requests

### DIFF
--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -109,7 +109,7 @@ func TestService_NextJob(t *testing.T) {
 func TestJobHandler(t *testing.T) {
 	fc := gcsfake.GCSClient{}
 	fc.AddTestBucket("fake-bucket",
-		gcsfake.BucketHandle{
+		&gcsfake.BucketHandle{
 			ObjAttrs: []*storage.ObjectAttrs{
 				{Name: "obj1", Updated: time.Now()},
 				{Name: "obj2", Updated: time.Now()},

--- a/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
@@ -62,7 +62,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-disco-batch-"
         - name: NUM_QUEUES
-          value: "4"
+          value: "2"
         ports:
         - name: prometheus-port
           containerPort: 9090

--- a/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etl-gardener-disco

--- a/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etl-gardener-ndt

--- a/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
@@ -62,7 +62,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-ndt-batch-"
         - name: NUM_QUEUES
-          value: "8"  # There are actually 16 but we don't need so many now.
+          value: "4"  # There are actually 16 but we don't need so many now.
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing-cluster/deployments/etl-gardener-ndt5.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-ndt5.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etl-gardener-ndt5

--- a/k8s/data-processing-cluster/deployments/etl-gardener-scamper.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-scamper.yml
@@ -62,7 +62,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-scamper-batch-"
         - name: NUM_QUEUES
-          value: "4"
+          value: "2"
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing-cluster/deployments/etl-gardener-scamper.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-scamper.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etl-gardener-scamper

--- a/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
@@ -62,7 +62,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-sidestream-batch-"
         - name: NUM_QUEUES
-          value: "8"  # There are actually 16 but we don't need so many now.
+          value: "4"  # There are actually 16 but we don't need so many now.
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etl-gardener-sidestream

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etl-gardener-tcpinfo

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -63,7 +63,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-tcpinfo-batch-"
         - name: NUM_QUEUES
-          value: "4"
+          value: "2"
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etl-gardener-traceroute

--- a/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
@@ -62,7 +62,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-traceroute-batch-"
         - name: NUM_QUEUES
-          value: "4"
+          value: "2"
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etl-gardener-universal

--- a/tracker/job_test.go
+++ b/tracker/job_test.go
@@ -13,7 +13,7 @@ import (
 func TestPrefixFuncs(t *testing.T) {
 	fc := gcsfake.GCSClient{}
 	fc.AddTestBucket("fake-bucket",
-		gcsfake.BucketHandle{
+		&gcsfake.BucketHandle{
 			ObjAttrs: []*storage.ObjectAttrs{
 				{Name: "obj1", Updated: time.Now()},
 				{Name: "obj2", Updated: time.Now()},
@@ -25,19 +25,19 @@ func TestPrefixFuncs(t *testing.T) {
 
 	ndt5 := tracker.Job{
 		Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: time.Date(2011, 02, 03, 0, 0, 0, 0, time.UTC)}
-	if ok, _ := ndt5.HasFiles(ctx, fc); !ok {
+	if ok, _ := ndt5.HasFiles(ctx, &fc); !ok {
 		t.Error("Should be ok")
 	}
-	if files, byteCount, _ := ndt5.PrefixStats(ctx, fc); len(files) != 2 || byteCount != 2121 {
+	if files, byteCount, _ := ndt5.PrefixStats(ctx, &fc); len(files) != 2 || byteCount != 2121 {
 		t.Error("Should have 2 files with 2121 bytes", files, byteCount)
 	}
 
 	tcpinfo := tracker.Job{
 		Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Date: time.Date(2011, 02, 03, 0, 0, 0, 0, time.UTC)}
-	if ok, _ := tcpinfo.HasFiles(ctx, fc); ok {
+	if ok, _ := tcpinfo.HasFiles(ctx, &fc); ok {
 		t.Error("HasFiles should be false", ok)
 	}
-	if files, byteCount, _ := tcpinfo.PrefixStats(ctx, fc); len(files) != 0 || byteCount != 0 {
+	if files, byteCount, _ := tcpinfo.PrefixStats(ctx, &fc); len(files) != 0 || byteCount != 0 {
 		t.Error("Should have 0 files, 0 bytes", files, byteCount)
 	}
 }


### PR DESCRIPTION
This reduces the number of active queues, which reduces the request rate to be in line with the reduced number of instances.
See https://github.com/m-lab/etl/pull/959

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/318)
<!-- Reviewable:end -->
