### PR TITLE
Cloud build speedup

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -72,6 +72,7 @@ steps:
       "--build-arg", "VERSION=${TAG_NAME}${BRANCH_NAME}",
       "-t", "gcr.io/$PROJECT_ID/etl-gardener:${COMMIT_SHA}", "."
   ]
+  waitFor: ['-']
 
 - name: gcr.io/cloud-builders/docker
   id: "Push the docker container to gcr.io"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,6 +26,7 @@
 timeout: 1800s
 
 options:
+  machineType: 'N1_HIGHCPU_8'
   env:
   - PROJECT_ID=$PROJECT_ID
   - GIT_COMMIT=$COMMIT_SHA


### PR DESCRIPTION
This makes two changes:
  1.  Use High CPU instance for build.
  2. Allow concurrent build of docker container, alongside unit tests.

This improves the build (and deploy) time from roughly 30 minutes to roughly 5-6 minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/351)
<!-- Reviewable:end -->
