### PR TITLE
Source hopannotation1 archives from sandbox, staging, or public archives

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -17,7 +17,7 @@ sources:
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: pcap
-  target: tmp_ndt.pcap
+#  target: tmp_ndt.pcap
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: ndt
   datatype: hopannotation1

--- a/config/config.yml
+++ b/config/config.yml
@@ -18,7 +18,7 @@ sources:
   experiment: ndt
   datatype: pcap
   target: tmp_ndt.pcap
-- bucket: archive-measurement-lab
+- bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: ndt
   datatype: hopannotation1
   target: tmp_ndt.hopannotation1

--- a/config/config.yml
+++ b/config/config.yml
@@ -14,9 +14,9 @@ sources:
   experiment: ndt
   datatype: ndt7
   target: tmp_ndt.ndt7
-- bucket: archive-measurement-lab
-  experiment: ndt
-  datatype: pcap
+#- bucket: archive-measurement-lab
+#  experiment: ndt
+#  datatype: pcap
 #  target: tmp_ndt.pcap
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: ndt

--- a/config/config.yml
+++ b/config/config.yml
@@ -14,10 +14,10 @@ sources:
   experiment: ndt
   datatype: ndt7
   target: tmp_ndt.ndt7
-#- bucket: archive-measurement-lab
-#  experiment: ndt
-#  datatype: pcap
-#  target: tmp_ndt.pcap
+- bucket: archive-measurement-lab
+  experiment: ndt
+  datatype: pcap
+  target: tmp_ndt.pcap
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: ndt
   datatype: hopannotation1


### PR DESCRIPTION
Get hopannotation1 archive from the `ANNOTATION_SOURCE_PROJECT` variable.

The same change was done for the annotation data type https://github.com/m-lab/etl-gardener/pull/347.

We can observe that synthetic data (e.g., before August 2021) is being parsed and written out to the [bucket](https://pantheon.corp.google.com/storage/browser/etl-mlab-sandbox/ndt/hopannotation1/2021?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=mlab-sandbox&prefix=&forceOnObjectsSortingFiltering=false) in sandbox.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/357)
<!-- Reviewable:end -->
