### PR TITLE
Add v2 Jobs API

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -66,7 +66,7 @@ func NextJob(ctx context.Context, base url.URL) (tracker.JobWithTarget, error) {
 	decoder := json.NewDecoder(bytes.NewReader(b))
 	decoder.DisallowUnknownFields()
 
-	err = decoder.Decode(&job)
+	err = decoder.Decode(&job.Job)
 	if err != nil {
 		// TODO add metric, but in the correct namespace???
 		// When this happens, it is likely to be very spammy.
@@ -74,7 +74,7 @@ func NextJob(ctx context.Context, base url.URL) (tracker.JobWithTarget, error) {
 
 		// Try again but ignore unknown fields.
 		decoder = json.NewDecoder(bytes.NewReader(b))
-		err = decoder.Decode(&job)
+		err = decoder.Decode(&job.Job)
 		if err != nil {
 			// This is a more serious error.
 			log.Println(err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -48,7 +48,7 @@ func (g *fakeGardener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		j := g.jobs[0]
 		g.jobs = g.jobs[1:]
-		w.Write(j.Marshal())
+		w.Write(j.Job.Marshal())
 	case "/heartbeat":
 		g.t.Log(r.URL.Path, r.URL.Query())
 		g.heartbeats++
@@ -78,8 +78,8 @@ func TestJobClient(t *testing.T) {
 	j, err := client.NextJob(ctx, *gURL)
 	rtx.Must(err, "next job")
 
-	if j.Path() != "gs://foobar/ndt/ndt5/2019/01/01/" {
-		t.Error(j.Path())
+	if j.Job.Path() != "gs://foobar/ndt/ndt5/2019/01/01/" {
+		t.Error(j.Job.Path())
 	}
 
 	j, err = client.NextJob(ctx, *gURL)

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -49,7 +49,7 @@ func (y *YesterdaySource) nextJob(ctx context.Context) *tracker.JobWithTarget {
 
 	// Copy the jobspec and set the date.
 	job := y.jobSpecs[y.nextIndex]
-	job.Date = y.Date
+	job.Job.Date = y.Date
 
 	// Advance to the next jobSpec for next call.
 	y.nextIndex++
@@ -159,7 +159,7 @@ func (svc *Service) NextJob(ctx context.Context) tracker.JobWithTarget {
 	}
 
 	job := svc.jobSpecs[svc.nextIndex]
-	job.Date = svc.Date
+	job.Job.Date = svc.Date
 	job.ID = job.Job.Key()
 	svc.nextIndex++
 
@@ -184,7 +184,7 @@ func (svc *Service) ifHasFiles(ctx context.Context, job tracker.JobWithTarget) t
 			log.Println(err)
 		}
 		if !ok {
-			log.Println(job, "has no files", job.Bucket)
+			log.Println(job, "has no files", job.Job.Bucket)
 			return tracker.JobWithTarget{}
 		}
 	}

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 // Package job provides an http handler to serve up jobs to ETL parsers.
@@ -130,7 +131,7 @@ func TestResume(t *testing.T) {
 	svc, err := job.NewJobService(ctx, tk, start, "fake-bucket", sources, &NullSaver{}, nil)
 	must(t, err)
 	j := svc.NextJob(ctx)
-	if j.Date != last.Date {
+	if j.Job.Date != last.Date {
 		t.Error(j, last)
 	}
 }
@@ -194,7 +195,7 @@ func TestResumeFromSaver(t *testing.T) {
 	must(t, err)
 	// NextJob should return a job with date provided by FakeSaver.
 	j := svc.NextJob(ctx)
-	if j.Date != resume {
+	if j.Job.Date != resume {
 		t.Error("Expected ", resume, "got", j)
 	}
 

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -77,6 +77,25 @@ func getJob(jobString string) (Job, error) {
 	return job, err
 }
 
+func getID(req *http.Request) (Key, error) {
+	// Prefer the /v2 "id" parameter.
+	id := req.Form.Get("id")
+	if id != "" {
+		return Key(id), nil
+	}
+
+	// Fallback to the "job" parameter used by the original /job api.
+	j := req.Form.Get("job")
+	if j == "" {
+		return "", errors.New("no job id found")
+	}
+	job, err := getJob(j)
+	if err != nil {
+		return "", err
+	}
+	return job.Key(), nil
+}
+
 func (h *Handler) heartbeat(resp http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		resp.WriteHeader(http.StatusMethodNotAllowed)
@@ -86,14 +105,13 @@ func (h *Handler) heartbeat(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	// TODO(soltesz): update client to send "id" instead of job.
-	job, err := getJob(req.Form.Get("job"))
+	id, err := getID(req)
 	if err != nil {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
 		return
 	}
-	if err := h.tracker.Heartbeat(job.Key()); err != nil {
-		logx.Debug.Printf("%v %+v\n", err, job)
+	if err := h.tracker.Heartbeat(id); err != nil {
+		logx.Debug.Printf("%v %+v\n", err, id)
 		resp.WriteHeader(http.StatusGone)
 		return
 	}
@@ -109,8 +127,7 @@ func (h *Handler) update(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	// TODO(soltesz): update client to send "id" instead of job.
-	job, err := getJob(req.Form.Get("job"))
+	id, err := getID(req)
 	if err != nil {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
 		return
@@ -122,8 +139,8 @@ func (h *Handler) update(resp http.ResponseWriter, req *http.Request) {
 	}
 	detail := req.Form.Get("detail")
 
-	if err := h.tracker.SetStatus(job.Key(), State(state), detail); err != nil {
-		log.Printf("Not found %+v\n", job)
+	if err := h.tracker.SetStatus(id, State(state), detail); err != nil {
+		log.Printf("Not found %+v\n", id)
 		resp.WriteHeader(http.StatusGone)
 		return
 	}
@@ -140,8 +157,7 @@ func (h *Handler) errorFunc(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 	jobErr := req.Form.Get("error")
-	// TODO(soltesz): update client to send "id" instead of job.
-	job, err := getJob(req.Form.Get("job"))
+	id, err := getID(req)
 	if err != nil {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
 		return
@@ -150,7 +166,7 @@ func (h *Handler) errorFunc(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusFailedDependency)
 		return
 	}
-	if err := h.tracker.SetStatus(job.Key(), ParseError, jobErr); err != nil {
+	if err := h.tracker.SetStatus(id, ParseError, jobErr); err != nil {
 		resp.WriteHeader(http.StatusGone)
 		return
 	}
@@ -166,7 +182,7 @@ func (h *Handler) nextJob(resp http.ResponseWriter, req *http.Request) *JobWithT
 	job := h.jobservice.NextJob(req.Context())
 
 	// Check for empty job (no job found with files)
-	if job.Date.Equal(time.Time{}) {
+	if job.Job.Date.Equal(time.Time{}) {
 		log.Println(MsgNoJobFound)
 		resp.WriteHeader(http.StatusInternalServerError)
 		resp.Write([]byte(MsgNoJobFound))
@@ -186,13 +202,13 @@ func (h *Handler) nextJob(resp http.ResponseWriter, req *http.Request) *JobWithT
 // nextJobV1 returns the next JobWithTarget and returns the tracker.Job to the requesting client.
 func (h *Handler) nextJobV1(resp http.ResponseWriter, req *http.Request) {
 	job := h.nextJob(resp, req)
+	if job == nil {
+		return
+	}
 	log.Printf("Dispatching %s\n", job.Job)
-	_, err := resp.Write(job.Marshal())
+	_, err := resp.Write(job.Job.Marshal())
 	if err != nil {
 		log.Println(err)
-		// This should precede the Write(), but the Write failed, so this
-		// is likely ok.
-		resp.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 }
@@ -200,15 +216,15 @@ func (h *Handler) nextJobV1(resp http.ResponseWriter, req *http.Request) {
 // nextJobV2 returns the next JobWithTarget to the requesting client.
 func (h *Handler) nextJobV2(resp http.ResponseWriter, req *http.Request) {
 	job := h.nextJob(resp, req)
+	if job == nil {
+		return
+	}
 	log.Printf("Dispatching %s\n", job.Job)
 	// Marshal complete JobWithTarget object.
 	b, _ := json.Marshal(job)
 	_, err := resp.Write(b)
 	if err != nil {
 		log.Println(err)
-		// This should precede the Write(), but the Write failed, so this
-		// is likely ok.
-		resp.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 }
@@ -219,4 +235,9 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/update", h.update)
 	mux.HandleFunc("/error", h.errorFunc)
 	mux.HandleFunc("/job", h.nextJobV1)
+
+	mux.HandleFunc("/v2/job/heartbeat", h.heartbeat)
+	mux.HandleFunc("/v2/job/update", h.update)
+	mux.HandleFunc("/v2/job/error", h.errorFunc)
+	mux.HandleFunc("/v2/job/next", h.nextJobV2)
 }

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -204,3 +204,27 @@ func TestNextJobHandler(t *testing.T) {
 	// This one should fail because the fakeJobService returns a duplicate job.
 	postAndExpect(t, &url, http.StatusInternalServerError)
 }
+
+func TestNextJobV2Handler(t *testing.T) {
+	date := time.Date(2019, 01, 02, 0, 0, 0, 0, time.UTC)
+	job := tracker.NewJob("bucket", "exp", "type", date)
+	// Add job, empty, and duplicate job.
+	url, _ := testSetup(t, []tracker.Job{job, tracker.Job{}, job})
+	url.Path = "/v2/job/next"
+
+	// Wrong method.
+	getAndExpect(t, &url, http.StatusMethodNotAllowed)
+
+	// This should succeed, because the fakeJobService returns its job.
+	r := postAndExpect(t, &url, http.StatusOK)
+	want := `{"ID":"","Job":{"Bucket":"bucket","Experiment":"exp","Datatype":"type","Date":"2019-01-02T00:00:00Z"}}`
+	if want != r {
+		t.Fatal(r)
+	}
+
+	// This one should fail because the fakeJobService returns empty results.
+	postAndExpect(t, &url, http.StatusInternalServerError)
+
+	// This one should fail because the fakeJobService returns a duplicate job.
+	postAndExpect(t, &url, http.StatusInternalServerError)
+}

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -195,7 +195,7 @@ func TestNextJobHandler(t *testing.T) {
 	r := postAndExpect(t, &url, http.StatusOK)
 	want := `{"Bucket":"bucket","Experiment":"exp","Datatype":"type","Date":"2019-01-02T00:00:00Z"}`
 	if want != r {
-		t.Fatal(r)
+		t.Fatalf("/job returned wrong result: got %q, want %q", r, want)
 	}
 
 	// This one should fail because the fakeJobService returns empty results.
@@ -219,7 +219,7 @@ func TestNextJobV2Handler(t *testing.T) {
 	r := postAndExpect(t, &url, http.StatusOK)
 	want := `{"ID":"","Job":{"Bucket":"bucket","Experiment":"exp","Datatype":"type","Date":"2019-01-02T00:00:00Z"}}`
 	if want != r {
-		t.Fatal(r)
+		t.Fatalf("/v2/job/next returned wrong result: got %q, want %q", r, want)
 	}
 
 	// This one should fail because the fakeJobService returns empty results.

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/m-lab/go/rtx"
+
 	"cloud.google.com/go/datastore"
 	"cloud.google.com/go/storage"
 	"github.com/googleapis/google-cloud-go-testing/datastore/dsiface"
@@ -46,6 +48,13 @@ type JobWithTarget struct {
 
 func (j JobWithTarget) String() string {
 	return fmt.Sprint(j.Job.String(), j.Job.Filter)
+}
+
+func (j JobWithTarget) Marshal() []byte {
+	b, err := json.Marshal(j)
+	// NOTE: marshaling a struct with primitive types should never fail.
+	rtx.PanicOnError(err, "failed to marshal JobWithTarget: %s", j)
+	return b
 }
 
 // NewJob creates a new job object.
@@ -96,7 +105,8 @@ func (j Job) Path() string {
 
 // Marshal marshals the job to json.
 func (j Job) Marshal() []byte {
-	b, _ := json.Marshal(j)
+	b, err := json.Marshal(j)
+	rtx.PanicOnError(err, "failed to marshal Job: %s", j)
 	return b
 }
 

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -39,13 +39,13 @@ type Job struct {
 // JobWithTarget specifies a type/date job, and a destination
 // table or GCS prefix
 type JobWithTarget struct {
-	ID Key // ID used by gardener & parsers to identify a Job's status and configuration.
-	Job
+	ID  Key // ID used by gardener & parsers to identify a Job's status and configuration.
+	Job Job
 	// TODO: enable configuration for parser to target alterate buckets.
 }
 
 func (j JobWithTarget) String() string {
-	return fmt.Sprint(j.Job.String(), j.Filter)
+	return fmt.Sprint(j.Job.String(), j.Job.Filter)
 }
 
 // NewJob creates a new job object.

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -50,6 +50,8 @@ func (j JobWithTarget) String() string {
 	return fmt.Sprint(j.Job.String(), j.Job.Filter)
 }
 
+// Marshal marshals the JobWithTarget to json. If the JobWithTarget type ever
+// includes fields that cannot be marshalled, then Marshal will panic.
 func (j JobWithTarget) Marshal() []byte {
 	b, err := json.Marshal(j)
 	// NOTE: marshaling a struct with primitive types should never fail.
@@ -103,7 +105,8 @@ func (j Job) Path() string {
 		j.Bucket, j.Experiment, j.Date.Format("2006/01/02/"))
 }
 
-// Marshal marshals the job to json.
+// Marshal marshals the Job to json. If the Job type ever includes fields that
+// cannot be marshalled, then Marshal will panic.
 func (j Job) Marshal() []byte {
 	b, err := json.Marshal(j)
 	rtx.PanicOnError(err, "failed to marshal Job: %s", j)


### PR DESCRIPTION
This change adds new, v2 Jobs API resources based around the Job ID and JobWithTarget resource type.

Previously, the JobWithTarget.Job was not an explicit field and the NextJob handler returned only the Job fields. This behavior is preserved for current clients (the original /job resource). With this change, the `/v2/job/next` resource returns a complete `JobWithTarget` type that includes an `ID` and `Job` subfield. Once the parser client migrates to this v2 API, we will be able to add new fields as needed to support additional functionality (configured output datasets, daily only, etc) without violating the contract between the parser and gardener JobsAPI.

Because of the different handling of the Job or JobWithTarget return type by the "v1" and "v2" APIs, there are two versions of the "next Job" handler. However, all other handlers for `Update`, `Heartbeat` and `Error` should be forward and backward compatible, first looking for an "id" parameter (v2 API), and falling back for earlier clients to a "job" parameter (v1 API).

The next change will add a new v2/client.go package for calling these v2 API resources, which will allow us to easily migrate the parser to this new interface.

Part of:
* https://github.com/m-lab/etl-gardener/issues/349

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/384)
<!-- Reviewable:end -->
