### PR TITLE
Add JobIterator and DateIterators to job service

### DIFF
--- a/job-service/iterators.go
+++ b/job-service/iterators.go
@@ -10,9 +10,6 @@ import (
 var (
 	// ErrNoDateAvailable is returned if a DateIterator does not have a date available.
 	ErrNoDateAvailable = errors.New("no date is available")
-
-	// ErrBadDate is returned if a bad date is returned by a date iterator.
-	ErrBadDate = errors.New("bad date")
 )
 
 type namedSaver interface {
@@ -28,7 +25,7 @@ type namedSaver interface {
 // roughly follow: filter, save, read, update, return. By saving the current
 // date before updating, we ensure that a mid-process restart would pickup where
 // it left off, possibly at the expense of some reprocessing, but with assurance
-// that no dates were skipped.
+// that no date data was skipped.
 type DateIterator interface {
 	Next() (time.Time, error)
 }
@@ -68,7 +65,7 @@ func NewDailyIterator(delay time.Duration, saver namedSaver) *DailyIterator {
 
 // Next returns the next "daily" date. Until 'delay' after UTC midnight, Next will
 // return ErrNoDateAvailable. If err is nil, then the returned time is the next
-// daily date. After every update, the new date is saved.
+// daily date. The current date is saved before every update.
 func (d *DailyIterator) Next() (time.Time, error) {
 	// Do not proceed until after midnight+delay the next day.
 	if time.Since(d.Date) < 24*time.Hour+d.delay {
@@ -112,8 +109,8 @@ func NewHistoricalIterator(start time.Time, saver namedSaver) *HistoricalIterato
 }
 
 // Next returns the next "historical" date. If this date is within 36h of
-// current, real world date, then the historical cycle restarts. After every
-// update, the new date is saved.
+// current, real world date, then the historical cycle restarts. The current
+// date is saved before every update.
 func (h *HistoricalIterator) Next() (time.Time, error) {
 	// Start over when we reach yesterday.
 	if time.Since(h.Date) < 36*time.Hour {

--- a/job-service/iterators.go
+++ b/job-service/iterators.go
@@ -1,0 +1,181 @@
+package job
+
+import (
+	"errors"
+	"time"
+
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+var (
+	// ErrNoDateAvailable is returned if a DateIterator does not have a date available.
+	ErrNoDateAvailable = errors.New("no date is available")
+
+	// ErrBadDate is returned if a bad date is returned by a date iterator.
+	ErrBadDate = errors.New("bad date")
+)
+
+type namedSaver interface {
+	Save(v any) error
+	Load(v any) error
+}
+
+// DateIterator defines the interface common to the Daily and Historical
+// iterators.
+//
+// DateIterator implementations should prioritize process continuity and
+// reliability after restart. For example, the sequence of operations should
+// roughly follow: filter, save, read, update, return. By saving the current
+// date before updating, we ensure that a mid-process restart would pickup where
+// it left off, possibly at the expense of some reprocessing, but with assurance
+// that no dates were skipped.
+type DateIterator interface {
+	Next() (time.Time, error)
+}
+
+// old: load, update, filter, save - may skip data.
+// new: load, filter, save, update - may reprocess data.
+
+// DailyIterator tracks state and dates for "daily" processing events.
+type DailyIterator struct {
+	Date  time.Time     // The next date to process.
+	delay time.Duration // wait this long after UTC midnight before processing next date.
+	saver namedSaver
+}
+
+// HistoricalIterator tracks state and dates for "historical" processing events.
+type HistoricalIterator struct {
+	Date  time.Time // The next date to process.
+	start time.Time // Earliest date to process after reaching current date.
+	saver namedSaver
+}
+
+// NewDailyIterator creates a new DailyIterator.  The delay is an additional
+// offset after UTC midnight before the next Date is processed.  The starting
+// Date will be yesterday or the date successfully loaded from the given saver.
+func NewDailyIterator(delay time.Duration, saver namedSaver) *DailyIterator {
+	d := &DailyIterator{
+		Date:  tracker.YesterdayDate(),
+		saver: saver,
+		delay: delay,
+	}
+	// Attempt to load Date from previously saved data.
+	tmp := &DailyIterator{}
+	err := d.saver.Load(tmp)
+	if err == nil && !tmp.Date.IsZero() {
+		// Ignore load errors.
+		d.Date = tmp.Date
+	}
+	return d
+}
+
+// Next returns the next "daily" date. Until 'delay' after UTC midnight, Next will
+// return ErrNoDateAvailable. If err is nil, then the returned time is the next
+// daily date. After every update, the new date is saved.
+func (d *DailyIterator) Next() (time.Time, error) {
+	// Do not proceed until after midnight+delay the next day.
+	if time.Since(d.Date) < 24*time.Hour+d.delay {
+		return time.Time{}, ErrNoDateAvailable // Zero time.
+	}
+
+	// Saving before advancing to next date ensures we process this date fully.
+	err := d.saver.Save(d)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	r := d.Date
+	// Advance to next "yesterday" date.
+	d.Date = d.Date.UTC().AddDate(0, 0, 1).Truncate(24 * time.Hour)
+	return r, nil
+}
+
+// NewHistoricalIterator creates a new HistoricalIterator. The iterator will
+// begin from the given start unless a different date is successfully loaded
+// from the given saver. The returned HistoricalIterator.Date is guaranteed to
+// be later or equal to the start date.
+func NewHistoricalIterator(start time.Time, saver namedSaver) *HistoricalIterator {
+	h := &HistoricalIterator{
+		Date:  start,
+		start: start,
+		saver: saver,
+	}
+	// Attempt to load Date from previously saved data.
+	tmp := &DailyIterator{}
+	err := h.saver.Load(tmp)
+	if err == nil && !tmp.Date.IsZero() {
+		// Ignore load errors.
+		h.Date = tmp.Date
+	}
+	// Enforce consistent dates.
+	if h.Date.Before(h.start) {
+		h.Date = h.start
+	}
+	return h
+}
+
+// Next returns the next "historical" date. If this date is within 36h of
+// current, real world date, then the historical cycle restarts. After every
+// update, the new date is saved.
+func (h *HistoricalIterator) Next() (time.Time, error) {
+	// Start over when we reach yesterday.
+	if time.Since(h.Date) < 36*time.Hour {
+		h.Date = h.start
+	}
+	// Saving before advancing to next date ensures we process this date fully.
+	err := h.saver.Save(h)
+	if err != nil {
+		return time.Time{}, err
+	}
+	r := h.Date
+	// Advance to next date.
+	h.Date = h.Date.UTC().AddDate(0, 0, 1).Truncate(24 * time.Hour)
+	return r, nil
+}
+
+// JobIterator iterates over Job configurations for an underlying DateIterator sequence.
+type JobIterator struct {
+	date      DateIterator
+	specs     []tracker.JobWithTarget // The job prefixes to be iterated through.
+	nextIndex int
+	lastDate  time.Time
+}
+
+// NewJobIterator creates a new JobIterator. For every date returned by the
+// DateIterator, the JobIterator will enumerate every jobSpec for that date
+// before advancing to the next date.
+func NewJobIterator(date DateIterator, jobSpecs []tracker.JobWithTarget) *JobIterator {
+	return &JobIterator{
+		date:      date,
+		specs:     jobSpecs,
+		nextIndex: len(jobSpecs), // Guarantee first call to Next updates lastDate.
+	}
+}
+
+// Len returns the number of Job specs.
+func (j *JobIterator) Len() int {
+	return len(j.specs)
+}
+
+// Next returns the next JobWithTarget for the current date. Next may return an
+// error when the underlying DateIterator returns an error, e.g. ErrNoDateAvailable.
+func (j *JobIterator) Next() (*tracker.JobWithTarget, error) {
+	var t time.Time
+	var err error
+	if j.nextIndex >= len(j.specs) {
+		t, err = j.date.Next()
+		if err != nil {
+			return nil, err
+		}
+		j.lastDate = t
+		j.nextIndex = 0
+	}
+
+	// Copy the jobspec and set the date.
+	jt := &tracker.JobWithTarget{}
+	*jt = j.specs[j.nextIndex]
+	jt.Job.Date = j.lastDate
+	jt.ID = jt.Job.Key()
+	j.nextIndex++ // increment index for next call.
+	return jt, nil
+}

--- a/job-service/iterators.go
+++ b/job-service/iterators.go
@@ -33,9 +33,6 @@ type DateIterator interface {
 	Next() (time.Time, error)
 }
 
-// old: load, update, filter, save - may skip data.
-// new: load, filter, save, update - may reprocess data.
-
 // DailyIterator tracks state and dates for "daily" processing events.
 type DailyIterator struct {
 	Date  time.Time     // The next date to process.

--- a/job-service/iterators.go
+++ b/job-service/iterators.go
@@ -95,7 +95,7 @@ func NewHistoricalIterator(start time.Time, saver namedSaver) *HistoricalIterato
 		saver: saver,
 	}
 	// Attempt to load Date from previously saved data.
-	tmp := &DailyIterator{}
+	tmp := &HistoricalIterator{}
 	err := h.saver.Load(tmp)
 	if err == nil && !tmp.Date.IsZero() {
 		// Ignore load errors.

--- a/job-service/iterators_test.go
+++ b/job-service/iterators_test.go
@@ -99,7 +99,17 @@ func TestHistoricalIterator(t *testing.T) {
 			},
 		},
 		{
-			name:  "success-reload-with-alternate-start",
+			name:  "success-reload-continue",
+			start: time.Date(2019, time.July, 2, 0, 0, 0, 0, time.UTC),
+			saver: persistence.NewLocalNamedSaver(path.Join(dir, "success.json")),
+			want: []time.Time{
+				time.Date(2019, time.July, 2, 0, 0, 0, 0, time.UTC),
+				time.Date(2019, time.July, 3, 0, 0, 0, 0, time.UTC),
+				time.Date(2019, time.July, 4, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:  "success-reload-with-later-start",
 			start: time.Date(2020, time.June, 30, 0, 0, 0, 0, time.UTC),
 			saver: persistence.NewLocalNamedSaver(path.Join(dir, "success.json")),
 			want: []time.Time{

--- a/job-service/iterators_test.go
+++ b/job-service/iterators_test.go
@@ -1,0 +1,235 @@
+package job
+
+import (
+	"errors"
+	"path"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/m-lab/etl-gardener/persistence"
+	"github.com/m-lab/etl-gardener/tracker"
+)
+
+type noopSaver struct{}
+
+func (f *noopSaver) Save(v any) error {
+	return nil
+}
+func (f *noopSaver) Load(v any) error {
+	return nil
+}
+
+type failSaver struct{}
+
+func (f *failSaver) Save(v any) error {
+	return errors.New("save failed")
+}
+func (f *failSaver) Load(v any) error {
+	return errors.New("load failed")
+}
+
+func TestDailyIterator(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name    string
+		saver   namedSaver
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			// The first time we create the DailyIterator, the success.json will be empty, but it will be saved.
+			name:  "success-create",
+			saver: persistence.NewLocalNamedSaver(path.Join(dir, "success.json")),
+			want:  tracker.YesterdayDate(),
+		},
+		{
+			// The second time we create the DailyIterator, the success.json will successfully load a value.
+			name:  "success-reload",
+			saver: persistence.NewLocalNamedSaver(path.Join(dir, "success.json")),
+			want:  tracker.YesterdayDate(),
+		},
+		{
+			name:    "error",
+			saver:   &failSaver{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDailyIterator(0, tt.saver)
+
+			n, err := d.Next()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DailyIterator.Next returned error; got %v, wantErr %t", err, tt.wantErr)
+			}
+			if n != tt.want {
+				t.Errorf("DailyIterator.Next returned wrong date; got %q, want %q", n, tt.want)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			// Calling next again, should fail.
+			_, err = d.Next()
+			if err != ErrNoDateAvailable {
+				t.Errorf("DailyIterator.Next returned non-nil error; %v", err)
+			}
+		})
+	}
+}
+
+func TestHistoricalIterator(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		name    string
+		start   time.Time
+		saver   namedSaver
+		want    []time.Time
+		wantErr bool
+	}{
+		{
+			name:  "success",
+			start: time.Date(2019, time.June, 30, 0, 0, 0, 0, time.UTC),
+			saver: persistence.NewLocalNamedSaver(path.Join(dir, "success.json")),
+			want: []time.Time{
+				time.Date(2019, time.June, 30, 0, 0, 0, 0, time.UTC),
+				time.Date(2019, time.July, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2019, time.July, 2, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:  "success-reload-with-alternate-start",
+			start: time.Date(2020, time.June, 30, 0, 0, 0, 0, time.UTC),
+			saver: persistence.NewLocalNamedSaver(path.Join(dir, "success.json")),
+			want: []time.Time{
+				time.Date(2020, time.June, 30, 0, 0, 0, 0, time.UTC),
+				time.Date(2020, time.July, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2020, time.July, 2, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:  "success-restart-wrap",
+			start: time.Now().UTC().Add(-48 * time.Hour).Truncate(24 * time.Hour),
+			saver: &noopSaver{},
+			want: []time.Time{
+				time.Now().UTC().Add(-48 * time.Hour).Truncate(24 * time.Hour),
+				time.Now().UTC().Add(-24 * time.Hour).Truncate(24 * time.Hour),
+				time.Now().UTC().Add(-48 * time.Hour).Truncate(24 * time.Hour),
+			},
+		},
+		{
+			name:    "error-failsave",
+			start:   time.Date(2019, time.June, 30, 0, 0, 0, 0, time.UTC),
+			saver:   &failSaver{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewHistoricalIterator(tt.start, tt.saver)
+
+			times := []time.Time{}
+			for i := 0; i < 3; i++ {
+				n, err := h.Next()
+				if err != nil {
+					break
+				}
+				times = append(times, n)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(times, tt.want) {
+				t.Errorf("NewHistoricalIterator() = got %v, want %v", times, tt.want)
+			}
+		})
+	}
+}
+
+type incDateIterator struct {
+	Date time.Time
+}
+
+func (f *incDateIterator) Next() (time.Time, error) {
+	d := f.Date
+	f.Date = f.Date.AddDate(0, 0, 1)
+	return d, nil
+}
+
+type errAfter2DateIterator struct {
+	Date time.Time
+	i    int
+}
+
+func (f *errAfter2DateIterator) Next() (time.Time, error) {
+	d := f.Date
+	f.Date = f.Date.AddDate(0, 0, 1)
+	f.i++
+	if f.i > 2 {
+		return time.Time{}, ErrNoDateAvailable
+	}
+	return d, nil
+}
+
+func TestNewJobIterator(t *testing.T) {
+	type idOrErr struct {
+		ID  tracker.Key
+		err error
+	}
+	tests := []struct {
+		name    string
+		date    DateIterator
+		specs   []tracker.JobWithTarget
+		expect  []idOrErr
+		wantErr bool
+	}{
+		{
+			name: "success",
+			date: &incDateIterator{Date: time.Date(2020, time.July, 1, 0, 0, 0, 0, time.UTC)},
+			specs: []tracker.JobWithTarget{
+				{Job: tracker.Job{Bucket: "bucket1", Experiment: "exp1", Datatype: "dt1"}, DailyOnly: true},
+				{Job: tracker.Job{Bucket: "bucket2", Experiment: "exp2", Datatype: "dt2"}},
+			},
+			expect: []idOrErr{
+				{ID: tracker.Key("bucket1/exp1/dt1/20200701")},
+				{ID: tracker.Key("bucket2/exp2/dt2/20200701")},
+				{ID: tracker.Key("bucket1/exp1/dt1/20200702")},
+				{ID: tracker.Key("bucket2/exp2/dt2/20200702")},
+				{ID: tracker.Key("bucket1/exp1/dt1/20200703")},
+				{ID: tracker.Key("bucket2/exp2/dt2/20200703")},
+			},
+		},
+		{
+			name: "with-error",
+			date: &errAfter2DateIterator{Date: time.Date(2020, time.July, 1, 0, 0, 0, 0, time.UTC)},
+			specs: []tracker.JobWithTarget{
+				{Job: tracker.Job{Bucket: "bucket1", Experiment: "exp1", Datatype: "dt1"}, DailyOnly: true},
+			},
+			expect: []idOrErr{
+				{ID: tracker.Key("bucket1/exp1/dt1/20200701")},
+				{ID: tracker.Key("bucket1/exp1/dt1/20200702")},
+				{err: ErrNoDateAvailable},
+				{err: ErrNoDateAvailable},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := NewJobIterator(tt.date, tt.specs)
+
+			if j.Len() != len(tt.specs) {
+				t.Errorf("JobIterator.Len() returned wrong length; got %d, want %d", j.Len(), len(tt.specs))
+			}
+			for i := 0; i < len(tt.expect); i++ {
+				jt, err := j.Next()
+				if jt != nil && jt.ID != tt.expect[i].ID {
+					t.Errorf("JobIterator.Next() ID is not expected; got %q, want %q", jt.ID, tt.expect[i].ID)
+				}
+				if err != tt.expect[i].err {
+					t.Errorf("JobIterator.Next() error is not expected; got %v, want %t", err, tt.expect[i].err)
+				}
+			}
+		})
+	}
+}

--- a/job-service/job-service_test.go
+++ b/job-service/job-service_test.go
@@ -130,7 +130,7 @@ func TestResume(t *testing.T) {
 	must(t, err)
 	j := svc.NextJob(ctx)
 	if j.Job.Date != last.Date {
-		t.Error(j, last)
+		t.Errorf("NextJob() Job date does not match; got %s, want %s", j.Job.Date, last.Date)
 	}
 }
 


### PR DESCRIPTION
This change adds three new types to eventually replace the current implementation of the job-service NextJob logic.

This change adds two types that implement a `DateIterator` interface:
* DailyIterator - for generating a sequence of dates for processing "yesterday".
* HistoricalIterator - for generating a sequence of dates for historical processing.

This change adds a generic `JobIterator` that can accept either a `DailyIterator` or `HistoricalIterator`. Ultimately, the job service will include two JobIterators using one of each `DateIterator`.

Notable about this implementation:
* Previously (currently) the NextJob logic follows a persistence cycle below.  If restarted mid-processing, the next date is reloaded before all data is processed, potentially skipping some data.
    * load (on restart)
    * update, filter, save (for next job date).
* The JobIterator here follows a persistence cycle below.  If restarted mid-processing, the current date is reloaded potentially reprocessing some data, but none is skipped.
    * load (on restart)
    * filter, save, update (for next job date).

Part of:
* https://github.com/m-lab/etl-gardener/issues/349

Tested only with unit tests. This change adds a new interface before using it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/395)
<!-- Reviewable:end -->
