### PR TITLE
Add gardener configuration for PCAP datatype

### DIFF
--- a/cloud/bq/ops.go
+++ b/cloud/bq/ops.go
@@ -47,16 +47,9 @@ func NewTableOps(ctx context.Context, job tracker.Job, project string, loadSourc
 func NewTableOpsWithClient(client bqiface.Client, job tracker.Job, project string, loadSource string) (*TableOps, error) {
 	switch job.Datatype {
 	case "annotation":
-		return &TableOps{
-			client:        client,
-			LoadSource:    loadSource,
-			Project:       project,
-			Date:          "date",
-			Job:           job,
-			PartitionKeys: map[string]string{"id": "id"},
-			OrderKeys:     "",
-		}, nil
-
+		fallthrough
+	case "pcap":
+		fallthrough
 	case "ndt7":
 		return &TableOps{
 			client:        client,

--- a/cloud/bq/ops_test.go
+++ b/cloud/bq/ops_test.go
@@ -57,15 +57,17 @@ func TestValidateQueries(t *testing.T) {
 				t.Fatal(t.Name(), err, bq.DedupQuery(*qp))
 			}
 
-			if qp.Job.Datatype != "annotation" && qp.Job.Datatype != "pcap" {
-				j, err := qp.Join(ctx, true)
-				if err != nil {
-					t.Fatal(t.Name(), err, bq.JoinQuery(*qp))
-				}
-				status := j.LastStatus()
-				if status.Err() != nil {
-					t.Fatal(t.Name(), err, bq.JoinQuery(*qp))
-				}
+			if qp.Job.Datatype != "ndt7" {
+				return
+			}
+
+			j, err = qp.Join(ctx, true)
+			if err != nil {
+				t.Fatal(t.Name(), err, bq.JoinQuery(*qp))
+			}
+			status = j.LastStatus()
+			if status.Err() != nil {
+				t.Fatal(t.Name(), err, bq.JoinQuery(*qp))
 			}
 		})
 	}

--- a/cloud/bq/ops_test.go
+++ b/cloud/bq/ops_test.go
@@ -37,7 +37,7 @@ func TestValidateQueries(t *testing.T) {
 		t.Log("Skipping test for --short")
 	}
 	ctx := context.Background()
-	dataTypes := []string{"annotation", "ndt7"}
+	dataTypes := []string{"annotation", "ndt7", "pcap"}
 	// TODO Add "preserve" query
 	// Test for each datatype
 	for _, dataType := range dataTypes {
@@ -57,7 +57,7 @@ func TestValidateQueries(t *testing.T) {
 				t.Fatal(t.Name(), err, bq.DedupQuery(*qp))
 			}
 
-			if qp.Job.Datatype != "annotation" {
+			if qp.Job.Datatype != "annotation" && qp.Job.Datatype != "pcap" {
 				j, err := qp.Join(ctx, true)
 				if err != nil {
 					t.Fatal(t.Name(), err, bq.JoinQuery(*qp))

--- a/config/config.yml
+++ b/config/config.yml
@@ -14,6 +14,10 @@ sources:
   experiment: ndt
   datatype: ndt7
   target: tmp_ndt.ndt7
+- bucket: archive-measurement-lab
+  experiment: ndt
+  datatype: pcap
+  target: tmp_ndt.pcap
 #- bucket: archive-measurement-lab
 #  experiment: ndt
 #  datatype: tcpinfo

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -364,9 +364,9 @@ func deleteFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *
 }
 
 func joinFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Outcome {
-	if j.Datatype == "annotation" {
-		// annotation should not be annotated.
-		return Success(j, "Annotation does not require join")
+	if j.Datatype == "annotation" || j.Datatype == "pcap" {
+		// These should not be annotated.
+		return Success(j, fmt.Sprintf("%s does not require join", j.Datatype))
 	}
 	delay := time.Since(stateChangeTime).Round(time.Minute)
 	to, err := tableOps(ctx, j)

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -37,6 +37,8 @@ func TestStandardMonitor(t *testing.T) {
 
 	tk.AddJob(tracker.NewJob("bucket", "ndt", "annotation", time.Now()))
 
+	tk.AddJob(tracker.NewJob("bucket", "ndt", "pcap", time.Now()))
+
 	m, err := ops.NewStandardMonitor(context.Background(), cloud.BQConfig{}, tk)
 	rtx.Must(err, "NewMonitor failure")
 	// We add some new actions in place of the Parser activity.


### PR DESCRIPTION
- Add PCAP entry to Gardener config.
- Prevent PCAP data from being joined (processing should be complete after dedup).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/335)
<!-- Reviewable:end -->
