### PR TITLE
Add local writer option for persistence of Gardener job status

### DIFF
--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -57,6 +57,11 @@ var (
 )
 
 var (
+	saverType = flagx.Enum{
+		Options: []string{"datastore", "local"},
+		Value:   "datastore",
+	}
+
 	jobExpirationTime = flag.Duration("job_expiration_time", 24*time.Hour, "Time after which stale jobs will be purged")
 	jobCleanupDelay   = flag.Duration("job_cleanup_delay", 3*time.Hour, "Time after which completed jobs will be removed from tracker")
 	shutdownTimeout   = flag.Duration("shutdown_timeout", 1*time.Minute, "Graceful shutdown time allowance")
@@ -69,6 +74,8 @@ var (
 func init() {
 	// Always prepend the filename and line number.
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	flag.Var(&saverType, "saver.backend", "Set the saver backend to 'datastore' or 'local' file.")
 }
 
 // Environment provides "global" variables.
@@ -314,14 +321,21 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 func mustStandardTracker() *tracker.Tracker {
-	client, err := datastore.NewClient(context.Background(), env.Project)
-	rtx.Must(err, "datastore client")
+	var saver tracker.Saver
 	dsKey := datastore.NameKey("tracker", "jobs", nil)
 	dsKey.Namespace = "gardener"
 
+	switch saverType.Value {
+	case "datastore":
+		client, err := datastore.NewClient(context.Background(), env.Project)
+		rtx.Must(err, "datastore client")
+		saver = tracker.NewDatastoreSaver(dsiface.AdaptClient(client), dsKey)
+	case "local":
+		saver = tracker.NewLocalSaver(dsKey)
+	}
+
 	tk, err := tracker.InitTracker(
-		context.Background(),
-		dsiface.AdaptClient(client), dsKey,
+		context.Background(), saver,
 		time.Minute, *jobExpirationTime, *jobCleanupDelay)
 	rtx.Must(err, "tracker init")
 	if tk == nil {
@@ -332,12 +346,19 @@ func mustStandardTracker() *tracker.Tracker {
 }
 
 func mustCreateJobService(ctx context.Context) *job.Service {
+	var saver persistence.Saver
 	storageClient, err := storage.NewClient(ctx)
 	rtx.Must(err, "Could not create storage client for job service")
 
-	saver, err := persistence.NewDatastoreSaver(context.Background(), os.Getenv("PROJECT"))
-	rtx.Must(err, "Could not initialize datastore saver")
-	svc, err := job.NewJobService(ctx, globalTracker, config.StartDate(),
+	switch saverType.Value {
+	case "datastore":
+		saver, err = persistence.NewDatastoreSaver(context.Background(), os.Getenv("PROJECT"))
+		rtx.Must(err, "Could not initialize datastore saver")
+	case "local":
+		saver = persistence.NewLocalSaver()
+	}
+	svc, err := job.NewJobService(
+		ctx, globalTracker, config.StartDate(),
 		os.Getenv("PROJECT"), config.Sources(), saver,
 		stiface.AdaptClient(storageClient))
 	rtx.Must(err, "Could not initialize job service")

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -114,7 +114,10 @@ func TestResume(t *testing.T) {
 	ctx := context.Background()
 
 	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)
-	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0, 0) // Only using jobmap.
+	dsKey := datastore.NameKey("TestResume", "jobs", nil)
+	dsKey.Namespace = "gardener"
+	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
+	tk, err := tracker.InitTracker(context.Background(), saver, 0, 0, 0) // Only using jobmap.
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +272,10 @@ func TestEarlyWrapping(t *testing.T) {
 	})
 	defer monkey.Unpatch(time.Now)
 	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)
-	tk, err := tracker.InitTracker(context.Background(), nil, nil, 0, 0, 0) // Only using jobmap.
+	dsKey := datastore.NameKey("TestEarlyWrapping", "jobs", nil)
+	dsKey.Namespace = "gardener"
+	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
+	tk, err := tracker.InitTracker(context.Background(), saver, 0, 0, 0) // Only using jobmap.
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -114,9 +114,7 @@ func TestResume(t *testing.T) {
 	ctx := context.Background()
 
 	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)
-	dsKey := datastore.NameKey("TestResume", "jobs", nil)
-	dsKey.Namespace = "gardener"
-	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
+	saver := tracker.NewLocalSaver(t.TempDir(), nil)
 	tk, err := tracker.InitTracker(context.Background(), saver, 0, 0, 0) // Only using jobmap.
 	if err != nil {
 		t.Fatal(err)
@@ -272,9 +270,7 @@ func TestEarlyWrapping(t *testing.T) {
 	})
 	defer monkey.Unpatch(time.Now)
 	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)
-	dsKey := datastore.NameKey("TestEarlyWrapping", "jobs", nil)
-	dsKey.Namespace = "gardener"
-	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
+	saver := tracker.NewLocalSaver(t.TempDir(), nil)
 	tk, err := tracker.InitTracker(context.Background(), saver, 0, 0, 0) // Only using jobmap.
 	if err != nil {
 		t.Fatal(err)

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/datastore"
 	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/ops"
 	"github.com/m-lab/etl-gardener/tracker"
@@ -28,9 +27,7 @@ func TestStandardMonitor(t *testing.T) {
 	defer cleanup()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	dsKey := datastore.NameKey("TestConcurrentUpdates", "jobs", nil)
-	dsKey.Namespace = "gardener"
-	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
+	saver := tracker.NewLocalSaver(t.TempDir(), nil)
 	tk, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	rtx.Must(err, "tk init")
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/datastore"
 	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/ops"
 	"github.com/m-lab/etl-gardener/tracker"
@@ -27,7 +28,10 @@ func TestStandardMonitor(t *testing.T) {
 	defer cleanup()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0, 0)
+	dsKey := datastore.NameKey("TestConcurrentUpdates", "jobs", nil)
+	dsKey.Namespace = "gardener"
+	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
+	tk, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	rtx.Must(err, "tk init")
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
 	// Not yet supported.

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/datastore"
-
 	"github.com/m-lab/go/rtx"
 
 	"github.com/m-lab/etl-gardener/cloud"
@@ -37,8 +35,7 @@ func newStateFunc(detail string) ops.ActionFunc {
 
 func TestMonitor_Watch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	dsKey := datastore.NameKey("TestMonitor_Watch", "monitor", nil)
-	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
+	saver := tracker.NewLocalSaver(t.TempDir(), nil)
 	tk, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	rtx.Must(err, "tk init")
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
@@ -82,8 +79,7 @@ func TestMonitor_Watch(t *testing.T) {
 func TestOutcomeUpdate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	dsKey := datastore.NameKey("TestOutcomeUpdate", "monitor", nil)
-	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
+	saver := tracker.NewLocalSaver(t.TempDir(), nil)
 	tk, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	rtx.Must(err, "tk init")
 	job := tracker.NewJob("bucket", "exp", "type", time.Now())

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/datastore"
+
 	"github.com/m-lab/go/rtx"
 
 	"github.com/m-lab/etl-gardener/cloud"
@@ -35,7 +37,9 @@ func newStateFunc(detail string) ops.ActionFunc {
 
 func TestMonitor_Watch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0, 0)
+	dsKey := datastore.NameKey("TestMonitor_Watch", "monitor", nil)
+	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
+	tk, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	rtx.Must(err, "tk init")
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
 	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))
@@ -78,7 +82,9 @@ func TestMonitor_Watch(t *testing.T) {
 func TestOutcomeUpdate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	tk, err := tracker.InitTracker(ctx, nil, nil, 0, 0, 0)
+	dsKey := datastore.NameKey("TestOutcomeUpdate", "monitor", nil)
+	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
+	tk, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	rtx.Must(err, "tk init")
 	job := tracker.NewJob("bucket", "exp", "type", time.Now())
 	tk.AddJob(job)

--- a/persistence/persistence_test.go
+++ b/persistence/persistence_test.go
@@ -4,11 +4,9 @@ package persistence_test
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"reflect"
 	"testing"
-	"time"
 
 	"cloud.google.com/go/datastore"
 
@@ -68,51 +66,4 @@ func TestDatastoreSaver(t *testing.T) {
 	if err != datastore.ErrNoSuchEntity {
 		t.Fatal("Should have errored")
 	}
-}
-
-func TestFetchAll(t *testing.T) {
-	o := NewO1("foo")
-	o.Integer = 1234
-
-	ctx := context.Background()
-	ds, err := persistence.NewDatastoreSaver(ctx, "mlab-testing")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = ds.Save(ctx, &o)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for i := 0; i < 20; i++ {
-		o := NewO1(fmt.Sprint("foo", i))
-		o.Integer = (int32)(i)
-		err = ds.Save(ctx, &o)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	var keys []*datastore.Key
-	var slice []O1
-
-	// datastore sometimes takes a while to become consistent.
-	for i := 0; i < 50; i++ {
-		var objs interface{}
-		keys, objs, err = ds.FetchAll(ctx, O1{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		slice = objs.([]O1)
-		if len(slice) >= 21 {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	if len(slice) != 21 {
-		t.Error("Should be 21 items, but got", len(slice))
-	}
-
-	err = ds.Client.DeleteMulti(ctx, keys)
-	rtx.Must(err, "Delete error")
 }

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -14,7 +14,6 @@ import (
 
 	"cloud.google.com/go/datastore"
 	"github.com/m-lab/etl-gardener/tracker"
-	"github.com/m-lab/go/cloudtest/dsfake"
 )
 
 func init() {
@@ -35,12 +34,11 @@ func (f *fakeJobService) NextJob(ctx context.Context) tracker.JobWithTarget {
 }
 
 func testSetup(t *testing.T, jobs []tracker.Job) (url.URL, *tracker.Tracker) {
-	client := dsfake.NewClient()
 	dsKey := datastore.NameKey("TestTrackerAddDelete", "jobs", nil)
 	dsKey.Namespace = "gardener"
-	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(context.Background(), client, dsKey, 0, 0, 0)
+	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
+	tk, err := tracker.InitTracker(context.Background(), saver, 0, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -508,18 +508,23 @@ func loadFromDatastore(ctx context.Context, client dsiface.Client, key *datastor
 	return state, err
 }
 
-// loadJobMap loads the persisted map of jobs in flight.
+// loadJobMap loads the persisted map of jobs in flight from datastore.
 func loadJobMap(ctx context.Context, client dsiface.Client, key *datastore.Key) (JobMap, Job, error) {
 	state, err := loadFromDatastore(ctx, client, key)
 	if err != nil {
 		return nil, Job{}, err
 	}
+	return loadJobMapFromState(state)
+}
+
+// loadJobMapFromState completes unmarshalling a saverStruct.
+func loadJobMapFromState(state saverStruct) (JobMap, Job, error) {
 	log.Println("Last save:", state.SaveTime.Format("01/02T15:04"))
 	log.Println(string(state.Jobs))
 
 	jobMap := make(JobMap, 100)
 	log.Println("Unmarshalling", len(state.Jobs))
-	err = json.Unmarshal(state.Jobs, &jobMap)
+	err := json.Unmarshal(state.Jobs, &jobMap)
 	if err != nil {
 		log.Fatal("loadJobMap failed", err)
 	}

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -53,7 +53,6 @@ type Tracker struct {
 type Saver interface {
 	Save(ctx context.Context, src interface{}) error
 	Load(ctx context.Context) (JobMap, Job, error)
-	Delete(ctx context.Context) error
 }
 
 type DatastoreSaver struct {
@@ -77,10 +76,6 @@ func (ds *DatastoreSaver) Load(ctx context.Context) (JobMap, Job, error) {
 	return loadJobMap(ctx, ds.client, ds.key)
 }
 
-func (ds *DatastoreSaver) Delete(ctx context.Context) error {
-	return nil
-}
-
 type LocalSaver struct {
 	dir  string
 	key  *datastore.Key
@@ -95,6 +90,9 @@ func NewLocalSaver(dir string, dsKey *datastore.Key) *LocalSaver {
 }
 
 func (ls *LocalSaver) fname() string {
+	if ls.key == nil {
+		return "nil-localsaver.txt"
+	}
 	return path.Join(ls.dir, ls.key.Namespace+"-"+ls.key.Kind+"-"+ls.key.Name)
 }
 

--- a/tracker/tracker_integration_test.go
+++ b/tracker/tracker_integration_test.go
@@ -29,7 +29,8 @@ func TestWithDatastore(t *testing.T) {
 	// quite a while to propogate.
 	defer must(t, cleanup(client, dsKey))
 
-	tk, err := tracker.InitTracker(ctx, client, dsKey, 0, 0, 0)
+	saver := tracker.NewDatastoreSaver(client, dsKey)
+	tk, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	must(t, err)
 	if tk == nil {
 		t.Fatal("nil Tracker")
@@ -45,7 +46,7 @@ func TestWithDatastore(t *testing.T) {
 	_, err = tk.Sync(ctx, time.Time{})
 	must(t, err)
 	// Check that the sync (and InitTracker) work.
-	restore, err := tracker.InitTracker(ctx, client, dsKey, 0, 0, 0)
+	restore, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	must(t, err)
 
 	if restore.NumJobs() != 500 {

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -101,7 +101,6 @@ func TestTrackerAddDelete(t *testing.T) {
 	dsKey := datastore.NameKey("TestTrackerAddDelete", "jobs", nil)
 	dsKey.Namespace = "gardener"
 	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
-	defer saver.Delete(context.Background())
 
 	tk, err := tracker.InitTracker(ctx, saver, 0, 0, time.Second)
 	must(t, err)
@@ -169,7 +168,6 @@ func TestUpdates(t *testing.T) {
 	dsKey := datastore.NameKey("TestUpdate", "jobs", nil)
 	dsKey.Namespace = "gardener"
 	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
-	defer saver.Delete(context.Background())
 
 	tk, err := tracker.InitTracker(context.Background(), saver, 0, 0, 0)
 	must(t, err)
@@ -214,7 +212,6 @@ func TestNonexistentJobAccess(t *testing.T) {
 	dsKey := datastore.NameKey("TestNonexistentJobAccess", "jobs", nil)
 	dsKey.Namespace = "gardener"
 	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
-	defer saver.Delete(context.Background())
 
 	tk, err := tracker.InitTracker(context.Background(), saver, 0, 0, 0)
 	must(t, err)
@@ -250,7 +247,6 @@ func TestJobMapHTML(t *testing.T) {
 	dsKey := datastore.NameKey("TestJobMapHTML", "jobs", nil)
 	dsKey.Namespace = "gardener"
 	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
-	defer saver.Delete(context.Background())
 
 	tk, err := tracker.InitTracker(context.Background(), saver, 0, 0, 0)
 	must(t, err)
@@ -274,7 +270,6 @@ func TestExpiration(t *testing.T) {
 	dsKey := datastore.NameKey("TestExpiration", "jobs", nil)
 	dsKey.Namespace = "gardener"
 	saver := tracker.NewLocalSaver(t.TempDir(), dsKey)
-	defer saver.Delete(context.Background())
 
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
This change introduces two new flags and preserves default behavior. These flags allow selecting a new "local saver" to persist Gardener state to local disk instead of using Datastore for the v2 system. The v1 "legacy" mode continues to use Datastore.

This change is necessary because we recently encountered a limitation in Datastore object sizes when adding a new datatype configuration #364.

Because default behavior is preserved, this functionality must be enabled explicitly using a flag. The `-saver.dir` must already exist.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/365)
<!-- Reviewable:end -->
