### PR TITLE
Eliminate use of _DOCKER_TAG substitution

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -70,13 +70,13 @@ steps:
   args: [
     "build",
       "--build-arg", "VERSION=${TAG_NAME}${BRANCH_NAME}",
-      "-t", "gcr.io/$PROJECT_ID/etl-gardener:$_DOCKER_TAG", "."
+      "-t", "gcr.io/$PROJECT_ID/etl-gardener:${COMMIT_SHA}", "."
   ]
 
 - name: gcr.io/cloud-builders/docker
   id: "Push the docker container to gcr.io"
   args: [
-    "push", "gcr.io/$PROJECT_ID/etl-gardener:$_DOCKER_TAG"
+    "push", "gcr.io/$PROJECT_ID/etl-gardener:${COMMIT_SHA}"
   ]
 
 # UNIVERSAL CLUSTER: Run apply-cluster.sh


### PR DESCRIPTION
The `_DOCKER_TAG` substitution was originally intended to allow production images to use the tag name as the image tag, e.g. `gcr.io/mlab-oti/etl-gardener:prod-v2.4.2`, however this does not work as intended because the kubernetes configuration unconditionally uses the `COMMIT_SHA` as the image tag.

To eliminate the unnecessary indirection and different handling in staging and production, this change removes the `DOCKER_TAG` in favor of using `COMMIT_SHA` directly.

After merge, the _DOCKER_TAG substitution in the etl-gardener cloudbuild trigger configuration should be removed manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/336)
<!-- Reviewable:end -->
