### PR TITLE
Provide a -gardener_addr flag (1 of 2)

### DIFF
--- a/cmd/gardener/gardener.go
+++ b/cmd/gardener/gardener.go
@@ -67,6 +67,7 @@ var (
 	jobCleanupDelay   = flag.Duration("job_cleanup_delay", 3*time.Hour, "Time after which completed jobs will be removed from tracker")
 	shutdownTimeout   = flag.Duration("shutdown_timeout", 1*time.Minute, "Graceful shutdown time allowance")
 	statusPort        = flag.String("status_port", ":0", "The public interface port where status (and pprof) will be published")
+	gardenerAddr      = flag.String("gardener_addr", ":8080", "The listen address for the gardener jobs service")
 
 	// Context and injected variables to allow smoke testing of main()
 	mainCtx, mainCancel = context.WithCancel(context.Background())
@@ -398,7 +399,7 @@ func main() {
 	mux := http.NewServeMux()
 	// Start up the main job and update server.
 	server := &http.Server{
-		Addr:    ":8080",
+		Addr:    *gardenerAddr,
 		Handler: mux,
 	}
 

--- a/cmd/gardener/gardener_test.go
+++ b/cmd/gardener/gardener_test.go
@@ -74,9 +74,10 @@ func TestManagerMode(t *testing.T) {
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 
 	vars := map[string]string{
-		"SERVICE_MODE": "manager",
-		"PROJECT":      "mlab-testing",
-		"STATUS_PORT":  ":0",
+		"SERVICE_MODE":  "manager",
+		"PROJECT":       "mlab-testing",
+		"STATUS_PORT":   ":0",
+		"GARDENER_ADDR": ":8888", // any number other than default.
 	}
 	for k, v := range vars {
 		cleanup := osx.MustSetenv(k, v)
@@ -85,7 +86,7 @@ func TestManagerMode(t *testing.T) {
 
 	go func(t *testing.T) {
 		defer mainCancel()
-		resp, err := waitFor("http://localhost:8080/ready")
+		resp, err := waitFor("http://localhost:8888/ready")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This change adds a new flag to the gardener binary to specify the gardener server's `-gardener_addr`.

With local saver support, gardener should be able to support local development mode with a parser in local development mode simultaneously. However, before this change, the gardener server addr was statically defined as ":8080", which conflicted with the default for the parser's server port and flag conventions. This change makes the value configurable.

Default behavior remains unchanged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/371)
<!-- Reviewable:end -->
