### PR TITLE
Begin parsing first data from v2 platform

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 ---
-start_date: 2019-02-01
+start_date: 2019-03-29 # Earliest date for v2 platform datatypes.
 tracker:
   timeout: 5h
 monitor:

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 ---
-start_date: 2020-02-01
+start_date: 2019-02-01
 tracker:
   timeout: 5h
 monitor:


### PR DESCRIPTION
This change updates the Gardener configuration so that it will begin parsing annotation data (or other data from the v2 platform) as soon as that data first became available. This turns out to be 2019-03-29 (from ndt/tcpinfo).

FYI: @cristinaleonr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/346)
<!-- Reviewable:end -->
