### PR TITLE
Update schema on output tables for JOIN'd tables

### DIFF
--- a/cloud/bq/ops.go
+++ b/cloud/bq/ops.go
@@ -262,6 +262,9 @@ func (to TableOps) Join(ctx context.Context, dryRun bool) (bqiface.Job, error) {
 			WriteDisposition: bigquery.WriteTruncate,
 			// Create the table if it doesn't exist
 			CreateDisposition: bigquery.CreateIfNeeded,
+			// Allow additional fields introduced by the raw tables to be automatically
+			// added to the joined, materialized output table.
+			SchemaUpdateOptions: []string{"ALLOW_FIELD_ADDITION", "ALLOW_FIELD_RELAXATION"},
 			// Partitioning spec, in event we have to create the table.
 			TimePartitioning: &bigquery.TimePartitioning{
 				Field:                  "date",


### PR DESCRIPTION
This change addresses a long standing failure in gardener where new fields in raw tables would introduce failures to write the joined, materialized tables. The failure was due to the joined table not having the new fields and etl/cmd/update-schema not populating them. This change allows BigQuery to do the update automatically. Removing fields is still not supported.

This change supports deployment of:
* https://github.com/m-lab/ndt-server/pull/345 

Though without integration tests, this change
* Fixes https://github.com/m-lab/etl-gardener/issues/325

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/368)
<!-- Reviewable:end -->
