### PR TITLE
Source annotation archives from sandbox, staging, or public archives

### DIFF
--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -18,6 +18,12 @@ CLUSTER=${CLOUDSDK_CONTAINER_CLUSTER:?Please provide cluster name: $USAGE}
 DATE_SKIP=${DATE_SKIP:-"0"}  # Number of dates to skip between each processed date (for sandbox).
 TASK_FILE_SKIP=${TASK_FILE_SKIP:-"0"}  # Number of files to skip between each processed file (for sandbox).
 
+# Use sandbox in sandbox, staging in staging, and use measurement-lab in oti.
+SOURCE_PROJECT=${PROJECT_ID/mlab-oti/measurement-lab}
+sed -i \
+    -e 's/{{ANNOTATION_SOURCE_PROJECT}}/'${SOURCE_PROJECT}'/g' \
+    config/config.yml
+
 # Create the configmap
 kubectl create configmap gardener-config --dry-run \
     --from-file config/config.yml \

--- a/config/config.yml
+++ b/config/config.yml
@@ -6,7 +6,7 @@ monitor:
   polling_interval: 1m
 sources:
 # NOTE: It now matters what order these are in.
-- bucket: archive-measurement-lab
+- bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: ndt
   datatype: annotation
   target: tmp_ndt.annotation


### PR DESCRIPTION
This change adds conditional source for the annotation archives to enable testing of the annotation export process.

In sandbox and staging projects, gardener will source archives from the local project, e.g. gs://archive-mlab-staging. In mlab-oti, gardener will source archives from gs://archive-measurement-lab.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/347)
<!-- Reviewable:end -->
