### PR TITLE
Set JobWithTarget.ID for historical and yesterday NextJob paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Run the gardener v2 ("manager" mode) with local writer support:
 go get ./cmd/gardener
 ~/bin/gardener \
     -project=mlab-sandbox \
-    -service.mode=manager \
     -status_port=:8082 \
     -gardener_addr=localhost:8081 \
     -prometheusx.listen-address=:9991 \

--- a/job-service/job-service.go
+++ b/job-service/job-service.go
@@ -48,8 +48,9 @@ func (y *YesterdaySource) nextJob(ctx context.Context) *tracker.JobWithTarget {
 	}
 
 	// Copy the jobspec and set the date.
-	job := y.jobSpecs[y.nextIndex]
-	job.Job.Date = y.Date
+	jt := y.jobSpecs[y.nextIndex]
+	jt.Job.Date = y.Date
+	jt.ID = jt.Job.Key()
 
 	// Advance to the next jobSpec for next call.
 	y.nextIndex++
@@ -68,7 +69,7 @@ func (y *YesterdaySource) nextJob(ctx context.Context) *tracker.JobWithTarget {
 		}
 	}
 
-	return &job
+	return &jt
 }
 
 func initYesterday(ctx context.Context, saver persistence.Saver, delay time.Duration, specs []tracker.JobWithTarget) (*YesterdaySource, error) {
@@ -158,9 +159,9 @@ func (svc *Service) NextJob(ctx context.Context) tracker.JobWithTarget {
 		return svc.ifHasFiles(ctx, *j)
 	}
 
-	job := svc.jobSpecs[svc.nextIndex]
-	job.Job.Date = svc.Date
-	job.ID = job.Job.Key()
+	jt := svc.jobSpecs[svc.nextIndex]
+	jt.Job.Date = svc.Date
+	jt.ID = jt.Job.Key()
 	svc.nextIndex++
 
 	if svc.nextIndex >= len(svc.jobSpecs) {
@@ -174,7 +175,7 @@ func (svc *Service) NextJob(ctx context.Context) tracker.JobWithTarget {
 			log.Println(err)
 		}
 	}
-	return svc.ifHasFiles(ctx, job)
+	return svc.ifHasFiles(ctx, jt)
 }
 
 func (svc *Service) ifHasFiles(ctx context.Context, job tracker.JobWithTarget) tracker.JobWithTarget {


### PR DESCRIPTION
This change ensures that the `JobWithTarget.ID` is set for jobs created by the historical as well as the yesterday job sources. This change adds unit testing that covers both paths.

This change also includes small fixes to the README by removing an obsolete flag, and the job-service_test.go by removing a dependency on datastore, allowing the unit test to be run without "integration" support.

Part of:
* https://github.com/m-lab/etl-gardener/issues/349

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/386)
<!-- Reviewable:end -->
