### PR TITLE
Add gardener_jobs_total metric

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -64,7 +64,7 @@ var (
 		[]string{"experiment", "datatype", "status"}, // TODO change to warning
 	)
 
-	// JobsCount counts all the jobs (successful or otherwise) for each datatype.
+	// JobsCount counts all the jobs (successful or otherwise) for each v2 datatype.
 	//
 	// Provides metrics:
 	//  gardener_jobs_total{datatype, status}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -64,6 +64,20 @@ var (
 		[]string{"experiment", "datatype", "status"}, // TODO change to warning
 	)
 
+	// JobsCount counts all the jobs (successful or otherwise) for each datatype.
+	//
+	// Provides metrics:
+	//  gardener_jobs_total{datatype, status}
+	// Example usage:
+	// metrics.JobsCount.WithLabelValues(dt, "success").Inc()
+	JobsCount = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gardener_jobs_total",
+			Help: "Number of finished jobs",
+		},
+		[]string{"datatype", "status"},
+	)
+
 	// TasksInFlight maintains a count of the number of tasks in flight.
 	// TODO consider deprecating this and using Started - Completed.
 	//

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -64,18 +64,18 @@ var (
 		[]string{"experiment", "datatype", "status"}, // TODO change to warning
 	)
 
-	// JobsCount counts all the jobs (successful or otherwise) for each v2 datatype.
+	// JobsTotal counts all the jobs (successful or otherwise) for each v2 datatype.
 	//
 	// Provides metrics:
 	//  gardener_jobs_total{datatype, status}
 	// Example usage:
-	// metrics.JobsCount.WithLabelValues(dt, "success").Inc()
-	JobsCount = promauto.NewCounterVec(
+	// metrics.JobsTotal.WithLabelValues(dt, "success").Inc()
+	JobsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "gardener_jobs_total",
 			Help: "Number of finished jobs",
 		},
-		[]string{"datatype", "status"},
+		[]string{"experiment", "datatype", "status"},
 	)
 
 	// TasksInFlight maintains a count of the number of tasks in flight.

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -11,6 +11,7 @@ func TestLintMetrics(t *testing.T) {
 	CompletedCount.WithLabelValues("exp", "type")
 	FailCount.WithLabelValues("exp", "type", "status")
 	WarningCount.WithLabelValues("exp", "type", "status")
+	JobsCount.WithLabelValues("type", "status")
 	StateDate.WithLabelValues("exp", "type", "x")
 	StateTimeHistogram.WithLabelValues("exp", "type", "x")
 	FilesPerDateHistogram.WithLabelValues("exp", "type", "x")

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -11,7 +11,7 @@ func TestLintMetrics(t *testing.T) {
 	CompletedCount.WithLabelValues("exp", "type")
 	FailCount.WithLabelValues("exp", "type", "status")
 	WarningCount.WithLabelValues("exp", "type", "status")
-	JobsCount.WithLabelValues("type", "status")
+	JobsTotal.WithLabelValues("exp", "type", "status")
 	StateDate.WithLabelValues("exp", "type", "x")
 	StateTimeHistogram.WithLabelValues("exp", "type", "x")
 	FilesPerDateHistogram.WithLabelValues("exp", "type", "x")

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -74,11 +74,14 @@ func (j Job) failureMetric(state State, errString string) {
 	defer errStringLock.Unlock()
 	if _, ok := errStrings[errString]; ok {
 		metrics.FailCount.WithLabelValues(j.Experiment, j.Datatype, errString).Inc()
+		metrics.JobsCount.WithLabelValues(j.Datatype, errString).Inc()
 	} else if len(errStrings) < maxUniqueErrStrings {
 		errStrings[errString] = struct{}{}
 		metrics.FailCount.WithLabelValues(j.Experiment, j.Datatype, errString).Inc()
+		metrics.JobsCount.WithLabelValues(j.Datatype, errString).Inc()
 	} else {
 		metrics.FailCount.WithLabelValues(j.Experiment, j.Datatype, "generic").Inc()
+		metrics.JobsCount.WithLabelValues(j.Datatype, "generic").Inc()
 	}
 }
 

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -74,14 +74,14 @@ func (j Job) failureMetric(state State, errString string) {
 	defer errStringLock.Unlock()
 	if _, ok := errStrings[errString]; ok {
 		metrics.FailCount.WithLabelValues(j.Experiment, j.Datatype, errString).Inc()
-		metrics.JobsCount.WithLabelValues(j.Datatype, errString).Inc()
+		metrics.JobsTotal.WithLabelValues(j.Experiment, j.Datatype, errString).Inc()
 	} else if len(errStrings) < maxUniqueErrStrings {
 		errStrings[errString] = struct{}{}
 		metrics.FailCount.WithLabelValues(j.Experiment, j.Datatype, errString).Inc()
-		metrics.JobsCount.WithLabelValues(j.Datatype, errString).Inc()
+		metrics.JobsTotal.WithLabelValues(j.Experiment, j.Datatype, errString).Inc()
 	} else {
 		metrics.FailCount.WithLabelValues(j.Experiment, j.Datatype, "generic").Inc()
-		metrics.JobsCount.WithLabelValues(j.Datatype, "generic").Inc()
+		metrics.JobsTotal.WithLabelValues(j.Experiment, j.Datatype, "generic").Inc()
 	}
 }
 

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -197,6 +197,7 @@ func (tr *Tracker) UpdateJob(job Job, new Status) error {
 	// When jobs are done, we update stats and may remove them from tracker.
 	if new.isDone() {
 		metrics.CompletedCount.WithLabelValues(job.Experiment, job.Datatype).Inc()
+		metrics.JobsCount.WithLabelValues(job.Datatype, "success").Inc()
 
 		// This could be done by GetStatus, but would change behaviors slightly.
 		if tr.cleanupDelay == 0 {

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -197,7 +197,7 @@ func (tr *Tracker) UpdateJob(job Job, new Status) error {
 	// When jobs are done, we update stats and may remove them from tracker.
 	if new.isDone() {
 		metrics.CompletedCount.WithLabelValues(job.Experiment, job.Datatype).Inc()
-		metrics.JobsCount.WithLabelValues(job.Datatype, "success").Inc()
+		metrics.JobsTotal.WithLabelValues(job.Experiment, job.Datatype, "success").Inc()
 
 		// This could be done by GetStatus, but would change behaviors slightly.
 		if tr.cleanupDelay == 0 {


### PR DESCRIPTION
Add a new metric that exports the number of Gardener jobs with a "status" label for success or failures. The goal is to use this metric to set up alerts around the rate of unrecoverable job failures.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/355)
<!-- Reviewable:end -->
