### PR TITLE
Add persistence.LocalNamedSaver

### DIFF
--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -91,3 +91,40 @@ func (ls *LocalSaver) Fetch(ctx context.Context, o StateObject) error {
 	}
 	return json.Unmarshal(b, o)
 }
+
+// LocalNamedSaver is a generic saver interface for persisting to/from JSON
+// objects.
+type LocalNamedSaver struct {
+	name string
+	mx   sync.Mutex
+}
+
+// NewLocalNamedSaver creates a new LocalNamedSaver that saves results to the
+// given file name.
+func NewLocalNamedSaver(name string) *LocalNamedSaver {
+	return &LocalNamedSaver{
+		name: name,
+	}
+}
+
+// Save serializes the given object as JSON and saves result.
+func (ls *LocalNamedSaver) Save(v any) error {
+	ls.mx.Lock()
+	defer ls.mx.Unlock()
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(ls.name, b, 0644)
+}
+
+// Load deserializes previously saved JSON content into the given object.
+func (ls *LocalNamedSaver) Load(v any) error {
+	ls.mx.Lock()
+	defer ls.mx.Unlock()
+	b, err := os.ReadFile(ls.name)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}

--- a/persistence/persistence_test.go
+++ b/persistence/persistence_test.go
@@ -78,7 +78,7 @@ func TestLocalNamedSaver(t *testing.T) {
 		name        string
 		input       any
 		output      any
-		removePerm  bool
+		removeDir   bool
 		wantSaveErr bool
 		removeFile  bool
 		wantLoadErr bool
@@ -96,7 +96,7 @@ func TestLocalNamedSaver(t *testing.T) {
 		{
 			name:        "save-error-no-write-permission",
 			input:       &foo{A: 10},
-			removePerm:  true,
+			removeDir:   true,
 			wantSaveErr: true,
 		},
 		{
@@ -117,8 +117,8 @@ func TestLocalNamedSaver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			file := dir + "/output.json"
-			if tt.removePerm {
-				os.Chmod(dir, 0000) // make directory unwritable.
+			if tt.removeDir {
+				os.Remove(dir) // make directory unwritable.
 			}
 			// save to named saver.
 			ls := persistence.NewLocalNamedSaver(file)

--- a/persistence/persistence_test.go
+++ b/persistence/persistence_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"path"
 	"reflect"
 	"testing"
 
@@ -116,7 +117,7 @@ func TestLocalNamedSaver(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			file := dir + "/output.json"
+			file := path.Join(dir, "output.json")
 			if tt.removeDir {
 				os.Remove(dir) // make directory unwritable.
 			}

--- a/persistence/persistence_test.go
+++ b/persistence/persistence_test.go
@@ -3,6 +3,7 @@ package persistence_test
 import (
 	"context"
 	"log"
+	"os"
 	"reflect"
 	"testing"
 
@@ -65,4 +66,85 @@ func TestNewLocalSaver(t *testing.T) {
 			t.Errorf("LocalSaver.Fetch() returned value after delete; got nil, want err")
 		}
 	})
+}
+
+func TestLocalNamedSaver(t *testing.T) {
+	type foo struct {
+		A int
+		B float64
+		C string
+	}
+	tests := []struct {
+		name        string
+		input       any
+		output      any
+		removePerm  bool
+		wantSaveErr bool
+		removeFile  bool
+		wantLoadErr bool
+	}{
+		{
+			name:   "successful-save-and-load",
+			input:  &foo{A: 10},
+			output: &foo{},
+		},
+		{
+			name:        "save-error-unsupported-type",
+			input:       struct{ F func() }{}, // invalid field.
+			wantSaveErr: true,
+		},
+		{
+			name:        "save-error-no-write-permission",
+			input:       &foo{A: 10},
+			removePerm:  true,
+			wantSaveErr: true,
+		},
+		{
+			name:        "load-error-missing-file",
+			input:       &foo{A: 10},
+			output:      &foo{},
+			removeFile:  true,
+			wantLoadErr: true,
+		},
+		{
+			name:        "load-error-wrong-target-type",
+			input:       &foo{A: 10},
+			output:      struct{ F func() }{},
+			wantLoadErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			file := dir + "/output.json"
+			if tt.removePerm {
+				os.Chmod(dir, 0000) // make directory unwritable.
+			}
+			// save to named saver.
+			ls := persistence.NewLocalNamedSaver(file)
+			err := ls.Save(tt.input)
+			if (err != nil) != tt.wantSaveErr {
+				t.Errorf("Save() got unexpected error; got %v, wantSaveErr %t", err, tt.wantSaveErr)
+			}
+			if tt.wantSaveErr {
+				return
+			}
+
+			if tt.removeFile {
+				os.Remove(file) // remove saved file so load fails.
+			}
+			err = ls.Load(tt.output)
+			if !tt.wantLoadErr && (err != nil) {
+				t.Errorf("Load() got unexpected error; got %v, want nil", err)
+			}
+			if tt.wantLoadErr {
+				return
+			}
+
+			// Compare intput and output structures to verify data is loaded correctly.
+			if !reflect.DeepEqual(tt.input, tt.output) {
+				t.Errorf("Load() got different values; got %v, want %v", tt.output, tt.input)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This change adds a generic `LocalNamedSaver` type that will replace the current `persistence.LocalSaver` and `tracker.LocalSaver` types in favor of a single generic mechanism.

This side quest will enable a simpler migration path https://github.com/m-lab/etl-gardener/pull/390#issuecomment-1184825626 on the way to completing https://github.com/m-lab/etl-gardener/issues/349

Tested only with unit tests. This change adds a new interface before using it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/394)
<!-- Reviewable:end -->
