### PR TITLE
Add local saver flags for gardener v2

### DIFF
--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -36,7 +36,12 @@ spec:
       containers:
       - image: gcr.io/{{GCLOUD_PROJECT}}/etl-gardener:{{GIT_COMMIT}}
         name: etl-gardener
-        args: ["--prometheusx.listen-address=:9090", "--config_path=/etc/config.yml"]
+        args: [
+          "--prometheusx.listen-address=:9090",
+          "--config_path=/etc/config.yml",
+          "-saver.backend=local",
+          "-saver.dir=/singleton"
+        ]
         env:
         - name: SERVICE_MODE # Whether to use task-queues or run as manager.
           value: "manager"


### PR DESCRIPTION
This change adds the local saver flags to the v2 gardener configuration. With this change, the v2 gardener will save/sync daily and historical job status to the "/singleton" disk volume. With this change the entities in Datastore are obsolete and should be removed to prevent confusion.

Fixes https://github.com/m-lab/etl-gardener/issues/364