### PR TITLE
Remove tracker.NewJob and add jobtest.NewJob for unit tests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/m-lab/etl-gardener/client"
 	"github.com/m-lab/etl-gardener/tracker"
+	"github.com/m-lab/etl-gardener/tracker/jobtest"
 	"github.com/m-lab/go/rtx"
 )
 
@@ -67,7 +68,7 @@ func TestJobClient(t *testing.T) {
 
 	// set up a fake gardener service.
 	fg := fakeGardener{t: t, jobs: make([]tracker.JobWithTarget, 0)}
-	spec := tracker.NewJob(
+	spec := jobtest.NewJob(
 		"foobar", "ndt", "ndt5", time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC))
 	rtx.Must(fg.AddJob(spec, "a.b.c"), "add job")
 	gardener := httptest.NewServer(&fg)

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/m-lab/etl-gardener/tracker"
+	"github.com/m-lab/etl-gardener/tracker/jobtest"
 	"github.com/m-lab/go/testingx"
 )
 
@@ -30,7 +31,7 @@ func TestJobClient_Next(t *testing.T) {
 			server: httptest.NewUnstartedServer(
 				// Returns a true tracker.JobWithTarget record.
 				http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-					j := tracker.NewJob("bucket", "experiment", "datatype", start)
+					j := jobtest.NewJob("bucket", "experiment", "datatype", start)
 					job := tracker.JobWithTarget{
 						ID:  j.Key(),
 						Job: j,

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -15,7 +15,8 @@ import (
 )
 
 var (
-	dataType = flag.String("datatype", "ndt7", "datatype")
+	exp      = flag.String("experiment", "ndt", "experiment name")
+	dataType = flag.String("datatype", "ndt7", "datatype name")
 	date     = flag.String("date", "", "partition date")
 )
 
@@ -28,7 +29,7 @@ DESCRIPTION
   It is intended for manual testing of the bq.TableOps.CopyTmpToRaw, and has no other practical purpose.
 
 EXAMPLES
-  copy -datatype=ndt7 -date=2020-03-01
+  copy -experiment=ndt -datatype=ndt7 -date=2020-03-01
 `
 
 func init() {
@@ -80,7 +81,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := tracker.NewJob("unused-bucket", "unused-experiment", *dataType, d)
+	j := tracker.Job{
+		Bucket: "unused-bucket", Experiment: *exp, Datatype: *dataType, Date: d,
+	}
 	log.Println(j)
 	copyFunc(ctx, j)
 }

--- a/cmd/load/load.go
+++ b/cmd/load/load.go
@@ -49,7 +49,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	j := tracker.NewJob("bucket", "ndt", *datatype, d)
+	j := tracker.Job{
+		Bucket: "unused-bucket", Experiment: "ndt", Datatype: *datatype, Date: d,
+	}
 	log.Println(j)
 
 	q, err := bq.NewTableOps(ctx, j, "mlab-sandbox",

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/m-lab/etl-gardener/job-service"
 	"github.com/m-lab/etl-gardener/persistence"
 	"github.com/m-lab/etl-gardener/tracker"
+	"github.com/m-lab/etl-gardener/tracker/jobtest"
 )
 
 func init() {
@@ -69,8 +70,8 @@ func TestService_NextJob(t *testing.T) {
 	ctx := context.Background()
 
 	sources := []config.SourceConfig{
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo"},
 	}
 	// This is three days before "now".  The job service should restart
 	// when it reaches 36 hours before "now", which is 2011-02-05
@@ -118,12 +119,12 @@ func TestResume(t *testing.T) {
 		t.Fatal(err)
 	}
 	lastJobDate := start.AddDate(0, 0, 3)
-	last := tracker.NewJob("fake-bucket", "ndt", "ndt5", lastJobDate)
+	last := jobtest.NewJob("fake-bucket", "ndt", "ndt5", lastJobDate)
 	tk.AddJob(last)
 
 	sources := []config.SourceConfig{
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo"},
 	}
 	svc, err := job.NewJobService(ctx, tk, start, "fake-bucket", sources, &NullSaver{}, nil)
 	must(t, err)
@@ -179,8 +180,8 @@ func TestResumeFromSaver(t *testing.T) {
 
 	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)
 	sources := []config.SourceConfig{
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo"},
 	}
 
 	// Set up fake saver.
@@ -216,8 +217,8 @@ func TestYesterdayFromSaver(t *testing.T) {
 
 	start := time.Date(2011, 2, 3, 0, 0, 0, 0, time.UTC)
 	sources := []config.SourceConfig{
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo"},
 	}
 
 	// Set up fake saver.
@@ -275,9 +276,9 @@ func TestEarlyWrapping(t *testing.T) {
 	}
 
 	sources := []config.SourceConfig{
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5", Target: "tmp_ndt.ndt5"},
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo", Target: "tmp_ndt.tcpinfo"},
-		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "pcap", Target: "tmp_ndt.pcap", DailyOnly: true}, // skipped.
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "ndt5"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "tcpinfo"},
+		{Bucket: "fake-bucket", Experiment: "ndt", Datatype: "pcap", DailyOnly: true}, // skipped.
 	}
 	svc, err := job.NewJobService(ctx, tk, start, "fake-bucket", sources, &NullSaver{}, nil)
 	must(t, err)

--- a/ops/actions_test.go
+++ b/ops/actions_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package ops_test
@@ -23,17 +24,58 @@ func TestStandardMonitor(t *testing.T) {
 	}
 	logx.LogxDebug.Set("true")
 
+	d := time.Now()
+	// Statically define jobs with full configurations specified.
+	jobs := []tracker.Job{
+		// Not yet supported.
+		{
+			Bucket:     "bucket",
+			Experiment: "exp",
+			Datatype:   "type",
+			Date:       d,
+		},
+		// Valid experiment and datatype
+		// This does an actual dedup, so we need to allow enough time.
+		{
+			Bucket:     "bucket",
+			Experiment: "ndt",
+			Datatype:   "ndt7",
+			Date:       d,
+		},
+		{
+			Bucket:     "bucket",
+			Experiment: "ndt",
+			Datatype:   "annotation",
+			Date:       d,
+		},
+		{
+			Bucket:     "bucket",
+			Experiment: "ndt",
+			Datatype:   "pcap",
+			Date:       d,
+		},
+		{
+			Bucket:     "bucket",
+			Experiment: "ndt",
+			Datatype:   "hopannotation1",
+			Date:       d,
+		},
+		{
+			Bucket:     "bucket",
+			Experiment: "ndt",
+			Datatype:   "scamper1",
+			Date:       d,
+		},
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	saver := tracker.NewLocalSaver(t.TempDir(), nil)
 	tk, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	rtx.Must(err, "tk init")
-	// Not supported.
-	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
-	// Valid experiment and datatype
-	// This does an actual dedup, so we need to allow enough time.
-	datatypes := []string{"ndt7", "annotation", "pcap", "hopannotation1", "scamper1", "tcpinfo"}
-	for _, datatype := range datatypes {
-		tk.AddJob(tracker.NewJob("bucket", "ndt", datatype, time.Now()))
+
+	// Add jobs to the tracker.
+	for i := 0; i < len(jobs); i++ {
+		tk.AddJob(jobs[i])
 	}
 
 	m, err := ops.NewStandardMonitor(context.Background(), "mlab-testing", cloud.BQConfig{}, tk)

--- a/ops/ops_test.go
+++ b/ops/ops_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/m-lab/etl-gardener/cloud"
 	"github.com/m-lab/etl-gardener/ops"
 	"github.com/m-lab/etl-gardener/tracker"
+	"github.com/m-lab/etl-gardener/tracker/jobtest"
 )
 
 func init() {
@@ -38,9 +39,9 @@ func TestMonitor_Watch(t *testing.T) {
 	saver := tracker.NewLocalSaver(t.TempDir(), nil)
 	tk, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	rtx.Must(err, "tk init")
-	tk.AddJob(tracker.NewJob("bucket", "exp", "type", time.Now()))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type", time.Now()))
-	tk.AddJob(tracker.NewJob("bucket", "exp2", "type2", time.Now()))
+	tk.AddJob(jobtest.NewJob("bucket", "exp", "type", time.Now()))
+	tk.AddJob(jobtest.NewJob("bucket", "exp2", "type", time.Now()))
+	tk.AddJob(jobtest.NewJob("bucket", "exp2", "type2", time.Now()))
 
 	m, err := ops.NewMonitor(context.Background(), cloud.BQConfig{}, tk)
 	rtx.Must(err, "NewMonitor failure")
@@ -82,7 +83,7 @@ func TestOutcomeUpdate(t *testing.T) {
 	saver := tracker.NewLocalSaver(t.TempDir(), nil)
 	tk, err := tracker.InitTracker(ctx, saver, 0, 0, 0)
 	rtx.Must(err, "tk init")
-	job := tracker.NewJob("bucket", "exp", "type", time.Now())
+	job := jobtest.NewJob("bucket", "exp", "type", time.Now())
 	tk.AddJob(job)
 
 	m, err := ops.NewMonitor(context.Background(), cloud.BQConfig{}, tk)

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -14,6 +14,7 @@ import (
 
 	"cloud.google.com/go/datastore"
 	"github.com/m-lab/etl-gardener/tracker"
+	"github.com/m-lab/etl-gardener/tracker/jobtest"
 )
 
 func init() {
@@ -85,7 +86,7 @@ func postAndExpect(t *testing.T, url *url.URL, code int) string {
 
 func TestUpdateHandler(t *testing.T) {
 	date := time.Date(2019, 01, 02, 0, 0, 0, 0, time.UTC)
-	job := tracker.NewJob("bucket", "exp", "type", date)
+	job := jobtest.NewJob("bucket", "exp", "type", date)
 	server, tk := testSetup(t, []tracker.Job{job})
 
 	url := tracker.UpdateURL(server, job, tracker.Parsing, "foobar")
@@ -117,7 +118,7 @@ func TestUpdateHandler(t *testing.T) {
 func TestHeartbeatHandler(t *testing.T) {
 	logx.LogxDebug.Set("true")
 	date := time.Date(2019, 01, 02, 0, 0, 0, 0, time.UTC)
-	job := tracker.NewJob("bucket", "exp", "type", date)
+	job := jobtest.NewJob("bucket", "exp", "type", date)
 	server, tk := testSetup(t, []tracker.Job{job})
 
 	url := tracker.HeartbeatURL(server, job)
@@ -149,7 +150,7 @@ func TestHeartbeatHandler(t *testing.T) {
 
 func TestErrorHandler(t *testing.T) {
 	date := time.Date(2019, 01, 02, 0, 0, 0, 0, time.UTC)
-	job := tracker.NewJob("bucket", "exp", "type", date)
+	job := jobtest.NewJob("bucket", "exp", "type", date)
 	server, tk := testSetup(t, []tracker.Job{job})
 
 	url := tracker.ErrorURL(server, job, "error")
@@ -183,7 +184,7 @@ func TestErrorHandler(t *testing.T) {
 
 func TestNextJobHandler(t *testing.T) {
 	date := time.Date(2019, 01, 02, 0, 0, 0, 0, time.UTC)
-	job := tracker.NewJob("bucket", "exp", "type", date)
+	job := jobtest.NewJob("bucket", "exp", "type", date)
 	// Add job, empty, and duplicate job.
 	url, _ := testSetup(t, []tracker.Job{job, tracker.Job{}, job})
 	url.Path = "job"
@@ -207,7 +208,7 @@ func TestNextJobHandler(t *testing.T) {
 
 func TestNextJobV2Handler(t *testing.T) {
 	date := time.Date(2019, 01, 02, 0, 0, 0, 0, time.UTC)
-	job := tracker.NewJob("bucket", "exp", "type", date)
+	job := jobtest.NewJob("bucket", "exp", "type", date)
 	// Add job, empty, and duplicate job.
 	url, _ := testSetup(t, []tracker.Job{job, tracker.Job{}, job})
 	url.Path = "/v2/job/next"

--- a/tracker/jobtest/job.go
+++ b/tracker/jobtest/job.go
@@ -1,0 +1,17 @@
+package jobtest
+
+import (
+	"time"
+
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+// NewJob creates a new tracker.Job for unit testing.
+func NewJob(bucket, exp, typ string, date time.Time) tracker.Job {
+	return tracker.Job{
+		Bucket:     bucket,
+		Experiment: exp,
+		Datatype:   typ,
+		Date:       date.UTC().Truncate(24 * time.Hour),
+	}
+}

--- a/tracker/jobtest/job_test.go
+++ b/tracker/jobtest/job_test.go
@@ -1,0 +1,54 @@
+package jobtest
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+func TestNewJob(t *testing.T) {
+	tests := []struct {
+		name   string
+		bucket string
+		exp    string
+		typ    string
+		date   time.Time
+		want   tracker.Job
+	}{
+		{
+			name:   "success",
+			bucket: "bucket",
+			exp:    "exp",
+			typ:    "typ",
+			date:   time.Date(2019, time.February, 03, 00, 00, 00, 00, time.UTC),
+			want: tracker.Job{
+				Bucket:     "bucket",
+				Experiment: "exp",
+				Datatype:   "typ",
+				Date:       time.Date(2019, time.February, 03, 00, 00, 00, 00, time.UTC),
+			},
+		},
+		{
+			name:   "success-trucate-date",
+			bucket: "bucket",
+			exp:    "exp",
+			typ:    "typ",
+			date:   time.Date(2019, time.February, 03, 02, 03, 04, 05, time.UTC),
+			want: tracker.Job{
+				Bucket:     "bucket",
+				Experiment: "exp",
+				Datatype:   "typ",
+				Date:       time.Date(2019, time.February, 03, 00, 00, 00, 00, time.UTC),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewJob(tt.bucket, tt.exp, tt.typ, tt.date); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewJob() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -11,10 +11,10 @@ import (
 	"cloud.google.com/go/datastore"
 	"github.com/googleapis/google-cloud-go-testing/datastore/dsiface"
 
+	"github.com/m-lab/etl-gardener/tracker"
+	"github.com/m-lab/etl-gardener/tracker/jobtest"
 	"github.com/m-lab/go/cloudtest/dsfake"
 	"github.com/m-lab/go/logx"
-
-	"github.com/m-lab/etl-gardener/tracker"
 )
 
 func init() {
@@ -38,7 +38,7 @@ func createJobs(t *testing.T, tk *tracker.Tracker, exp string, typ string, n int
 	date := startDate
 	for i := 0; i < n; i++ {
 		go func(date time.Time) {
-			job := tracker.NewJob(
+			job := jobtest.NewJob(
 				"bucket", exp, typ, date,
 			)
 			err := tk.AddJob(job)
@@ -56,7 +56,7 @@ func completeJobs(t *testing.T, tk *tracker.Tracker, exp string, typ string, n i
 	// Delete all jobs.
 	date := startDate
 	for i := 0; i < n; i++ {
-		job := tracker.NewJob(
+		job := jobtest.NewJob(
 			"bucket", exp, typ, date,
 		)
 		err := tk.SetStatus(job.Key(), tracker.Complete, "")
@@ -236,7 +236,7 @@ func TestNonexistentJobAccess(t *testing.T) {
 		t.Error("Should be ErrJobNotFound", err)
 	}
 
-	js := tracker.NewJob("bucket", "exp", "type", startDate)
+	js := jobtest.NewJob("bucket", "exp", "type", startDate)
 	must(t, tk.AddJob(js))
 
 	err = tk.AddJob(js)
@@ -266,7 +266,7 @@ func TestJobMapHTML(t *testing.T) {
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)
 	}
-	js := tracker.NewJob("bucket", "exp", "type", startDate)
+	js := jobtest.NewJob("bucket", "exp", "type", startDate)
 	must(t, tk.AddJob(js))
 
 	buf := bytes.Buffer{}
@@ -287,7 +287,7 @@ func TestExpiration(t *testing.T) {
 	tk, err := tracker.InitTracker(ctx, saver, 5*time.Millisecond, 10*time.Millisecond, 1*time.Millisecond)
 	must(t, err)
 
-	job := tracker.NewJob("bucket", "exp", "type", startDate)
+	job := jobtest.NewJob("bucket", "exp", "type", startDate)
 	err = tk.SetStatus(job.Key(), tracker.Parsing, "")
 	if err != tracker.ErrJobNotFound {
 		t.Error("Should be ErrJobNotFound", err)


### PR DESCRIPTION
This change removes a 'DEPRECATED' function from tracker that was only used in unit tests and non production binaries (cmd/load, cmd/copy). Instead, the functionality of `NewJob` is added to a new `jobtest` package and all references in unit tests are updated throughout.

This change is a cleanup in preparation for the final change to complete https://github.com/m-lab/etl-gardener/issues/349

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/391)
<!-- Reviewable:end -->
