### PR TITLE
Add v2 client package for accessing gardener Jobs API

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -1,0 +1,115 @@
+package gardener
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+// JobClient manages requests to the Gardener Jobs API.
+type JobClient struct {
+	// Client is used for all HTTP requests to the Gardener API. A
+	// NewJobClient uses http.DefaultClient but may be overridden.
+	Client *http.Client
+	api    url.URL
+}
+
+// NewJobClient creates a new JobClient that targets the given base API URL.
+func NewJobClient(api url.URL) *JobClient {
+	return &JobClient{api: api, Client: http.DefaultClient}
+}
+
+// Next requests a new parse job from the Gardener Jobs API.
+func (c *JobClient) Next(ctx context.Context) (*tracker.JobWithTarget, error) {
+	u := c.api
+	u.Path = "/v2/job/next"
+	b, err := c.postReadBody(ctx, u)
+	if err != nil {
+		return nil, err
+	}
+	job := &tracker.JobWithTarget{}
+	err = json.Unmarshal(b, job)
+	if err != nil {
+		return nil, err
+	}
+	return job, nil
+}
+
+// Update sets a new state with given detail for the given job ID.
+func (c *JobClient) Update(ctx context.Context, id tracker.Key, state tracker.State, detail string) error {
+	u := c.api
+	u.Path = "/v2/job/update"
+	params := make(url.Values, 3)
+	params.Add("id", string(id))
+	params.Add("state", string(state))
+	params.Add("detail", detail)
+	u.RawQuery = params.Encode()
+	return c.postClose(ctx, u)
+}
+
+// Heartbeat sends a heartbeat message for the given job ID, notifying Gardener
+// that the job is still in progress.
+func (c *JobClient) Heartbeat(ctx context.Context, id tracker.Key) error {
+	u := c.api
+	u.Path = "/v2/job/heartbeat"
+	params := make(url.Values, 3)
+	params.Add("id", string(id))
+	u.RawQuery = params.Encode()
+	return c.postClose(ctx, u)
+}
+
+// Error reports an error message for the given job ID.
+func (c *JobClient) Error(ctx context.Context, id tracker.Key, errString string) error {
+	u := c.api
+	u.Path = "/v2/job/error"
+	params := make(url.Values, 3)
+	params.Add("id", string(id))
+	params.Add("error", errString)
+	u.RawQuery = params.Encode()
+	return c.postClose(ctx, u)
+}
+
+// postResp issues the request.
+func (c *JobClient) postResp(ctx context.Context, u url.URL) (*http.Response, error) {
+	// Limit posts to a constant 1 Minute timeout.
+	ctxUpdate, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctxUpdate, http.MethodPost, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(http.StatusText(resp.StatusCode))
+	}
+	return resp, nil
+}
+
+// postReadBody issues post and reads response body.
+func (c *JobClient) postReadBody(ctx context.Context, u url.URL) ([]byte, error) {
+	resp, err := c.postResp(ctx, u)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return ioutil.ReadAll(resp.Body)
+}
+
+// postClose posts the given URL and ignores the response.
+func (c *JobClient) postClose(ctx context.Context, u url.URL) error {
+	resp, err := c.postResp(ctx, u)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -101,7 +101,7 @@ func (c *JobClient) postReadBody(ctx context.Context, u url.URL) ([]byte, error)
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // postClose posts the given URL and ignores the response.

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -107,7 +107,7 @@ func TestJobClient_Next(t *testing.T) {
 			}
 			c := NewJobClient(*u)
 			if tt.corruptTransport {
-				// Corrupt the default http transport so that making the reqeust fails.
+				// Corrupt the default http transport so that making the request fails.
 				// Backup, reset for test, and restore.
 				orig := http.DefaultTransport
 				http.DefaultTransport = nil

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -1,0 +1,184 @@
+package gardener
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/m-lab/etl-gardener/tracker"
+	"github.com/m-lab/go/testingx"
+)
+
+func TestJobClient_Next(t *testing.T) {
+	start := time.Date(2019, time.June, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name             string
+		server           *httptest.Server
+		want             *tracker.JobWithTarget
+		wantErr          bool
+		corruptURL       bool
+		corruptTransport bool
+	}{
+		{
+			name: "success-with-id",
+			server: httptest.NewUnstartedServer(
+				// Returns a true tracker.JobWithTarget record.
+				http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+					j := tracker.NewJob("bucket", "experiment", "datatype", start)
+					job := tracker.JobWithTarget{
+						ID:  j.Key(),
+						Job: j,
+					}
+					b, _ := json.Marshal(&job)
+					_, err := resp.Write(b)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}),
+			),
+			want: &tracker.JobWithTarget{
+				ID: "bucket/experiment/datatype/20190601",
+				Job: tracker.Job{
+					Bucket:     "bucket",
+					Experiment: "experiment",
+					Datatype:   "datatype",
+					Date:       start,
+				},
+			},
+		},
+		{
+			name: "error-corrupt-reply",
+			server: httptest.NewUnstartedServer(
+				// Return a corrupted reply that cannot be Unmarshal'd.
+				http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+					_, err := resp.Write([]byte("-this-is-not-json-"))
+					if err != nil {
+						t.Fatal(err)
+					}
+				}),
+			),
+			wantErr: true,
+		},
+		{
+			name: "error-server-status-error",
+			server: httptest.NewUnstartedServer(
+				// Return a non-200 HTTP status response.
+				http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+					resp.WriteHeader(http.StatusInternalServerError)
+				}),
+			),
+			wantErr: true,
+		},
+		{
+			name: "error-corrupt-URL",
+			server: httptest.NewUnstartedServer(
+				http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+					resp.WriteHeader(http.StatusOK)
+				}),
+			),
+			wantErr:    true,
+			corruptURL: true,
+		},
+		{
+			name: "error-corrupt-http-transport",
+			server: httptest.NewUnstartedServer(
+				http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+					resp.WriteHeader(http.StatusOK)
+				}),
+			),
+			wantErr:          true,
+			corruptTransport: true,
+		},
+	}
+	for _, tt := range tests {
+		tt.server.Start()
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.server.URL)
+			testingx.Must(t, err, "failed to parse httptest server url: %q", tt.server.URL)
+			if tt.corruptURL {
+				// Corrupt the URL scheme so that creating a new HTTP request fails.
+				u.Scheme = "-not-a-scheme-"
+			}
+			c := NewJobClient(*u)
+			if tt.corruptTransport {
+				// Corrupt the default http transport so that making the reqeust fails.
+				// Backup, reset for test, and restore.
+				orig := http.DefaultTransport
+				http.DefaultTransport = nil
+				defer func() {
+					http.DefaultTransport = orig
+				}()
+			}
+
+			// Call Next job API.
+			got, err := c.Next(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JobClient.Next() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("JobClient.Next() = %#v, want %#v", got, tt.want)
+			}
+		})
+		tt.server.CloseClientConnections()
+		tt.server.Close()
+	}
+}
+
+func TestJobClient_Update_Heartbeat_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		server  *httptest.Server
+		wantErr bool
+	}{
+		{
+			name: "success",
+			server: httptest.NewUnstartedServer(
+				http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+					resp.WriteHeader(http.StatusOK)
+					err := req.ParseForm()
+					testingx.Must(t, err, "failed to parse form")
+					id := req.Form.Get("id")
+					if id == "" {
+						t.Error("received request without ID")
+					}
+				}),
+			),
+		},
+		{
+			name: "error-server-status-error",
+			server: httptest.NewUnstartedServer(
+				// Return a non-200 HTTP status response.
+				http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+					resp.WriteHeader(http.StatusInternalServerError)
+				}),
+			),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt.server.Start()
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.server.URL)
+			testingx.Must(t, err, "failed to parse server url: %q", tt.server.URL)
+			c := NewJobClient(*u)
+			if err := c.Update(context.Background(), "id", tracker.Complete, "okay"); (err != nil) != tt.wantErr {
+				t.Errorf("JobClient.Heartbeat() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err := c.Heartbeat(context.Background(), "id"); (err != nil) != tt.wantErr {
+				t.Errorf("JobClient.Heartbeat() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err := c.Error(context.Background(), "id", "error message"); (err != nil) != tt.wantErr {
+				t.Errorf("JobClient.Heartbeat() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+		tt.server.CloseClientConnections()
+		tt.server.Close()
+	}
+}


### PR DESCRIPTION
This change adds a new all-inclusive v2 client implementation for accessing the gardener Jobs API resources.

The previous jobs API was accessed using a mixture of logic across three packages:
* Generate URLs - https://github.com/m-lab/etl-gardener/blob/master/tracker/handler.go#L22-L54
* NextJob - https://github.com/m-lab/etl-gardener/blob/master/client/client.go#L52
* Generate URLs and custom POST logic - https://github.com/m-lab/etl/blob/master/active/poller.go#L203-L206

The new version of the Jobs API creates a dedicated client and encapsulates all requests to the v2 API.

Part of:
* https://github.com/m-lab/etl-gardener/issues/349

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/385)
<!-- Reviewable:end -->
