### PR TITLE
Add create script for parser-pool-16 with 16 CPUs and appropriate scopes.

### DIFF
--- a/create-parser-pool.sh
+++ b/create-parser-pool.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Configure cluster, network, firewall and node-pools for gardener and etl.
+
+set -x
+set -e
+
+USAGE="$0 <project> <region>"
+PROJECT=${1:?Please provide the GCP project id, e.g. mlab-sandbox: $USAGE}
+REGION=${2:?Please provide the cluster region, e.g. us-central1: $USAGE}
+
+gcloud config unset compute/zone
+gcloud config set project $PROJECT
+gcloud config set compute/region $REGION
+gcloud config set container/cluster data-processing
+
+gcloud container node-pools delete parser-pool-16 || true
+
+gcloud container node-pools create parser-pool-16 \
+    --machine-type=n1-standard-16 \
+    --enable-autoscaling --num-nodes=0 --min-nodes=0 --max-nodes=2 \
+    --enable-autorepair --enable-autoupgrade \
+    --scopes storage-rw,compute-rw,datastore,cloud-platform \
+    --node-labels=parser-node=true,storage-rw=true


### PR DESCRIPTION
Tested manually on mlab-sandbox.

This configures num-nodes=0 intentionally.  This results in uneven number of nodes per zone, which is not recommended, but it seems to work fine, and reduces costs by avoiding unused nodes.

Note that this does not delete any other node-pools that might be used for parsers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/333)
<!-- Reviewable:end -->
