### PR TITLE
Embed a static git commit hash in the gardener binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,13 @@ COPY . .
 
 # Get the requirements and put the produced binaries in /go/bin
 RUN go get -v ./...
+WORKDIR /go/src/github.com/m-lab/etl-gardener
 RUN go install \
       -v \
-      -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
-      ./...
+      -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h) -X main.Version=$(git describe --tags) -X main.GitCommit=$(git log -1 --format=%H)" \
+      ./cmd/gardener
 
-FROM alpine
+FROM alpine:3.12
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 
 COPY --from=builder /go/bin/gardener /bin/gardener

--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -27,8 +27,6 @@ kubectl create configmap gardener-config --dry-run \
 CFG=/tmp/${CLUSTER}-${PROJECT}.yml
 kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
     --value GCLOUD_PROJECT=${PROJECT} \
-    --value GIT_COMMIT=${TRAVIS_COMMIT} \
-    --value GIT_TAG=${TRAVIS_TAG} \
     --value DATE_SKIP=${DATE_SKIP} \
     --value TASK_FILE_SKIP=${TASK_FILE_SKIP} \
     > ${CFG}

--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -27,6 +27,7 @@ kubectl create configmap gardener-config --dry-run \
 CFG=/tmp/${CLUSTER}-${PROJECT}.yml
 kexpand expand --ignore-missing-keys k8s/${CLUSTER}/*/*.yml \
     --value GCLOUD_PROJECT=${PROJECT} \
+    --value GIT_COMMIT=${TRAVIS_COMMIT} \
     --value DATE_SKIP=${DATE_SKIP} \
     --value TASK_FILE_SKIP=${TASK_FILE_SKIP} \
     > ${CFG}

--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -44,6 +44,18 @@ import (
 )
 
 var (
+	// GitCommit and Version hold the git commit id and git tags of this build.
+	// It is recommended that the strings be set as part of the build/link
+	// process, using commands like:
+	//
+	//   version="-X main.Version=$(git describe --tags)"
+	//   commit="-X main.GitCommit=$(git log -1 --format=%H)"
+	//   go build -ldflags "$version $commit" ./cmd/gardener
+	GitCommit = "nocommit"
+	Version   = "noversion"
+)
+
+var (
 	jobExpirationTime = flag.Duration("job_expiration_time", 24*time.Hour, "Time after which stale jobs will be purged")
 	jobCleanupDelay   = flag.Duration("job_cleanup_delay", 3*time.Hour, "Time after which completed jobs will be removed from tracker")
 	shutdownTimeout   = flag.Duration("shutdown_timeout", 1*time.Minute, "Graceful shutdown time allowance")
@@ -66,7 +78,7 @@ type environment struct {
 
 	// Vars for Status()
 	Commit  string
-	Release string
+	Version string
 
 	// Determines what kind of service to run.
 	// "manager" will cause loading of config, and passive management.
@@ -156,8 +168,8 @@ func loadEnvVarsForTaskQueue() {
 // LoadEnv loads any required environment variables.
 func LoadEnv() {
 	var ok bool
-	env.Commit = os.Getenv("GIT_COMMIT")
-	env.Release = os.Getenv("RELEASE_TAG")
+	env.Commit = GitCommit
+	env.Version = Version
 	env.BatchDataset = os.Getenv("DATASET")
 	env.FinalDataset = os.Getenv("FINAL_DATASET")
 
@@ -243,10 +255,10 @@ var globalTracker *tracker.Tracker
 func Status(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "<html><body>\n")
 	if len(env.Commit) >= 8 {
-		fmt.Fprintf(w, "Release: %s <br>  Commit: <a href=\"https://github.com/m-lab/etl-gardener/tree/%s\">%s</a><br>\n",
-			env.Release, env.Commit, env.Commit[0:7])
+		fmt.Fprintf(w, "Version: %s <br>  Commit: <a href=\"https://github.com/m-lab/etl-gardener/tree/%s\">%s</a><br>\n",
+			env.Version, env.Commit, env.Commit[0:7])
 	} else {
-		fmt.Fprintf(w, "Release: %s <br>  Commit: unknown\n", env.Release)
+		fmt.Fprintf(w, "Version: %s <br>  Commit: unknown\n", env.Version)
 	}
 
 	fmt.Fprintf(w, "</br></br>\n")

--- a/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
@@ -40,8 +40,6 @@ spec:
         env:
         - name: GARDENER_SERVICE
           value: "true"
-        - name: GIT_COMMIT
-          value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
         # NOTE: We read archives from the public archive for all projects.

--- a/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
@@ -40,8 +40,6 @@ spec:
         env:
         - name: GARDENER_SERVICE
           value: "true"
-        - name: GIT_COMMIT
-          value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
         # NOTE: We read archives from the public archive for all projects.

--- a/k8s/data-processing-cluster/deployments/etl-gardener-ndt5.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-ndt5.yml
@@ -40,8 +40,6 @@ spec:
         env:
         - name: GARDENER_SERVICE
           value: "true"
-        - name: GIT_COMMIT
-          value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
         # NOTE: We read archives from the public archive for all projects.

--- a/k8s/data-processing-cluster/deployments/etl-gardener-scamper.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-scamper.yml
@@ -40,8 +40,6 @@ spec:
         env:
         - name: GARDENER_SERVICE
           value: "true"
-        - name: GIT_COMMIT
-          value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
         # NOTE: We read archives from the public archive for all projects.

--- a/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
@@ -40,8 +40,6 @@ spec:
         env:
         - name: GARDENER_SERVICE
           value: "true"
-        - name:  GIT_COMMIT
-          value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: {{GCLOUD_PROJECT}}
         # NOTE: We read archives from the public archive for all projects.

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -40,8 +40,6 @@ spec:
         env:
         - name: GARDENER_SERVICE
           value: "true"
-        - name: GIT_COMMIT
-          value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
         # NOTE: We read archives from the public archive for all projects.

--- a/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-traceroute.yml
@@ -40,8 +40,6 @@ spec:
         env:
         - name: GARDENER_SERVICE
           value: "true"
-        - name: GIT_COMMIT
-          value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
         # NOTE: We read archives from the public archive for all projects.

--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -40,8 +40,6 @@ spec:
         env:
         - name: SERVICE_MODE # Whether to use task-queues or run as manager.
           value: "manager"
-        - name: GIT_COMMIT
-          value: "{{GIT_COMMIT}}"
         - name: PROJECT
           value: "{{GCLOUD_PROJECT}}"
         - name: STATUS_PORT


### PR DESCRIPTION
Currently, etl-gardener reads the "GIT_COMMIT" value from its runtime environment, which could be out of sync with reality. This change embeds the real git commit as a static variable at build time.

This change simplifies configuration and supports an effort to migrate the gardener deployment to cloudbuild.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/324)
<!-- Reviewable:end -->
