### PR TITLE
Add daily only option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type SourceConfig struct {
 	Datatype   string `yaml:"datatype"`
 	Filter     string `yaml:"filter"`
 	Target     string `yaml:"target"`
+	DailyOnly  bool   `yaml:"daily_only"`
 }
 
 // Gardener is the full config for a Gardener instance.

--- a/config/config.go
+++ b/config/config.go
@@ -5,13 +5,11 @@ package config
 // Modelled on https://dev.to/ilyakaznacheev/a-clean-way-to-pass-configs-in-a-go-application-1g64
 
 import (
-	"flag"
-	"fmt"
+	"errors"
 	"log"
 	"os"
 	"time"
 
-	"github.com/kelseyhightower/envconfig"
 	"gopkg.in/yaml.v2"
 )
 
@@ -43,57 +41,34 @@ type Gardener struct {
 	Sources   []SourceConfig `yaml:"sources"`
 }
 
-var gardener Gardener
-
-// Sources returns the list of sources that should be processed.
-func Sources() []SourceConfig {
-	src := make([]SourceConfig, len(gardener.Sources))
-	copy(src, gardener.Sources)
-	return src
-}
-
 // StartDate returns the first date that should be processed.
-func StartDate() time.Time {
-	return gardener.StartDate.UTC().Truncate(24 * time.Hour)
+func (g *Gardener) Start() time.Time {
+	return g.StartDate.UTC().Truncate(24 * time.Hour)
 }
 
 // ParseConfig loads the full Config, or Exits on failure.
-func ParseConfig() {
-	log.Println("config init")
-	readFile(&gardener)
-	readEnv(&gardener)
-
-	log.Printf("%+v\n", gardener)
-}
-
-func processError(err error) {
-	fmt.Println(err)
-	// For now don't die...	os.Exit(2)
-}
-
-var configPath = flag.String("config_path", "config.yml", "Path to the config file.")
-
-func readFile(cfg *Gardener) {
-	log.Println("Config path:", *configPath)
-	if *configPath == "" {
-		return
-	}
-	f, err := os.Open(*configPath)
+func ParseConfig(name string) (*Gardener, error) {
+	log.Println("Config path:", name)
+	g := &Gardener{}
+	err := readFile(name, g)
 	if err != nil {
-		processError(err)
+		return nil, err
+	}
+	return g, nil
+}
+
+var ErrNoConfig = errors.New("no config file given")
+
+func readFile(name string, cfg *Gardener) error {
+	if name == "" {
+		return ErrNoConfig
+	}
+	f, err := os.Open(name)
+	if err != nil {
+		return err
 	}
 	defer f.Close()
 
 	decoder := yaml.NewDecoder(f)
-	err = decoder.Decode(cfg)
-	if err != nil {
-		processError(err)
-	}
-}
-
-func readEnv(cfg *Gardener) {
-	err := envconfig.Process("", cfg)
-	if err != nil {
-		processError(err)
-	}
+	return decoder.Decode(cfg)
 }

--- a/config/config.yml
+++ b/config/config.yml
@@ -10,39 +10,34 @@ sources:
   experiment: ndt
   datatype: annotation
   target: tmp_ndt.annotation
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt5
   target: tmp_ndt.ndt5
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt7
   target: tmp_ndt.ndt7
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: pcap
   target: tmp_ndt.pcap
-  daily_only: true
+  # TODO(github.com/m-lab/etl-gardener/issues/389): Enable after pcap historical
+  # reprocessing completes once.
+  # daily_only: true
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: ndt
   datatype: hopannotation1
   target: tmp_ndt.hopannotation1
-  daily_only: true
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: scamper1
   target: tmp_ndt.scamper1
-  daily_only: true
 - bucket: archive-measurement-lab
   experiment: utilization
   datatype: switch
   target: tmp_utilization.switch
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: tcpinfo
   target: tmp_ndt.tcpinfo
-  daily_only: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -10,32 +10,39 @@ sources:
   experiment: ndt
   datatype: annotation
   target: tmp_ndt.annotation
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt5
   target: tmp_ndt.ndt5
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt7
   target: tmp_ndt.ndt7
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: pcap
   target: tmp_ndt.pcap
-  # daily_only: true
+  daily_only: true
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: ndt
   datatype: hopannotation1
   target: tmp_ndt.hopannotation1
+  daily_only: true
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: scamper1
   target: tmp_ndt.scamper1
+  daily_only: true
 - bucket: archive-measurement-lab
   experiment: utilization
   datatype: switch
   target: tmp_utilization.switch
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: tcpinfo
   target: tmp_ndt.tcpinfo
+  daily_only: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -22,6 +22,7 @@ sources:
   experiment: ndt
   datatype: pcap
   target: tmp_ndt.pcap
+  # daily_only: true
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: ndt
   datatype: hopannotation1

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,12 +38,12 @@ func TestParseConfig(t *testing.T) {
 			},
 		},
 		{
-			name:    "error-no-file",
+			name:    "error-empty-file-name",
 			file:    "",
 			wantErr: true,
 		},
 		{
-			name:    "error-no-such-file",
+			name:    "error-file-does-not-exist",
 			file:    "this-file-does-not-exist",
 			wantErr: true,
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,13 +1,12 @@
 package config_test
 
 import (
-	"flag"
 	"log"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/m-lab/etl-gardener/config"
-	"github.com/m-lab/go/flagx"
-	"github.com/m-lab/go/rtx"
 )
 
 func init() {
@@ -15,11 +14,56 @@ func init() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 }
 
-func TestBasic(t *testing.T) {
-	flag.Set("config_path", "testdata/config.yml")
-	flag.Parse()
-	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from env")
-
-	config.ParseConfig()
-
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		start   string
+		want    *config.Gardener
+		wantErr bool
+	}{
+		{
+			name:  "success",
+			file:  "testdata/config.yml",
+			start: "2019-03-04",
+			want: &config.Gardener{
+				StartDate: time.Date(2019, time.March, 4, 0, 1, 2, 0, time.UTC),
+				Tracker:   config.TrackerConfig{Timeout: 5 * time.Hour},
+				Monitor:   config.MonitorConfig{PollingInterval: 5 * time.Minute},
+				Sources: []config.SourceConfig{
+					{Bucket: "archive-measurement-lab", Experiment: "ndt", Datatype: "tcpinfo", Filter: ".*T??:??:00.*Z", Target: "ndt.tcpinfo", DailyOnly: false},
+					{Bucket: "archive-measurement-lab", Experiment: "ndt", Datatype: "ndt5", Filter: ".*T??:??:00.*Z", Target: "ndt.ndt5", DailyOnly: false},
+					{Bucket: "archive-measurement-lab", Experiment: "ndt", Datatype: "pcap", Filter: "", Target: "ndt.pcap", DailyOnly: true},
+				},
+			},
+		},
+		{
+			name:    "error-no-file",
+			file:    "",
+			wantErr: true,
+		},
+		{
+			name:    "error-no-such-file",
+			file:    "this-file-does-not-exist",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := config.ParseConfig(tt.file)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseConfig() = %v, want %v", got, tt.want)
+			}
+			if got.Start().Format("2006-01-02") != tt.start {
+				t.Errorf("Gardener.Start() wrong date; got %q, want %q", got.Start().Format("2006-01-02"), tt.start)
+			}
+		})
+	}
 }

--- a/config/testdata/config.yml
+++ b/config/testdata/config.yml
@@ -1,4 +1,5 @@
 ---
+start_date: 2019-03-04T00:01:02Z
 tracker:
   timeout: 5h
 monitor:
@@ -12,7 +13,13 @@ sources:
   target: ndt.tcpinfo
 - bucket: archive-measurement-lab
   experiment: ndt
-  datatype: ndt5 
+  datatype: ndt5
   filter: .*T??:??:00.*Z
   start: 2019-08-01
   target: ndt.ndt5
+- bucket: archive-measurement-lab
+  experiment: ndt
+  datatype: pcap
+  start: 2019-08-01
+  target: ndt.pcap
+  daily_only: true

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -244,8 +244,8 @@ func TestYesterdayFromSaver(t *testing.T) {
 	}
 
 	for i, e := range expected {
-		want := tracker.JobWithTarget{}
-		json.Unmarshal([]byte(e.body), &want)
+		want := &tracker.JobWithTarget{}
+		json.Unmarshal([]byte(e.body), want)
 		got := svc.NextJob(ctx)
 		diff := deep.Equal(want, got)
 		if diff != nil {
@@ -277,6 +277,7 @@ func TestEarlyWrapping(t *testing.T) {
 	sources := []config.SourceConfig{
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
 		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "pcap", Target: "tmp_ndt.pcap", DailyOnly: true}, // skipped.
 	}
 	svc, err := job.NewJobService(ctx, tk, start, "fake-bucket", sources, &NullSaver{}, nil)
 	must(t, err)

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -54,7 +54,7 @@ func ErrorURL(base url.URL, job Job, errString string) *url.URL {
 }
 
 type JobService interface {
-	NextJob(ctx context.Context) JobWithTarget
+	NextJob(ctx context.Context) *JobWithTarget
 }
 
 // Handler provides handlers for update, heartbeat, etc.
@@ -196,7 +196,7 @@ func (h *Handler) nextJob(resp http.ResponseWriter, req *http.Request) *JobWithT
 		resp.Write([]byte(MsgJobExists))
 		return nil
 	}
-	return &jt
+	return jt
 }
 
 // nextJobV1 returns the next JobWithTarget and returns the tracker.Job to the requesting client.

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -27,10 +27,10 @@ type fakeJobService struct {
 	calls int
 }
 
-func (f *fakeJobService) NextJob(ctx context.Context) tracker.JobWithTarget {
+func (f *fakeJobService) NextJob(ctx context.Context) *tracker.JobWithTarget {
 	j := f.jobs[f.calls]
 	f.calls++
-	return tracker.JobWithTarget{Job: j}
+	return &tracker.JobWithTarget{Job: j}
 }
 
 func testSetup(t *testing.T, jobs []tracker.Job) (url.URL, *tracker.Tracker) {

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -41,8 +41,9 @@ type Job struct {
 // JobWithTarget specifies a type/date job, and a destination
 // table or GCS prefix
 type JobWithTarget struct {
-	ID  Key // ID used by gardener & parsers to identify a Job's status and configuration.
-	Job Job
+	ID        Key // ID used by gardener & parsers to identify a Job's status and configuration.
+	Job       Job
+	DailyOnly bool `json:"-"`
 	// TODO: enable configuration for parser to target alterate buckets.
 }
 

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -84,11 +84,15 @@ func cleanup(client dsiface.Client, key *datastore.Key) error {
 }
 
 func TestJobPath(t *testing.T) {
-	withType := tracker.Job{"bucket", "exp", "type", startDate, ""}
+	withType := tracker.Job{
+		Bucket: "bucket", Experiment: "exp", Datatype: "type", Date: startDate, Filter: "",
+	}
 	if withType.Path() != "gs://bucket/exp/type/"+startDate.Format("2006/01/02/") {
 		t.Error("wrong path:", withType.Path())
 	}
-	withoutType := tracker.Job{"bucket", "exp", "", startDate, ""}
+	withoutType := tracker.Job{
+		Bucket: "bucket", Experiment: "exp", Date: startDate, Filter: "",
+	}
 	if withoutType.Path() != "gs://bucket/exp/"+startDate.Format("2006/01/02/") {
 		t.Error("wrong path", withType.Path())
 	}
@@ -174,7 +178,9 @@ func TestUpdates(t *testing.T) {
 
 	createJobs(t, tk, "JobToUpdate", "type", 1)
 
-	job := tracker.Job{"bucket", "JobToUpdate", "type", startDate, ""}
+	job := tracker.Job{
+		Bucket: "bucket", Experiment: "JobToUpdate", Datatype: "type", Date: startDate, Filter: "",
+	}
 	key := job.Key()
 	must(t, tk.SetStatus(key, tracker.Parsing, "foo"))
 	must(t, tk.SetStatus(key, tracker.Stabilizing, "bar"))
@@ -191,7 +197,9 @@ func TestUpdates(t *testing.T) {
 	if status.Detail() != "foobar" {
 		t.Error("Incorrect detail", status.LastStateInfo())
 	}
-	j := tracker.Job{"bucket", "JobToUpdate", "other-type", startDate, ""}
+	j := tracker.Job{
+		Bucket: "bucket", Experiment: "JobToUpdate", Datatype: "other-type", Date: startDate, Filter: "",
+	}
 	err = tk.SetStatus(j.Key(), tracker.Stabilizing, "")
 	if err != tracker.ErrJobNotFound {
 		t.Error(err, "should have been ErrJobNotFound")


### PR DESCRIPTION
This change adds a new gardener datatype configuration option for `daily_only: <bool>`. Default behavior is unchanged.

This change refactors the `config` package interface to use standard return type and error propagation, removes a package flag in favor of defining this in the `main` package, and completes unit test coverage of that package.

This change will ultimately allow us to set the pcap processing to "daily only" to prevent the excess reprocessing for historical pcap data. 

This change obsoletes the change started in:
* https://github.com/m-lab/etl-gardener/pull/352

Part of a sequence of changes leading to:
* https://github.com/m-lab/etl-gardener/issues/349

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/388)
<!-- Reviewable:end -->
