### PR TITLE
Add tcpinfo v2 gardener config

### DIFF
--- a/cloud/bq/ops.go
+++ b/cloud/bq/ops.go
@@ -56,6 +56,8 @@ func NewTableOpsWithClient(client bqiface.Client, job tracker.Job, project strin
 		fallthrough
 	case "scamper1":
 		fallthrough
+	case "tcpinfo":
+		fallthrough
 	case "ndt5":
 		fallthrough
 	case "ndt7":

--- a/cloud/bq/ops_test.go
+++ b/cloud/bq/ops_test.go
@@ -38,7 +38,7 @@ func TestValidateQueries(t *testing.T) {
 		t.Log("Skipping test for --short")
 	}
 	ctx := context.Background()
-	dataTypes := []string{"annotation", "ndt7", "pcap", "hopannotation1", "scamper1"}
+	dataTypes := []string{"annotation", "ndt7", "pcap", "hopannotation1", "scamper1", "tcpinfo"}
 	// TODO Add "preserve" query
 	// Test for each datatype
 	for _, dataType := range dataTypes {

--- a/config/config.yml
+++ b/config/config.yml
@@ -34,7 +34,7 @@ sources:
   experiment: utilization
   datatype: switch
   target: tmp_utilization.switch
-#- bucket: archive-measurement-lab
-#  experiment: ndt
-#  datatype: tcpinfo
-#  target: tmp_ndt.tcpinfo
+- bucket: archive-{{NDT_SOURCE_PROJECT}}
+  experiment: ndt
+  datatype: tcpinfo
+  target: tmp_ndt.tcpinfo

--- a/ops/actions.go
+++ b/ops/actions.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	JoinableDatatypes = map[string]bool{"ndt7": true, "scamper1": true, "ndt5": true}
+	JoinableDatatypes = map[string]bool{"ndt7": true, "scamper1": true, "ndt5": true, "tcpinfo": true}
 )
 
 func newStateFunc(detail string) ActionFunc {

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -29,10 +29,9 @@ func TestStandardMonitor(t *testing.T) {
 	rtx.Must(err, "tk init")
 	// Not supported.
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now()))
 	// Valid experiment and datatype
 	// This does an actual dedup, so we need to allow enough time.
-	datatypes := []string{"ndt7", "annotation", "pcap", "hopannotation1", "scamper1"}
+	datatypes := []string{"ndt7", "annotation", "pcap", "hopannotation1", "scamper1", "tcpinfo"}
 	for _, datatype := range datatypes {
 		tk.AddJob(tracker.NewJob("bucket", "ndt", datatype, time.Now()))
 	}
@@ -70,15 +69,15 @@ func TestStandardMonitor(t *testing.T) {
 	// "Joining" state.
 	failTime := time.Now().Add(300 * time.Second)
 
-	for time.Now().Before(failTime) && (tk.NumJobs() > 2 || tk.NumFailed() < 1) {
+	for time.Now().Before(failTime) && (tk.NumJobs() > 1 || tk.NumFailed() < 1) {
 		time.Sleep(time.Millisecond)
 	}
-	if tk.NumFailed() != 2 {
-		t.Error("Expected NumFailed = 2:", tk.NumFailed())
+	if tk.NumFailed() != 1 {
+		t.Error("Expected NumFailed = 1:", tk.NumFailed())
 	}
 	// We expect only the two failed jobs; ignore jobs in the final (joining) state.
 	count := tk.NumJobs()
-	if count > 2 {
+	if count > 1 {
 		jobs, _, _ := tk.GetState()
 		for j, s := range jobs {
 			a := m.GetAction(s.LastStateInfo().State)
@@ -96,8 +95,8 @@ func TestStandardMonitor(t *testing.T) {
 		fmt.Println()
 	}
 	// If there are still more than two failed jobs remaining, report an error.
-	if count != 2 {
-		t.Error("Expected NumJobs = 2:", tk.NumJobs())
+	if count != 1 {
+		t.Error("Expected NumJobs = 1:", tk.NumJobs())
 	}
 	cancel()
 }

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -27,9 +27,9 @@ func TestStandardMonitor(t *testing.T) {
 	saver := tracker.NewLocalSaver(t.TempDir(), nil)
 	tk, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	rtx.Must(err, "tk init")
+	// Not supported.
 	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
-	// Not yet supported.
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "tcpinfo", time.Now()))
+	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now()))
 	// Valid experiment and datatype
 	// This does an actual dedup, so we need to allow enough time.
 	datatypes := []string{"ndt7", "annotation", "pcap", "hopannotation1", "scamper1"}


### PR DESCRIPTION
This change updates the gardener config to enable tcpinfo parsing. This change complements the update to the v2 parser 
in https://github.com/m-lab/etl/pull/1067

Part of:
* https://github.com/m-lab/etl/issues/1066

Testing:
* unit testing, local development mode w/ local output, and by sandbox deployment (with sandbox gardener configs, to verify processing) See: `mlab-sandbox.ndt.tcpinfo`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/377)
<!-- Reviewable:end -->
