### PR TITLE
Increase reprocessing rate for legacy types

### DIFF
--- a/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
@@ -60,8 +60,7 @@ spec:
         - name: QUEUE_BASE
           value: "etl-disco-batch-"
         - name: NUM_QUEUES
-          # NOTE: low,high capacity: 1,2
-          value: "2"
+          value: "1"
         ports:
         - name: prometheus-port
           containerPort: 9090

--- a/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-disco.yml
@@ -60,7 +60,8 @@ spec:
         - name: QUEUE_BASE
           value: "etl-disco-batch-"
         - name: NUM_QUEUES
-          value: "1"
+          # NOTE: low,high capacity: 1,2
+          value: "2"
         ports:
         - name: prometheus-port
           containerPort: 9090

--- a/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-ndt.yml
@@ -60,7 +60,8 @@ spec:
         - name: QUEUE_BASE
           value: "etl-ndt-batch-"
         - name: NUM_QUEUES
-          value: "1"  # There are actually 16 but we don't need so many now.
+          # NOTE: low,high capacity: 1,8
+          value: "8"  # There are actually 16 but we don't need so many now.
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing-cluster/deployments/etl-gardener-scamper.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-scamper.yml
@@ -60,7 +60,8 @@ spec:
         - name: QUEUE_BASE
           value: "etl-scamper-batch-"
         - name: NUM_QUEUES
-          value: "1"
+          # NOTE: low,high capacity: 1,2
+          value: "2"
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-sidestream.yml
@@ -60,7 +60,8 @@ spec:
         - name: QUEUE_BASE
           value: "etl-sidestream-batch-"
         - name: NUM_QUEUES
-          value: "1"  # There are actually 16 but we don't need so many now.
+          # NOTE: low,high capacity: 1,8
+          value: "8"  # There are actually 16 but we don't need so many now.
 
         ports:
         - name: prometheus-port

--- a/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
+++ b/k8s/data-processing-cluster/deployments/etl-gardener-tcpinfo.yml
@@ -61,7 +61,8 @@ spec:
         - name: QUEUE_BASE
           value: "etl-tcpinfo-batch-"
         - name: NUM_QUEUES
-          value: "1"
+          # NOTE: low,high capacity: 1,4
+          value: "4"
 
         ports:
         - name: prometheus-port


### PR DESCRIPTION
This change increases the resources assigned to the legacy batch parser. This change will allow faster reprocessing of historical data types in preparation for the annotation export process.

This is related to https://github.com/m-lab/etl/pull/1010

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/334)
<!-- Reviewable:end -->
