### PR TITLE
Improve two flaky tests

### DIFF
--- a/ops/ops.go
+++ b/ops/ops.go
@@ -133,6 +133,10 @@ func (m *Monitor) AddAction(state tracker.State, cond ConditionFunc, op ActionFu
 	}
 }
 
+func (m *Monitor) GetAction(state tracker.State) Action {
+	return m.actions[state]
+}
+
 // UpdateJob updates the tracker state with the outcome.
 func (m *Monitor) UpdateJob(o *Outcome, state tracker.State) (string, error) {
 	// Allow error to override implicit (-) detail.

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-lab/go/logx"
 	"github.com/m-lab/go/rtx"
 
 	"github.com/m-lab/etl-gardener/cloud"
@@ -35,8 +34,6 @@ func newStateFunc(detail string) ops.ActionFunc {
 }
 
 func TestMonitor_Watch(t *testing.T) {
-	logx.LogxDebug.Set("true")
-
 	ctx, cancel := context.WithCancel(context.Background())
 	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0, 0)
 	rtx.Must(err, "tk init")
@@ -79,8 +76,6 @@ func TestMonitor_Watch(t *testing.T) {
 }
 
 func TestOutcomeUpdate(t *testing.T) {
-	logx.LogxDebug.Set("true")
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0, 0)


### PR DESCRIPTION
The frequency of flaky tests interrupting the build seems to have increased, and disrupts review and deployment of otherwise qualified changes. These fixes address two flaky tests in gardener:

* Fixes: https://github.com/m-lab/etl-gardener/issues/337

  - TestSanityCheckAndCopy - could fail for two different 4xx HTTP errors for non-deterministic reasons. This change adds both errors.

* Addresses: https://github.com/m-lab/etl-gardener/issues/328

  - TestStandardMonitor - could fail when some integration test operations took longer than 30s to complete. Anecdotally, tis can sometimes be multiple minutes. Since this completion time is not under our control, this change increases the timeout and ignores operations that are still in their final state ("joining").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/363)
<!-- Reviewable:end -->
