### PR TITLE
Remove legacy URL and v1 job logic, update tests for v2 resources

### DIFF
--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -2,11 +2,8 @@ package tracker
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"log"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/m-lab/go/logx"
@@ -16,42 +13,6 @@ var (
 	MsgNoJobFound = "No job found. Try again."
 	MsgJobExists  = "Job already exists. Try again."
 )
-
-// UpdateURL makes an update request URL.
-// TODO(soltesz): move client functions to client package.
-func UpdateURL(base url.URL, job Job, state State, detail string) *url.URL {
-	base.Path += "update"
-	params := make(url.Values, 3)
-	params.Add("job", string(job.Marshal()))
-	params.Add("state", string(state))
-	params.Add("detail", detail)
-
-	base.RawQuery = params.Encode()
-	return &base
-}
-
-// HeartbeatURL makes an update request URL.
-// TODO(soltesz): move client functions to client package.
-func HeartbeatURL(base url.URL, job Job) *url.URL {
-	base.Path += "heartbeat"
-	params := make(url.Values, 3)
-	params.Add("job", string(job.Marshal()))
-
-	base.RawQuery = params.Encode()
-	return &base
-}
-
-// ErrorURL makes an update request URL.
-// TODO(soltesz): move client functions to client package.
-func ErrorURL(base url.URL, job Job, errString string) *url.URL {
-	base.Path += "error"
-	params := make(url.Values, 3)
-	params.Add("job", string(job.Marshal()))
-	params.Add("error", errString)
-
-	base.RawQuery = params.Encode()
-	return &base
-}
 
 type JobService interface {
 	NextJob(ctx context.Context) *JobWithTarget
@@ -68,34 +29,6 @@ func NewHandler(tr *Tracker, js JobService) *Handler {
 	return &Handler{tracker: tr, jobservice: js}
 }
 
-func getJob(jobString string) (Job, error) {
-	var job Job
-	if jobString == "" {
-		return job, errors.New("Empty job")
-	}
-	err := json.Unmarshal([]byte(jobString), &job)
-	return job, err
-}
-
-func getID(req *http.Request) (Key, error) {
-	// Prefer the /v2 "id" parameter.
-	id := req.Form.Get("id")
-	if id != "" {
-		return Key(id), nil
-	}
-
-	// Fallback to the "job" parameter used by the original /job api.
-	j := req.Form.Get("job")
-	if j == "" {
-		return "", errors.New("no job id found")
-	}
-	job, err := getJob(j)
-	if err != nil {
-		return "", err
-	}
-	return job.Key(), nil
-}
-
 func (h *Handler) heartbeat(resp http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodPost {
 		resp.WriteHeader(http.StatusMethodNotAllowed)
@@ -105,8 +38,8 @@ func (h *Handler) heartbeat(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	id, err := getID(req)
-	if err != nil {
+	id := Key(req.Form.Get("id"))
+	if id == "" {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
 		return
 	}
@@ -127,8 +60,8 @@ func (h *Handler) update(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	id, err := getID(req)
-	if err != nil {
+	id := Key(req.Form.Get("id"))
+	if id == "" {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
 		return
 	}
@@ -156,9 +89,9 @@ func (h *Handler) errorFunc(resp http.ResponseWriter, req *http.Request) {
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	id := Key(req.Form.Get("id"))
 	jobErr := req.Form.Get("error")
-	id, err := getID(req)
-	if err != nil {
+	if id == "" {
 		resp.WriteHeader(http.StatusUnprocessableEntity)
 		return
 	}
@@ -199,20 +132,6 @@ func (h *Handler) nextJob(resp http.ResponseWriter, req *http.Request) *JobWithT
 	return jt
 }
 
-// nextJobV1 returns the next JobWithTarget and returns the tracker.Job to the requesting client.
-func (h *Handler) nextJobV1(resp http.ResponseWriter, req *http.Request) {
-	jt := h.nextJob(resp, req)
-	if jt == nil {
-		return
-	}
-	log.Printf("Dispatching %s\n", jt.Job)
-	_, err := resp.Write(jt.Job.Marshal())
-	if err != nil {
-		log.Println(err)
-		return
-	}
-}
-
 // nextJobV2 returns the next JobWithTarget to the requesting client.
 func (h *Handler) nextJobV2(resp http.ResponseWriter, req *http.Request) {
 	jt := h.nextJob(resp, req)
@@ -229,11 +148,6 @@ func (h *Handler) nextJobV2(resp http.ResponseWriter, req *http.Request) {
 
 // Register registers the handlers on the server.
 func (h *Handler) Register(mux *http.ServeMux) {
-	mux.HandleFunc("/heartbeat", h.heartbeat)
-	mux.HandleFunc("/update", h.update)
-	mux.HandleFunc("/error", h.errorFunc)
-	mux.HandleFunc("/job", h.nextJobV1)
-
 	mux.HandleFunc("/v2/job/heartbeat", h.heartbeat)
 	mux.HandleFunc("/v2/job/update", h.update)
 	mux.HandleFunc("/v2/job/error", h.errorFunc)

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -106,14 +106,6 @@ func (j Job) Path() string {
 		j.Bucket, j.Experiment, j.Date.Format(timex.YYYYMMDDWithSlash))
 }
 
-// Marshal marshals the Job to json. If the Job type ever includes fields that
-// cannot be marshalled, then Marshal will panic.
-func (j Job) Marshal() []byte {
-	b, err := json.Marshal(j)
-	rtx.PanicOnError(err, "failed to marshal Job: %s", j)
-	return b
-}
-
 func (j Job) String() string {
 	return fmt.Sprintf("%s:%s/%s", j.Date.Format(timex.YYYYMMDD), j.Experiment, j.Datatype)
 }

--- a/tracker/job.go
+++ b/tracker/job.go
@@ -357,14 +357,6 @@ func (s *Status) NewState(state State) StateInfo {
 	return old
 }
 
-func (s Status) String() string {
-	last := s.LastStateInfo()
-	return fmt.Sprintf("%s %s (%s)",
-		s.DetailTime().Format("01/02~15:04:05"),
-		last.State,
-		last.Detail)
-}
-
 func (s *Status) isDone() bool {
 	return s.LastStateInfo().State == Complete
 }


### PR DESCRIPTION
This change removes the v1 client handler "*URL" functions in favor of the v2 client operations that provide the same functionality. This also updates unit tests to preserve and improve unit test coverage of the remaining handlers.

Part of:
* https://github.com/m-lab/etl/issues/1084

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/406)
<!-- Reviewable:end -->
