### PR TITLE
Remove remaining references to datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,40 +93,24 @@ the `./output` directory.
 Some of the gardener packages depend on complex, third-party services. To
 accommodate these the gardener unit tests are split into three categories:
 
-* Standard unit tests
+* Run standard unit tests
 
   ```sh
   go test -v ./...
   ```
 
-* Integration unit tests
+* Run integration unit tests
 
-  Many integration tests depend on datastore, so be sure the datastore emulator
-  is installed:
-
-  ```sh
-  gcloud components install beta
-  gcloud components install cloud-datastore-emulator
-  ```
-
-  And, then start the emulator, and set environment variables to make it
-  discoverable:
-
-  ```sh
-  gcloud beta emulators datastore start --project mlab-testing --no-store-on-disk &
-  sleep 2
-  $(gcloud beta emulators datastore env-init)
-  ```
-
-  Finally, run the integration tests, and optionally unset the datastore
-  environment variables:
+  Integration unit tests depend on state in the mlab-testing GCP project, and
+  require credentials to access this project. Members of M-Lab staff should be
+  able to use their existing cloud credentials and application default
+  credentials.
 
   ```sh
   go test -v -tags=integration -coverprofile=_integration.cov ./...
-  $(gcloud beta emulators datastore env-unset)
   ```
 
-* Race unit tests
+* Run race unit tests
 
   ```sh
   go test -race -v ./...

--- a/integration-testing.sh
+++ b/integration-testing.sh
@@ -29,24 +29,4 @@ pushd testfiles
 ./sync.sh
 popd
 
-# Remove boto config; recommended for datastore emulator.
-rm -f /etc/boto.cfg || :
-
-# Start datastore emulator.
-gcloud beta emulators datastore start --no-store-on-disk &
-
-t1=$( date +%s )
-until nc -z localhost 8081 ; do
-  sleep 1
-  t2=$( date +%s )
-  # Allow up to a minute for emulator to start up.
-  if [[ $t2 -gt $(( $t1 + 60 )) ]] ; then
-    echo "ERROR: failed to start or detect datastore emulator"
-    break
-  fi
-done
-$(gcloud beta emulators datastore env-init)
 go test -v -tags=integration -coverprofile=_integration.cov ./...
-
-# Shutdown datastore emulator.
-kill %1

--- a/tracker/README.md
+++ b/tracker/README.md
@@ -1,18 +1,14 @@
 # Gardener Tracker
 
 The Tracker keeps track of the state of all parsing activities, persists
-the data in datastore, and recovers the system state from datastore on
+current state to storage, and recovers the system state from storage on
 startup or recovery.
 
 The tracker is used by other components of Gardener to decide:
 
 1. what jobs to do next,
-1. when a job has failed and needs to be recovered,
-1. when postprocessing actions should be initiated.
+2. when a job has failed and needs to be recovered,
+3. when postprocessing actions should be initiated.
 
 The tracker provides an API to the other Gardener components to answer
 questions about the system state.
-
-1. a
-1. b
-1. c


### PR DESCRIPTION
This change removes remaining references to datastore from the READMEs and simplifies the integration-testing.sh setup.

Part of:
* https://github.com/m-lab/etl/issues/1084

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/403)
<!-- Reviewable:end -->
