### PR TITLE
Eliminate Job as map key

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -25,9 +25,9 @@ type fakeGardener struct {
 }
 
 func (g *fakeGardener) AddJob(job tracker.Job, target string) error {
-	jt, err := job.Target(target)
-	if err != nil {
-		return err
+	jt := tracker.JobWithTarget{
+		ID:  job.Key(),
+		Job: job,
 	}
 	g.jobs = append(g.jobs, jt)
 	return nil
@@ -39,7 +39,7 @@ func (g *fakeGardener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Fatal("Should be POST") // Not t.Fatal because this is asynchronous.
 	}
 	g.lock.Lock()
-	g.lock.Unlock()
+	defer g.lock.Unlock()
 	switch r.URL.Path {
 	case "/job":
 		if len(g.jobs) < 1 {

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -160,6 +160,7 @@ func (svc *Service) NextJob(ctx context.Context) tracker.JobWithTarget {
 
 	job := svc.jobSpecs[svc.nextIndex]
 	job.Date = svc.Date
+	job.ID = job.Job.Key()
 	svc.nextIndex++
 
 	if svc.nextIndex >= len(svc.jobSpecs) {
@@ -240,10 +241,9 @@ func NewJobService(ctx context.Context, tk jobAdder, startDate time.Time,
 			Date:       time.Time{}, // This is not used.
 		}
 		// TODO - handle gs:// targets
-		jt, err := job.Target(targetBase + "." + s.Target)
-		if err != nil {
-			log.Println(err, targetBase+s.Target)
-			continue
+		jt := tracker.JobWithTarget{
+			ID:  job.Key(),
+			Job: job,
 		}
 		specs = append(specs, jt)
 	}

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -298,9 +298,9 @@ func TestEarlyWrapping(t *testing.T) {
 		tk.AddJob(got.Job)
 		if k == 2 {
 			// Simulate "monitor" behavior and mark job complete to prevent AddJob error.
-			status, _ := tk.GetStatus(got.Job)
+			status, _ := tk.GetStatus(got.Job.Key())
 			status.NewState(tracker.Complete)
-			err := tk.UpdateJob(got.Job, status)
+			err := tk.UpdateJob(got.Job.Key(), status)
 			if err != nil {
 				t.Error(err)
 			}

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -44,7 +44,7 @@ func newJoinConditionFunc(tk *tracker.Tracker, detail string) ConditionFunc {
 		// (Technically, we only need to know whether the copy has completed.)
 		ann := j
 		ann.Datatype = "annotation"
-		status, err := tk.GetStatus(ann)
+		status, err := tk.GetStatus(ann.Key())
 		if err != nil {
 			// For early dates, there is no annotation job, so if the job
 			// is absent, we proceed with the join.

--- a/ops/ops.go
+++ b/ops/ops.go
@@ -147,17 +147,17 @@ func (m *Monitor) UpdateJob(o *Outcome, state tracker.State) (string, error) {
 
 	switch {
 	case o.IsDone():
-		if err := m.tk.SetStatus(o.job, state, detail); err != nil {
+		if err := m.tk.SetStatus(o.job.Key(), state, detail); err != nil {
 			return "set status error", err
 		}
 		return "done", nil
 	case o.ShouldRetry():
-		if err := m.tk.SetDetail(o.job, detail); err != nil {
+		if err := m.tk.SetDetail(o.job.Key(), detail); err != nil {
 			return "set status error", err
 		}
 		return "retry", nil
 	default:
-		if err := m.tk.SetJobError(o.job, detail); err != nil {
+		if err := m.tk.SetJobError(o.job.Key(), detail); err != nil {
 			return "set status error", err
 		}
 		return "fail", nil

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -91,7 +91,7 @@ func TestOutcomeUpdate(t *testing.T) {
 	retry := ops.Retry(job, errors.New("error"), "foobar")
 	m.UpdateJob(retry, tracker.Joining)
 
-	status, err := tk.GetStatus(job)
+	status, err := tk.GetStatus(job.Key())
 	must(t, err)
 	if status.Detail() != "foobar" {
 		t.Error(status.Detail())

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -88,7 +88,8 @@ func (h *Handler) heartbeat(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
 		return
 	}
-	if err := h.tracker.Heartbeat(job); err != nil {
+	// TODO(soltesz): update client to send "key" instead of job.
+	if err := h.tracker.Heartbeat(job.Key()); err != nil {
 		logx.Debug.Printf("%v %+v\n", err, job)
 		resp.WriteHeader(http.StatusGone)
 		return
@@ -117,7 +118,8 @@ func (h *Handler) update(resp http.ResponseWriter, req *http.Request) {
 	}
 	detail := req.Form.Get("detail")
 
-	if err := h.tracker.SetStatus(job, State(state), detail); err != nil {
+	// TODO(soltesz): update client to send "key" instead of job.
+	if err := h.tracker.SetStatus(job.Key(), State(state), detail); err != nil {
 		log.Printf("Not found %+v\n", job)
 		resp.WriteHeader(http.StatusGone)
 		return
@@ -144,7 +146,8 @@ func (h *Handler) errorFunc(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusFailedDependency)
 		return
 	}
-	if err := h.tracker.SetStatus(job, ParseError, jobErr); err != nil {
+	// TODO(soltesz): update client to send "key" instead of job.
+	if err := h.tracker.SetStatus(job.Key(), ParseError, jobErr); err != nil {
 		resp.WriteHeader(http.StatusGone)
 		return
 	}

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -31,6 +31,7 @@ func UpdateURL(base url.URL, job Job, state State, detail string) *url.URL {
 }
 
 // HeartbeatURL makes an update request URL.
+// TODO(soltesz): move client functions to client package.
 func HeartbeatURL(base url.URL, job Job) *url.URL {
 	base.Path += "heartbeat"
 	params := make(url.Values, 3)
@@ -41,6 +42,7 @@ func HeartbeatURL(base url.URL, job Job) *url.URL {
 }
 
 // ErrorURL makes an update request URL.
+// TODO(soltesz): move client functions to client package.
 func ErrorURL(base url.URL, job Job, errString string) *url.URL {
 	base.Path += "error"
 	params := make(url.Values, 3)
@@ -84,12 +86,12 @@ func (h *Handler) heartbeat(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	// TODO(soltesz): update client to send "id" instead of job.
 	job, err := getJob(req.Form.Get("job"))
 	if err != nil {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
 		return
 	}
-	// TODO(soltesz): update client to send "id" instead of job.
 	if err := h.tracker.Heartbeat(job.Key()); err != nil {
 		logx.Debug.Printf("%v %+v\n", err, job)
 		resp.WriteHeader(http.StatusGone)
@@ -107,6 +109,7 @@ func (h *Handler) update(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	// TODO(soltesz): update client to send "id" instead of job.
 	job, err := getJob(req.Form.Get("job"))
 	if err != nil {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
@@ -119,7 +122,6 @@ func (h *Handler) update(resp http.ResponseWriter, req *http.Request) {
 	}
 	detail := req.Form.Get("detail")
 
-	// TODO(soltesz): update client to send "id" instead of job.
 	if err := h.tracker.SetStatus(job.Key(), State(state), detail); err != nil {
 		log.Printf("Not found %+v\n", job)
 		resp.WriteHeader(http.StatusGone)
@@ -138,6 +140,7 @@ func (h *Handler) errorFunc(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 	jobErr := req.Form.Get("error")
+	// TODO(soltesz): update client to send "id" instead of job.
 	job, err := getJob(req.Form.Get("job"))
 	if err != nil {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
@@ -147,7 +150,6 @@ func (h *Handler) errorFunc(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusFailedDependency)
 		return
 	}
-	// TODO(soltesz): update client to send "id" instead of job.
 	if err := h.tracker.SetStatus(job.Key(), ParseError, jobErr); err != nil {
 		resp.WriteHeader(http.StatusGone)
 		return

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -18,6 +18,7 @@ var (
 )
 
 // UpdateURL makes an update request URL.
+// TODO(soltesz): move client functions to client package.
 func UpdateURL(base url.URL, job Job, state State, detail string) *url.URL {
 	base.Path += "update"
 	params := make(url.Values, 3)
@@ -88,7 +89,7 @@ func (h *Handler) heartbeat(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
 		return
 	}
-	// TODO(soltesz): update client to send "key" instead of job.
+	// TODO(soltesz): update client to send "id" instead of job.
 	if err := h.tracker.Heartbeat(job.Key()); err != nil {
 		logx.Debug.Printf("%v %+v\n", err, job)
 		resp.WriteHeader(http.StatusGone)
@@ -118,7 +119,7 @@ func (h *Handler) update(resp http.ResponseWriter, req *http.Request) {
 	}
 	detail := req.Form.Get("detail")
 
-	// TODO(soltesz): update client to send "key" instead of job.
+	// TODO(soltesz): update client to send "id" instead of job.
 	if err := h.tracker.SetStatus(job.Key(), State(state), detail); err != nil {
 		log.Printf("Not found %+v\n", job)
 		resp.WriteHeader(http.StatusGone)
@@ -146,7 +147,7 @@ func (h *Handler) errorFunc(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusFailedDependency)
 		return
 	}
-	// TODO(soltesz): update client to send "key" instead of job.
+	// TODO(soltesz): update client to send "id" instead of job.
 	if err := h.tracker.SetStatus(job.Key(), ParseError, jobErr); err != nil {
 		resp.WriteHeader(http.StatusGone)
 		return

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -99,7 +99,7 @@ func TestUpdateHandler(t *testing.T) {
 
 	// should update state to Parsing
 	postAndExpect(t, url, http.StatusOK)
-	stat, err := tk.GetStatus(job)
+	stat, err := tk.GetStatus(job.Key())
 	must(t, err)
 	if stat.State() != tracker.Parsing {
 		t.Fatal("update failed", stat)
@@ -108,7 +108,7 @@ func TestUpdateHandler(t *testing.T) {
 	url = tracker.UpdateURL(server, job, tracker.Complete, "")
 	postAndExpect(t, url, http.StatusOK)
 
-	_, err = tk.GetStatus(job)
+	_, err = tk.GetStatus(job.Key())
 	if err != tracker.ErrJobNotFound {
 		t.Fatal("Expected JobNotFound", err)
 	}
@@ -131,7 +131,7 @@ func TestHeartbeatHandler(t *testing.T) {
 
 	// should update state to Parsing
 	postAndExpect(t, url, http.StatusOK)
-	stat, err := tk.GetStatus(job)
+	stat, err := tk.GetStatus(job.Key())
 	must(t, err)
 	if time.Since(stat.HeartbeatTime) > 1*time.Second {
 		t.Fatal("heartbeat failed", stat)
@@ -141,7 +141,7 @@ func TestHeartbeatHandler(t *testing.T) {
 	url = tracker.UpdateURL(server, job, tracker.Complete, "")
 	postAndExpect(t, url, http.StatusOK)
 
-	_, err = tk.GetStatus(job)
+	_, err = tk.GetStatus(job.Key())
 	if err != tracker.ErrJobNotFound {
 		t.Fatal("Expected JobNotFound", err)
 	}
@@ -163,7 +163,7 @@ func TestErrorHandler(t *testing.T) {
 
 	// should successfully update state to Failed
 	postAndExpect(t, url, http.StatusOK)
-	stat, err := tk.GetStatus(job)
+	stat, err := tk.GetStatus(job.Key())
 	must(t, err)
 	if stat.Detail() != "error" {
 		t.Error("Expected error:", stat.Detail())
@@ -175,7 +175,7 @@ func TestErrorHandler(t *testing.T) {
 	url = tracker.UpdateURL(server, job, tracker.Complete, "")
 	postAndExpect(t, url, http.StatusOK)
 
-	_, err = tk.GetStatus(job)
+	_, err = tk.GetStatus(job.Key())
 	if err != tracker.ErrJobNotFound {
 		t.Fatal("Expected JobNotFound", err)
 	}

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -19,7 +19,6 @@ import (
 	"github.com/googleapis/google-cloud-go-testing/datastore/dsiface"
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 
-	"github.com/m-lab/go/cloud/bqx"
 	"github.com/m-lab/go/cloud/gcs"
 
 	"github.com/m-lab/etl-gardener/metrics"
@@ -40,11 +39,9 @@ type Job struct {
 // JobWithTarget specifies a type/date job, and a destination
 // table or GCS prefix
 type JobWithTarget struct {
+	ID Key // ID used by gardener & parsers to identify a Job's status and configuration.
 	Job
-	// One of these two fields indicates the destination,
-	// either a BigQuery table, or a GCS bucket/prefix string.
-	TargetTable           bqx.PDT `json:",omitempty"`
-	TargetBucketAndPrefix string  `json:",omitempty"` // gs://bucket/prefix
+	// TODO: enable configuration for parser to target alterate buckets.
 }
 
 func (j JobWithTarget) String() string {
@@ -55,7 +52,8 @@ func (j JobWithTarget) String() string {
 // DEPRECATED
 // NB:  The date will be converted to UTC and truncated to day boundary!
 func NewJob(bucket, exp, typ string, date time.Time) Job {
-	return Job{Bucket: bucket,
+	return Job{
+		Bucket:     bucket,
 		Experiment: exp,
 		Datatype:   typ,
 		Date:       date.UTC().Truncate(24 * time.Hour),
@@ -84,18 +82,6 @@ func (j Job) failureMetric(state State, errString string) {
 		metrics.FailCount.WithLabelValues(j.Experiment, j.Datatype, "generic").Inc()
 		metrics.JobsTotal.WithLabelValues(j.Experiment, j.Datatype, j.IsDaily(), "generic").Inc()
 	}
-}
-
-// Target adds a Target to the job, returning a JobWithTarget
-func (j Job) Target(target string) (JobWithTarget, error) {
-	if strings.HasPrefix(target, "gs://") {
-		return JobWithTarget{Job: j, TargetBucketAndPrefix: target}, nil
-	}
-	pdt, err := bqx.ParsePDT(target)
-	if err != nil {
-		return JobWithTarget{}, err
-	}
-	return JobWithTarget{Job: j, TargetTable: pdt}, nil
 }
 
 // Path returns the GCS path prefix to the job data.

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -162,6 +162,10 @@ func (j Job) IsDaily() string {
 	return strconv.FormatBool(isDaily)
 }
 
+func (j Job) Key() Key {
+	return Key(fmt.Sprintf("%s/%s/%s/%s", j.Bucket, j.Experiment, j.Datatype, j.Date.Format("20060102")))
+}
+
 // YesterdayDate returns the date for the daily job (e.g, yesterday UTC).
 func YesterdayDate() time.Time {
 	return time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -1)

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -149,6 +149,7 @@ func (j Job) IsDaily() string {
 }
 
 func (j Job) Key() Key {
+	// TODO(soltesz): include target dataset in key to allow different experiment/datatype combinations without conflict.
 	return Key(fmt.Sprintf("%s/%s/%s/%s", j.Bucket, j.Experiment, j.Datatype, j.Date.Format("20060102")))
 }
 

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -148,6 +148,7 @@ func (j Job) IsDaily() string {
 	return strconv.FormatBool(isDaily)
 }
 
+// Key returns a Job unique identifier (within the set of all jobs), suitable for use as a map key.
 func (j Job) Key() Key {
 	// TODO(soltesz): include target dataset in key to allow different experiment/datatype combinations without conflict.
 	return Key(fmt.Sprintf("%s/%s/%s/%s", j.Bucket, j.Experiment, j.Datatype, j.Date.Format("20060102")))

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -30,25 +30,25 @@ import (
 )
 
 type Key string
-type JobStatusMap map[Key]Status
-type JobStateMap map[Key]Job
+
+// jobStatusMap and jobStateMap are used within the tracker to map Job Keys to a
+// Job or Job Status.
+type jobStatusMap map[Key]Status
+type jobStateMap map[Key]Job
 
 // Tracker keeps track of all the jobs in flight.
 // Only tracker functions should access any of the fields.
 type Tracker struct {
-	// client dsiface.Client
-	// dsKey  *datastore.Key
 	saver Saver
 
-	// The lock should be held whenever accessing the jobs JobMap
+	// The lock should be held whenever accessing the jobs maps.
 	lock         sync.Mutex
 	lastModified time.Time
 
 	// These are the stored values.
 	lastJob   Job          // The last job that was added/initialized.
-	jobs      JobMap       // Map from Job to Status.
-	jobStatus JobStatusMap // Map from Job to Status.
-	jobState  JobStateMap  // Map from Job to Status.
+	jobStatus jobStatusMap // Map from Job to Status.
+	jobState  jobStateMap  // Map from Job to Status.
 
 	// Time after which stale job should be ignored or replaced.
 	expirationTime time.Duration
@@ -160,8 +160,8 @@ func InitTracker(
 	}
 
 	// Load the jobStatus and jobState from the loaded jobMap.
-	jobStatus := make(JobStatusMap, 100)
-	jobState := make(JobStateMap, 100)
+	jobStatus := make(jobStatusMap, 100)
+	jobState := make(jobStateMap, 100)
 	for j, s := range jobMap {
 		jobStatus[j.Key()] = s
 		jobState[j.Key()] = j

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m-lab/go/logx"
 )
 
+// Key is a unique identifier for a single tracker Job. Key may be used as a map key.
 type Key string
 
 // jobStatusMap and jobStateMap are used within the tracker to map Job Keys to a

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -158,8 +158,8 @@ func InitTracker(
 			metrics.TasksInFlight.WithLabelValues(j.Experiment, j.Datatype, s.Label()).Inc()
 		}
 	}
-	// Map from Job to Status.
 
+	// Load the jobStatus and jobState from the loaded jobMap.
 	jobStatus := make(JobStatusMap, 100)
 	jobState := make(JobStateMap, 100)
 	for j, s := range jobMap {
@@ -392,6 +392,7 @@ func (tr *Tracker) SetJobError(key Key, errString string) error {
 func (tr *Tracker) GetState() (JobMap, Job, time.Time) {
 	tr.lock.Lock()
 	defer tr.lock.Unlock()
+	// Construct a JobMap from the jobState and jobStatus maps.
 	m := make(JobMap)
 	for k, j := range tr.jobState {
 		s := tr.jobStatus[k]

--- a/tracker/tracker_race_test.go
+++ b/tracker/tracker_race_test.go
@@ -52,12 +52,12 @@ func TestConcurrentUpdates(t *testing.T) {
 				Date:       startDate.Add(time.Duration(24*rand.Intn(jobs)) * time.Hour),
 			}
 			if i%5 == 0 {
-				err := tk.SetStatus(k, tracker.State(fmt.Sprintf("State:%d", i)), "")
+				err := tk.SetStatus(k.Key(), tracker.State(fmt.Sprintf("State:%d", i)), "")
 				if err != nil {
 					log.Fatal(err, " ", k)
 				}
 			} else {
-				err := tk.Heartbeat(k)
+				err := tk.Heartbeat(k.Key())
 				if err != nil {
 					log.Fatal(err, " ", k)
 				}


### PR DESCRIPTION
This change updates the gardener tracker interface in a way that preserves external compatibility with the JobsAPI and the Saver output format. This change eliminates the use of the `Job` type as a go map key throughout the tracker package. Now the tracker maintains two private maps (`jobStatus` and `jobState`) which use a new `Key` type as the map key. Also, the tracker methods now accept `Key` parameters. This change will enable additional configuration information to be placed in the Job or JobWithTarget object without breaking compatibility with the parser.

With the gardener tracker no longer using the Job as key, next we can:
* Add `/v2/job/*` resources and client functions to operate on Job `Key`s (instead of the complete serialized Job)
* Update the ETL parser to use this new client library (removing the parser's dependency on complete serialized Job types)
* Complete https://github.com/m-lab/etl-gardener/pull/352
* Complete https://github.com/m-lab/etl-gardener/pull/350

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/375)
<!-- Reviewable:end -->
