### PR TITLE
Restore pcap config

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -14,11 +14,10 @@ sources:
   experiment: ndt
   datatype: ndt7
   target: tmp_ndt.ndt7
-# TODO(soltesz): re-enable after annotation export is completed in production.
-#- bucket: archive-measurement-lab
-#  experiment: ndt
-#  datatype: pcap
-#  target: tmp_ndt.pcap
+- bucket: archive-measurement-lab
+  experiment: ndt
+  datatype: pcap
+  target: tmp_ndt.pcap
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: hopannotation1


### PR DESCRIPTION
Restore the pcap processing for production. This completes the final step after the annotation export reprocessing in production. https://github.com/m-lab/stats-pipeline/issues/85

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/353)
<!-- Reviewable:end -->
