### PR TITLE
Parse sandbox archives for ndt & pcap

### DIFF
--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -23,6 +23,11 @@ SOURCE_PROJECT=${PROJECT_ID/mlab-oti/measurement-lab}
 sed -i \
     -e 's/{{ANNOTATION_SOURCE_PROJECT}}/'${SOURCE_PROJECT}'/g' \
     config/config.yml
+# Use sandbox in sandbox, measurement-lab in staging and oti.
+SOURCE_PROJECT=${SOURCE_PROJECT/mlab-staging/measurement-lab}
+sed -i \
+    -e 's/{{NDT_SOURCE_PROJECT}}/'${SOURCE_PROJECT}'/g' \
+    config/config.yml
 
 # Create the configmap
 kubectl create configmap gardener-config --dry-run \

--- a/config/config.yml
+++ b/config/config.yml
@@ -10,11 +10,11 @@ sources:
   experiment: ndt
   datatype: annotation
   target: tmp_ndt.annotation
-- bucket: archive-measurement-lab
+- bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt7
   target: tmp_ndt.ndt7
-- bucket: archive-measurement-lab
+- bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: pcap
   target: tmp_ndt.pcap


### PR DESCRIPTION
This change changes the ndt7 and pcap source archive bucket for mlab-sandbox in order to parse measurements to sandbox servers.

NOTE: ideally, the configuration could contain multiple source archives and multiple output datasets. However this functionality is blocked on internal refactoring, such as in #350 or #352 etc.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/361)
<!-- Reviewable:end -->
