### PR TITLE
Combine "handler" functions for the JobsAPI in tracker package

### DIFF
--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -8,14 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"log"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"bou.ke/monkey"
 	"cloud.google.com/go/datastore"
-	"cloud.google.com/go/storage"
 	"github.com/go-test/deep"
 
 	"github.com/m-lab/go/rtx"
@@ -24,8 +22,6 @@ import (
 	"github.com/m-lab/etl-gardener/job-service"
 	"github.com/m-lab/etl-gardener/persistence"
 	"github.com/m-lab/etl-gardener/tracker"
-
-	"github.com/m-lab/go/cloudtest/gcsfake"
 )
 
 func init() {
@@ -105,61 +101,6 @@ func TestService_NextJob(t *testing.T) {
 		if diff != nil {
 			t.Error(i, diff)
 		}
-	}
-}
-
-func TestJobHandler(t *testing.T) {
-	fc := gcsfake.GCSClient{}
-	fc.AddTestBucket("fake-bucket",
-		&gcsfake.BucketHandle{
-			ObjAttrs: []*storage.ObjectAttrs{
-				{Name: "obj1", Updated: time.Now()},
-				{Name: "obj2", Updated: time.Now()},
-				{Name: "ndt/ndt5/2011/02/03/foobar.tgz", Size: 101, Updated: time.Now()},
-			}})
-
-	ctx := context.Background()
-
-	// Fake time will avoid yesterday trigger.
-	now := time.Date(2011, 2, 16, 1, 2, 3, 4, time.UTC)
-	monkey.Patch(time.Now, func() time.Time {
-		return now
-	})
-	defer monkey.Unpatch(time.Now)
-
-	sources := []config.SourceConfig{
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
-	}
-	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)
-	svc, err := job.NewJobService(ctx, &NullTracker{}, start, "fake-bucket", sources, &NullSaver{}, &fc)
-	must(t, err)
-	req := httptest.NewRequest("", "/job", nil)
-	resp := httptest.NewRecorder()
-	svc.JobHandler(resp, req)
-	if resp.Code != http.StatusMethodNotAllowed {
-		t.Error("Should be MethodNotAllowed", http.StatusText(resp.Code))
-	}
-
-	// This one should fail because there are no objects with tcpinfo prefix.
-	req = httptest.NewRequest("POST", "/job", nil)
-	resp = httptest.NewRecorder()
-	svc.JobHandler(resp, req)
-	if resp.Code != http.StatusInternalServerError {
-		t.Error("Should be InternalServerError", http.StatusText(resp.Code), resp.Body.String())
-	}
-
-	// This should succeed, because the service advanced to ndt5/2011/02/03/
-	req = httptest.NewRequest("POST", "/job", nil)
-	resp = httptest.NewRecorder()
-	svc.JobHandler(resp, req)
-	if resp.Code != http.StatusOK {
-		t.Error("Should be StatusOK", http.StatusText(resp.Code), resp.Body.String())
-	}
-
-	want := `{"Bucket":"fake-bucket","Experiment":"ndt","Datatype":"ndt5","Date":"2011-02-03T00:00:00Z"}`
-	if want != resp.Body.String() {
-		t.Fatal(resp.Body.String())
 	}
 }
 

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -295,7 +295,7 @@ func TestEarlyWrapping(t *testing.T) {
 		got := svc.NextJob(context.Background())
 		tk.AddJob(got.Job)
 		if k == 2 {
-			// It's necessary to mark job complete to prevent AddJob error.
+			// Simulate "monitor" behavior and mark job complete to prevent AddJob error.
 			status, _ := tk.GetStatus(got.Job)
 			status.NewState(tracker.Complete)
 			err := tk.UpdateJob(got.Job, status)

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -291,8 +291,19 @@ func TestEarlyWrapping(t *testing.T) {
 		tracker.Job{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Date: start},
 	}
 
-	for _, realJob := range expected {
+	for k, realJob := range expected {
 		got := svc.NextJob(context.Background())
+		tk.AddJob(got.Job)
+		if k == 2 {
+			// It's necessary to mark job complete to prevent AddJob error.
+			status, _ := tk.GetStatus(got.Job)
+			status.NewState(tracker.Complete)
+			err := tk.UpdateJob(got.Job, status)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+
 		if got.Job != realJob {
 			t.Errorf("NextJob() wrong job: got %v, want %v", got.Job, realJob)
 		}

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -12,6 +12,11 @@ import (
 	"github.com/m-lab/go/logx"
 )
 
+var (
+	MsgNoJobFound = "No job found. Try again."
+	MsgJobExists  = "Job already exists. Try again."
+)
+
 // UpdateURL makes an update request URL.
 func UpdateURL(base url.URL, job Job, state State, detail string) *url.URL {
 	base.Path += "update"
@@ -156,12 +161,9 @@ func (h *Handler) nextJob(resp http.ResponseWriter, req *http.Request) {
 
 	// Check for empty job (no job found with files)
 	if job.Date.Equal(time.Time{}) {
-		log.Println("no job found")
+		log.Println(MsgNoJobFound)
 		resp.WriteHeader(http.StatusInternalServerError)
-		_, err := resp.Write([]byte("No job found.  Try again."))
-		if err != nil {
-			log.Println(err)
-		}
+		resp.Write([]byte(MsgNoJobFound))
 		return
 	}
 
@@ -169,10 +171,7 @@ func (h *Handler) nextJob(resp http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		log.Println(err, job)
 		resp.WriteHeader(http.StatusInternalServerError)
-		_, err = resp.Write([]byte("Job already exists.  Try again."))
-		if err != nil {
-			log.Println(err)
-		}
+		resp.Write([]byte(MsgJobExists))
 		return
 	}
 

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -1,11 +1,13 @@
 package tracker
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/m-lab/go/logx"
 )
@@ -43,14 +45,19 @@ func ErrorURL(base url.URL, job Job, errString string) *url.URL {
 	return &base
 }
 
+type JobService interface {
+	NextJob(ctx context.Context) JobWithTarget
+}
+
 // Handler provides handlers for update, heartbeat, etc.
 type Handler struct {
-	tracker *Tracker
+	tracker    *Tracker
+	jobservice JobService
 }
 
 // NewHandler returns a Handler that sends updates to provided Tracker.
-func NewHandler(tr *Tracker) *Handler {
-	return &Handler{tr}
+func NewHandler(tr *Tracker, js JobService) *Handler {
+	return &Handler{tracker: tr, jobservice: js}
 }
 
 func getJob(jobString string) (Job, error) {
@@ -139,9 +146,51 @@ func (h *Handler) errorFunc(resp http.ResponseWriter, req *http.Request) {
 	resp.WriteHeader(http.StatusOK)
 }
 
+func (h *Handler) nextJob(resp http.ResponseWriter, req *http.Request) {
+	// Must be a post because it changes state.
+	if req.Method != http.MethodPost {
+		resp.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	job := h.jobservice.NextJob(req.Context())
+
+	// Check for empty job (no job found with files)
+	if job.Date.Equal(time.Time{}) {
+		log.Println("no job found")
+		resp.WriteHeader(http.StatusInternalServerError)
+		_, err := resp.Write([]byte("No job found.  Try again."))
+		if err != nil {
+			log.Println(err)
+		}
+		return
+	}
+
+	err := h.tracker.AddJob(job.Job)
+	if err != nil {
+		log.Println(err, job)
+		resp.WriteHeader(http.StatusInternalServerError)
+		_, err = resp.Write([]byte("Job already exists.  Try again."))
+		if err != nil {
+			log.Println(err)
+		}
+		return
+	}
+
+	log.Printf("Dispatching %s\n", job.Job)
+	_, err = resp.Write(job.Marshal())
+	if err != nil {
+		log.Println(err)
+		// This should precede the Write(), but the Write failed, so this
+		// is likely ok.
+		resp.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
 // Register registers the handlers on the server.
 func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/heartbeat", h.heartbeat)
 	mux.HandleFunc("/update", h.update)
 	mux.HandleFunc("/error", h.errorFunc)
+	mux.HandleFunc("/job", h.nextJob)
 }

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -183,20 +183,6 @@ func TestErrorHandler(t *testing.T) {
 	}
 }
 
-/*
-func TestNextJobHandler(t *testing.T) {
-	server, _, job := testSetup(t)
-
-	j, err := client.NextJob(context.Background(), server)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if job != j.Job {
-		t.Error("jobs do not match:")
-	}
-}
-*/
-
 func TestNextJobHandler(t *testing.T) {
 	date := time.Date(2019, 01, 02, 0, 0, 0, 0, time.UTC)
 	job := tracker.NewJob("bucket", "exp", "type", date)


### PR DESCRIPTION
Previously the handler implementations for the JobsAPI was split across two packages. This change moves all handler functions to the tracker/handler.go 

Previously the instance relationships looked like:

* monitor contains a tracker
* handler contains a tracker (with three resource definitions /update, /heartbeat, /error)
* jobservice contains a tracker and config (with one resource definition /job)

With this change, the instance relationship look like:

* monitor contains a tracker
* jobservice contains config
* handler contains a tracker and jobservice (with all four resource definitions)

This consolidation (all handlers in one place) will allow us to introduce a "v2" api that extends the Job interface between the ETL parsers and the gardener.

NOTES:
* These resources are invoked using code in the `etl-gardener/client/client.go` package and custom implementations in `etl/active/poller.go`. These implementations should be consolidated to the client package in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/360)
<!-- Reviewable:end -->
