### PR TITLE
Initialize jobs total metric on startup.

### DIFF
--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -151,6 +151,8 @@ func InitTracker(
 	if saverV1 != nil && saveInterval > 0 {
 		go t.saveEvery(ctx, saveInterval)
 	}
+	// Initialize the jobs total metric on startup, to allow for longer processing times and fast alerts.
+	metrics.JobsTotal.WithLabelValues("", "", "", "starting").Inc()
 	return &t, nil
 }
 

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -152,7 +152,7 @@ func InitTracker(
 		go t.saveEvery(ctx, saveInterval)
 	}
 	// Initialize the jobs total metric on startup, to allow for longer processing times and fast alerts.
-	metrics.JobsTotal.WithLabelValues("", "", "", "starting").Inc()
+	metrics.JobsTotal.WithLabelValues("", "", "", "starting").Add(0)
 	return &t, nil
 }
 


### PR DESCRIPTION
Recently, we have observed alerts like https://github.com/m-lab/dev-tracker/issues/724 due to longer datatype processing times and existing short alert wait times. We want to know quickly whether the gardener service is down. So, this change initializes the `gardener_jobs_total` metric at startup so that it exists without interfering with existing alerts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/402)
<!-- Reviewable:end -->
