### PR TITLE
Disable pcap parsing temporarily

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -14,10 +14,11 @@ sources:
   experiment: ndt
   datatype: ndt7
   target: tmp_ndt.ndt7
-- bucket: archive-measurement-lab
-  experiment: ndt
-  datatype: pcap
-  target: tmp_ndt.pcap
+# TODO(soltesz): re-enable after annotation export is completed in production.
+#- bucket: archive-measurement-lab
+#  experiment: ndt
+#  datatype: pcap
+#  target: tmp_ndt.pcap
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: hopannotation1


### PR DESCRIPTION
This change disables the pcap parser temporarily in order to speed up reprocessing of other datatypes. In particular this will expedite the reprocessing of the synthetic annotations produced by the annotation export process.

The pcap configuration should be re-enabled once the annotation export is completed, i.e. once https://github.com/m-lab/stats-pipeline/issues/85 is closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/348)
<!-- Reviewable:end -->
