### PR TITLE
Cleanup: Replace ad-hoc env lookups with explicit flags and parameters

### DIFF
--- a/k8s/data-processing/deployments/etl-gardener-universal.yml
+++ b/k8s/data-processing/deployments/etl-gardener-universal.yml
@@ -37,23 +37,16 @@ spec:
       - image: gcr.io/{{GCLOUD_PROJECT}}/etl-gardener:{{GIT_COMMIT}}
         name: etl-gardener
         args: [
-          "--prometheusx.listen-address=:9090",
-          "--config_path=/etc/config.yml",
+          "-prometheusx.listen-address=:9090",
+          "-config_path=/etc/config.yml",
           "-saver.backend=local",
-          "-saver.dir=/singleton"
+          "-saver.dir=/singleton",
+          "-service.mode=manager",
+          "-status_port=:8081",
+          "-project={{GCLOUD_PROJECT}}",
+          "-shutdown_timeout=5m",
+          "-job_expiration_time=6h",
         ]
-        env:
-        - name: SERVICE_MODE # Whether to use task-queues or run as manager.
-          value: "manager"
-        - name: PROJECT
-          value: "{{GCLOUD_PROJECT}}"
-        - name: STATUS_PORT
-          value: ":8081"
-        - name: JOB_EXPIRATION_TIME
-          value: "6h"
-        - name: SHUTDOWN_TIMEOUT
-          value: "5m"
-
         ports:
         - name: prometheus-port
           containerPort: 9090

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -57,8 +56,13 @@ func newJoinConditionFunc(tk *tracker.Tracker, detail string) ConditionFunc {
 	}
 }
 
+type actionEnv struct {
+	project string
+}
+
 // NewStandardMonitor creates the standard monitor that handles several state transitions.
-func NewStandardMonitor(ctx context.Context, config cloud.BQConfig, tk *tracker.Tracker) (*Monitor, error) {
+func NewStandardMonitor(ctx context.Context, project string, config cloud.BQConfig, tk *tracker.Tracker) (*Monitor, error) {
+	a := actionEnv{project: project}
 	m, err := NewMonitor(ctx, config, tk)
 	if err != nil {
 		return nil, err
@@ -69,23 +73,23 @@ func NewStandardMonitor(ctx context.Context, config cloud.BQConfig, tk *tracker.
 		tracker.Loading)
 	m.AddAction(tracker.Loading,
 		nil,
-		loadFunc,
+		a.loadFunc,
 		tracker.Deduplicating)
 	m.AddAction(tracker.Deduplicating,
 		nil,
-		dedupFunc,
+		a.dedupFunc,
 		tracker.Copying)
 	m.AddAction(tracker.Copying,
 		nil,
-		copyFunc,
+		a.copyFunc,
 		tracker.Deleting)
 	m.AddAction(tracker.Deleting,
 		nil,
-		deleteFunc,
+		a.deleteFunc,
 		tracker.Joining)
 	m.AddAction(tracker.Joining,
 		newJoinConditionFunc(tk, "Join condition"),
-		joinFunc,
+		a.joinFunc,
 		tracker.Complete)
 	return m, nil
 }
@@ -138,13 +142,11 @@ func waitAndCheck(ctx context.Context, bqJob bqiface.Job, j tracker.Job, label s
 // TODO - would be nice to persist this object, instead of creating it
 // repeatedly.  If we end up with separate state machine per job, that
 // would be a good place for the TableOps object.
-func tableOps(ctx context.Context, j tracker.Job) (*bq.TableOps, error) {
+func (a *actionEnv) tableOps(ctx context.Context, j tracker.Job) (*bq.TableOps, error) {
 	// TODO pass in the JobWithTarget, and get this info from Target.
-	project := os.Getenv("PROJECT")
 	loadSource := fmt.Sprintf("gs://etl-%s/%s/%s/%s",
-		project,
-		j.Experiment, j.Datatype, j.Date.Format("2006/01/02/*"))
-	return bq.NewTableOps(ctx, j, project, loadSource)
+		a.project, j.Experiment, j.Datatype, j.Date.Format("2006/01/02/*"))
+	return bq.NewTableOps(ctx, j, a.project, loadSource)
 }
 
 func interpretStatus(op string, j tracker.Job, status *bigquery.JobStatus, delay time.Duration) string {
@@ -170,12 +172,12 @@ func interpretStatus(op string, j tracker.Job, status *bigquery.JobStatus, delay
 }
 
 // TODO improve test coverage?
-func dedupFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Outcome {
+func (a *actionEnv) dedupFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Outcome {
 	// This is the delay since entering the dedup state, due to monitor delay
 	// and retries.
 	delay := time.Since(stateChangeTime).Round(time.Minute)
 
-	qp, err := tableOps(ctx, j)
+	qp, err := a.tableOps(ctx, j)
 	if err != nil {
 		log.Println(j, err)
 		// This terminates this job.
@@ -264,12 +266,12 @@ func waitForLoad(ctx context.Context, bqJob bqiface.Job, j tracker.Job, label st
 }
 
 // TODO improve test coverage?
-func loadFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Outcome {
+func (a *actionEnv) loadFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Outcome {
 	// This is the delay since entering the dedup state, due to monitor delay
 	// and retries.
 	delay := time.Since(stateChangeTime).Round(time.Minute)
 
-	qp, err := tableOps(ctx, j)
+	qp, err := a.tableOps(ctx, j)
 	if err != nil {
 		log.Println(j, err)
 		// This terminates this job.
@@ -312,12 +314,12 @@ func loadFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Ou
 }
 
 // TODO improve test coverage?
-func copyFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Outcome {
+func (a *actionEnv) copyFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Outcome {
 	// This is the delay since entering the dedup state, due to monitor delay
 	// and retries.
 	delay := time.Since(stateChangeTime).Round(time.Minute)
 
-	qp, err := tableOps(ctx, j)
+	qp, err := a.tableOps(ctx, j)
 	if err != nil {
 		log.Println(j, err)
 		// This terminates this job.
@@ -349,8 +351,8 @@ func copyFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Ou
 }
 
 // TODO improve test coverage?
-func deleteFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Outcome {
-	qp, err := tableOps(ctx, j)
+func (a *actionEnv) deleteFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Outcome {
+	qp, err := a.tableOps(ctx, j)
 	if err != nil {
 		log.Println(j, err)
 		// This terminates this job.
@@ -367,13 +369,13 @@ func deleteFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *
 	return Success(j, "Successfully deleted partition")
 }
 
-func joinFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Outcome {
+func (a *actionEnv) joinFunc(ctx context.Context, j tracker.Job, stateChangeTime time.Time) *Outcome {
 	if !JoinableDatatypes[j.Datatype] {
 		// These should not be annotated.
 		return Success(j, fmt.Sprintf("%s does not require join", j.Datatype))
 	}
 	delay := time.Since(stateChangeTime).Round(time.Minute)
-	to, err := tableOps(ctx, j)
+	to, err := a.tableOps(ctx, j)
 	if err != nil {
 		log.Println(j, err)
 		// This terminates this job.

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/m-lab/etl-gardener/ops"
 	"github.com/m-lab/etl-gardener/tracker"
 	"github.com/m-lab/go/logx"
-	"github.com/m-lab/go/osx"
 	"github.com/m-lab/go/rtx"
 )
 
@@ -23,8 +22,6 @@ func TestStandardMonitor(t *testing.T) {
 		t.Skip("Skipping test that uses BQ backend")
 	}
 	logx.LogxDebug.Set("true")
-	cleanup := osx.MustSetenv("PROJECT", "mlab-testing")
-	defer cleanup()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	saver := tracker.NewLocalSaver(t.TempDir(), nil)
@@ -40,7 +37,7 @@ func TestStandardMonitor(t *testing.T) {
 		tk.AddJob(tracker.NewJob("bucket", "ndt", datatype, time.Now()))
 	}
 
-	m, err := ops.NewStandardMonitor(context.Background(), cloud.BQConfig{}, tk)
+	m, err := ops.NewStandardMonitor(context.Background(), "mlab-testing", cloud.BQConfig{}, tk)
 	rtx.Must(err, "NewMonitor failure")
 	// We override some actions in place of the default Parser activity.
 	// The resulting sequence should be:

--- a/ops/export_test.go
+++ b/ops/export_test.go
@@ -1,4 +1,1 @@
 package ops
-
-var NewJoinConditionFunc = newJoinConditionFunc
-var JoinFunc = joinFunc


### PR DESCRIPTION
This change is a cleanup of v2 gardener to consistently use flags to provide configuration information. Previously, gardener used a mixture of flags and environment variables for configuration of the service and the `ops` package.

This change replaces all v2 environmental dependencies with explicit flags or function parameters. Now, any value used by the v2 system is provided by a command line flag. Because gardener uses `flagx.ArgsFromEnv` any flag value can also be specified using the environment.

This change does not change default behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/372)
<!-- Reviewable:end -->
