### PR TITLE
Dailyonly option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type SourceConfig struct {
 	Datatype   string `yaml:"datatype"`
 	Filter     string `yaml:"filter"`
 	Target     string `yaml:"target"`
+	DailyOnly  bool   `yaml:"dailyOnly"`
 }
 
 // Gardener is the full config for a Gardener instance.

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ type SourceConfig struct {
 	Datatype   string `yaml:"datatype"`
 	Filter     string `yaml:"filter"`
 	Target     string `yaml:"target"`
-	DailyOnly  bool   `yaml:"dailyOnly"`
+	DailyOnly  bool   `yaml:"daily_only"`
 }
 
 // Gardener is the full config for a Gardener instance.

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -159,6 +159,7 @@ func (svc *Service) NextJob(ctx context.Context) tracker.JobWithTarget {
 		return *j
 	}
 
+	// We now check up to three jobs, since some jobs may be configured as dailyOnly.
 	for i := 0; i < 3; i++ {
 		job := svc.jobSpecs[svc.nextIndex]
 		job.Date = svc.Date
@@ -175,6 +176,7 @@ func (svc *Service) NextJob(ctx context.Context) tracker.JobWithTarget {
 				log.Println(err)
 			}
 		}
+		// Return a job only if it isn't configured as daily only.
 		if !job.DailyOnly() {
 			return job
 		}

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -78,6 +78,7 @@ func TestService_NextJob(t *testing.T) {
 	sources := []config.SourceConfig{
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "dailyonly", Target: "tmp_ndt.dailyonly", DailyOnly: true},
 	}
 	// This is three days before "now".  The job service should restart
 	// when it reaches 36 hours before "now", which is 2011-02-05
@@ -100,7 +101,7 @@ func TestService_NextJob(t *testing.T) {
 		want := tracker.Job{}
 		json.Unmarshal([]byte(e.body), &want)
 		got := svc.NextJob(ctx)
-		log.Println(got)
+		t.Log(got)
 		diff := deep.Equal(want, got.Job)
 		if diff != nil {
 			t.Error(i, diff)
@@ -279,6 +280,7 @@ func TestYesterdayFromSaver(t *testing.T) {
 	sources := []config.SourceConfig{
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "dailyonly", Target: "tmp_ndt.dailyonly", DailyOnly: true},
 	}
 
 	// Set up fake saver.
@@ -295,8 +297,11 @@ func TestYesterdayFromSaver(t *testing.T) {
 		// Yesterday (twice to catch up)
 		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-14T00:00:00Z"}`},
 		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"tcpinfo","Date":"2011-02-14T00:00:00Z"}`},
+		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"dailyonly","Date":"2011-02-14T00:00:00Z"}`},
+
 		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-15T00:00:00Z"}`},
 		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"tcpinfo","Date":"2011-02-15T00:00:00Z"}`},
+		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"dailyonly","Date":"2011-02-15T00:00:00Z"}`},
 		// Resume
 		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-10T00:00:00Z"}`},
 		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"tcpinfo","Date":"2011-02-10T00:00:00Z"}`},
@@ -308,6 +313,7 @@ func TestYesterdayFromSaver(t *testing.T) {
 		want := tracker.Job{}
 		json.Unmarshal([]byte(e.body), &want)
 		got := svc.NextJob(ctx)
+		t.Log(got)
 		diff := deep.Equal(want, got.Job)
 		if diff != nil {
 			t.Error(i, diff)

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -297,29 +297,28 @@ func TestYesterdayFromSaver(t *testing.T) {
 	must(t, err)
 
 	expected := []struct {
-		body string
+		json string
 	}{
 		// Yesterday (twice to catch up)
-		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-14T00:00:00Z"}`},
-		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"tcpinfo","Date":"2011-02-14T00:00:00Z"}`},
-		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"dailyonly","Date":"2011-02-14T00:00:00Z"}`},
+		{json: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-14T00:00:00Z"}`},
+		{json: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"tcpinfo","Date":"2011-02-14T00:00:00Z"}`},
+		{json: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"dailyonly","Date":"2011-02-14T00:00:00Z"}`},
 
-		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-15T00:00:00Z"}`},
-		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"tcpinfo","Date":"2011-02-15T00:00:00Z"}`},
-		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"dailyonly","Date":"2011-02-15T00:00:00Z"}`},
+		{json: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-15T00:00:00Z"}`},
+		{json: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"tcpinfo","Date":"2011-02-15T00:00:00Z"}`},
+		{json: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"dailyonly","Date":"2011-02-15T00:00:00Z"}`},
 		// Resume
-		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-10T00:00:00Z"}`},
-		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"tcpinfo","Date":"2011-02-10T00:00:00Z"}`},
-		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-11T00:00:00Z"}`},
-		{body: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"tcpinfo","Date":"2011-02-11T00:00:00Z"}`},
+		{json: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-10T00:00:00Z"}`},
+		{json: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"tcpinfo","Date":"2011-02-10T00:00:00Z"}`},
+		{json: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-11T00:00:00Z"}`},
+		{json: `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"tcpinfo","Date":"2011-02-11T00:00:00Z"}`},
 	}
 
 	for i, e := range expected {
-		want := tracker.Job{}
-		json.Unmarshal([]byte(e.body), &want)
-		got := svc.NextJob(ctx)
-		t.Log(got)
-		diff := deep.Equal(want, got.Job)
+		j := svc.NextJob(ctx)
+		actual := string(j.Marshal())
+		t.Log(j)
+		diff := deep.Equal(e.json, actual)
 		if diff != nil {
 			t.Error(i, diff)
 		}

--- a/ops/ops.go
+++ b/ops/ops.go
@@ -208,7 +208,7 @@ func (m *Monitor) Watch(ctx context.Context, period time.Duration) {
 			for j, s := range jobs {
 				// If job is in a state that has an associated action...
 				if a, ok := m.actions[s.LastStateInfo().State]; ok {
-					m.tryApplyAction(ctx, a, j, s)
+					m.tryApplyAction(ctx, a, tracker.Job(j), s)
 				}
 			}
 		}

--- a/state/state.go
+++ b/state/state.go
@@ -15,11 +15,20 @@ import (
 	"cloud.google.com/go/datastore"
 	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
 
-	"github.com/m-lab/etl/etl"
 	"github.com/m-lab/go/dataset"
 
 	"github.com/m-lab/etl-gardener/metrics"
 )
+
+// Table names are all identical to experiment name, except for paris-traceroute.
+// This function allows independence from etl repo.
+// See etl/etl/globals.go for etl mappings.
+func tableName(dir string) string {
+	if dir == "paris-traceroute" {
+		return "traceroute"
+	}
+	return dir
+}
 
 // State indicates the state of a single Task in flight.
 type State int
@@ -227,7 +236,7 @@ func (t *Task) SourceAndDest(ds *dataset.Dataset) (bqiface.Table, bqiface.Table,
 		return nil, nil, err
 	}
 
-	tableName := etl.DirToTablename(prefix.DataType)
+	tableName := tableName(prefix.DataType)
 
 	src := ds.Table(tableName + "_" + strings.Join(strings.Split(prefix.DatePath, "/"), ""))
 	dest := ds.Table(tableName + "$" + strings.Join(strings.Split(prefix.DatePath, "/"), ""))

--- a/state/state.go
+++ b/state/state.go
@@ -25,7 +25,7 @@ import (
 // This function allows independence from etl repo.  It is used only by the legacy
 // gardener configs.
 // See etl/etl/globals.go for etl mappings.
-// DEPRECATED - table names are now identical to path experiment names.
+// Deprecated: - table names are now identical to path experiment names.
 func tableName(dir string) string {
 	if dir == "paris-traceroute" {
 		return "traceroute"

--- a/state/state.go
+++ b/state/state.go
@@ -20,9 +20,12 @@ import (
 	"github.com/m-lab/etl-gardener/metrics"
 )
 
+// TODO - eliminate this function.
 // Table names are all identical to experiment name, except for paris-traceroute.
-// This function allows independence from etl repo.
+// This function allows independence from etl repo.  It is used only by the legacy
+// gardener configs.
 // See etl/etl/globals.go for etl mappings.
+// DEPRECATED - table names are now identical to path experiment names.
 func tableName(dir string) string {
 	if dir == "paris-traceroute" {
 		return "traceroute"

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -34,6 +34,19 @@ type Job struct {
 	// Filter is an optional regex to apply to ArchiveURL names
 	// Note that HasFiles does not use this, so ETL may process no files.
 	Filter string `json:",omitempty"`
+
+	// Alternatively, export and use a json tag?
+	dailyOnly bool // Not included in json interface.
+}
+
+// SetDailyOnly disables reprocessing of old data
+// Only yesterday jobs will be dispatched.
+func (j *Job) SetDailyOnly() {
+	j.dailyOnly = true
+}
+
+func (j *Job) DailyOnly() bool {
+	return j.dailyOnly
 }
 
 // JobWithTarget specifies a type/date job, and a destination

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -39,6 +39,15 @@ type Job struct {
 	dailyOnly bool // Not included in json interface.
 }
 
+type JobKey Job
+
+// Key clears any fields that should not be used as part of the map key.
+// Since this is pass by value, a new copy is returned.
+func (j Job) Key() JobKey {
+	j.dailyOnly = false
+	return JobKey(j)
+}
+
 // SetDailyOnly disables reprocessing of old data
 // Only yesterday jobs will be dispatched.
 func (j *Job) SetDailyOnly() {
@@ -389,18 +398,18 @@ func NewStatus() Status {
 // JobMap is defined to allow custom json marshal/unmarshal.
 // It defines the map from Job to Status.
 // TODO implement datastore.PropertyLoadSaver
-type JobMap map[Job]Status
+type JobMap map[JobKey]Status
 
 // MarshalJSON implements json.Marshal
 func (jobs JobMap) MarshalJSON() ([]byte, error) {
 	type Pair struct {
-		Job   Job
-		State Status
+		JobKey JobKey
+		State  Status
 	}
 	pairs := make([]Pair, len(jobs))
 	i := 0
 	for k, v := range jobs {
-		pairs[i].Job = k
+		pairs[i].JobKey = k
 		pairs[i].State = v
 		i++
 	}

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -420,8 +420,8 @@ func (jobs JobMap) MarshalJSON() ([]byte, error) {
 // jobs and data should be non-nil.
 func (jobs *JobMap) UnmarshalJSON(data []byte) error {
 	type Pair struct {
-		Job   Job
-		State Status
+		JobKey JobKey
+		State  Status
 	}
 	pairs := make([]Pair, 0, 100)
 	err := json.Unmarshal(data, &pairs)
@@ -431,7 +431,7 @@ func (jobs *JobMap) UnmarshalJSON(data []byte) error {
 
 	log.Printf("Unmarshalling %d job/status pairs.\n", len(pairs))
 	for i := range pairs {
-		(*jobs)[pairs[i].Job] = pairs[i].State
+		(*jobs)[pairs[i].JobKey] = pairs[i].State
 	}
 	return nil
 }
@@ -446,7 +446,7 @@ var jobsTemplate = template.Must(template.New("").Parse(
 	</style>
 	<table style="width:100%%">
 		<tr>
-			<th> Job </th>
+			<th> JobKey </th>
 			<th> Elapsed </th>
 			<th> Update Time </th>
 			<th> State </th>
@@ -456,7 +456,7 @@ var jobsTemplate = template.Must(template.New("").Parse(
 		</tr>
 	    {{range .Jobs}}
 		<tr>
-			<td> {{.Job}} </td>
+			<td> {{.JobKey}} </td>
 			<td> {{.Status.Elapsed}} </td>
 			<td> {{.Status.DetailTime.Format "01/02~15:04:05"}} </td>
 			<td {{ if or (eq .Status.State "%s") (eq .Status.State "%s")}}
@@ -473,7 +473,7 @@ var jobsTemplate = template.Must(template.New("").Parse(
 // WriteHTML writes a table containing the jobs and status.
 func (jobs JobMap) WriteHTML(w io.Writer) error {
 	type Pair struct {
-		Job    Job
+		JobKey JobKey
 		Status Status
 	}
 	type JobRep struct {
@@ -482,7 +482,7 @@ func (jobs JobMap) WriteHTML(w io.Writer) error {
 	}
 	pairs := make([]Pair, 0, len(jobs))
 	for j := range jobs {
-		pairs = append(pairs, Pair{Job: j, Status: jobs[j]})
+		pairs = append(pairs, Pair{JobKey: j, Status: jobs[j]})
 	}
 	// Order by age.
 	// TODO - color code by how recently there has been an update.  We generally

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -141,6 +141,7 @@ func (tr *Tracker) saveEvery(interval time.Duration) {
 // Note that the returned object is a shallow copy, and the History
 // field shares the slice objects with the JobMap.
 func (tr *Tracker) GetStatus(job Job) (Status, error) {
+	job.dailyOnly = false // For the status, we always clear this field.
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
 	status, ok := tr.jobs[job]
@@ -154,6 +155,7 @@ func (tr *Tracker) GetStatus(job Job) (Status, error) {
 // May return ErrJobAlreadyExists if job already exists and is still in flight.
 func (tr *Tracker) AddJob(job Job) error {
 	status := NewStatus()
+	job.dailyOnly = false // For the status, we always clear this field.
 
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
@@ -181,6 +183,8 @@ func (tr *Tracker) AddJob(job Job) error {
 // UpdateJob updates an existing job.
 // May return ErrJobNotFound if job no longer exists.
 func (tr *Tracker) UpdateJob(job Job, new Status) error {
+	job.dailyOnly = false // For the status, we always clear this field.
+
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
 	old, ok := tr.jobs[job]

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -84,11 +84,11 @@ func cleanup(client dsiface.Client, key *datastore.Key) error {
 }
 
 func TestJobPath(t *testing.T) {
-	withType := tracker.Job{"bucket", "exp", "type", startDate, ""}
+	withType := tracker.Job{Bucket: "bucket", Experiment: "exp", Datatype: "type", Date: startDate, Filter: ""}
 	if withType.Path() != "gs://bucket/exp/type/"+startDate.Format("2006/01/02/") {
 		t.Error("wrong path:", withType.Path())
 	}
-	withoutType := tracker.Job{"bucket", "exp", "", startDate, ""}
+	withoutType := tracker.Job{Bucket: "bucket", Experiment: "exp", Date: startDate, Filter: ""}
 	if withoutType.Path() != "gs://bucket/exp/"+startDate.Format("2006/01/02/") {
 		t.Error("wrong path", withType.Path())
 	}
@@ -176,7 +176,8 @@ func TestUpdates(t *testing.T) {
 
 	createJobs(t, tk, "JobToUpdate", "type", 1)
 
-	job := tracker.Job{"bucket", "JobToUpdate", "type", startDate, ""}
+	job := tracker.Job{Bucket: "bucket", Experiment: "JobToUpdate", Datatype: "type", Date: startDate, Filter: ""}
+
 	must(t, tk.SetStatus(job, tracker.Parsing, "foo"))
 	must(t, tk.SetStatus(job, tracker.Stabilizing, "bar"))
 
@@ -193,7 +194,8 @@ func TestUpdates(t *testing.T) {
 		t.Error("Incorrect detail", status.LastStateInfo())
 	}
 
-	err = tk.SetStatus(tracker.Job{"bucket", "JobToUpdate", "other-type", startDate, ""}, tracker.Stabilizing, "")
+	err = tk.SetStatus(tracker.Job{Bucket: "bucket", Experiment: "JobToUpdate",
+		Datatype: "other-type", Date: startDate, Filter: ""}, tracker.Stabilizing, "")
 	if err != tracker.ErrJobNotFound {
 		t.Error(err, "should have been ErrJobNotFound")
 	}


### PR DESCRIPTION
This introduces a dailyOnly option, that suppresses reprocessing of old data for a datatype.  It will, of course, cause alerts to fire.

This is currently built on top of a change to provide faster build times, but that will be merged first.  Although it has sandbox in the name, deployment is currently being suppressed, as another branch that incorporates this change and others is currently running in sandbox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/352)
<!-- Reviewable:end -->
