### PR TITLE
Fix NextJob panic

### DIFF
--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -114,6 +114,7 @@ func (h *Handler) nextJob(resp http.ResponseWriter, req *http.Request) *JobWithT
 	}
 	jt := h.jobservice.NextJob(req.Context())
 	if jt == nil {
+		resp.WriteHeader(http.StatusInternalServerError)
 		return nil
 	}
 

--- a/tracker/handler.go
+++ b/tracker/handler.go
@@ -113,6 +113,9 @@ func (h *Handler) nextJob(resp http.ResponseWriter, req *http.Request) *JobWithT
 		return nil
 	}
 	jt := h.jobservice.NextJob(req.Context())
+	if jt == nil {
+		return nil
+	}
 
 	// Check for empty job (no job found with files)
 	if jt.Job.Date.Equal(time.Time{}) {

--- a/tracker/handler_test.go
+++ b/tracker/handler_test.go
@@ -31,6 +31,10 @@ type fakeJobService struct {
 }
 
 func (f *fakeJobService) NextJob(ctx context.Context) *tracker.JobWithTarget {
+	if f.calls >= len(f.jobs) {
+		// Return nil if there are no more jobs.
+		return nil
+	}
 	j := f.jobs[f.calls]
 	f.calls++
 	return &tracker.JobWithTarget{Job: j}
@@ -279,5 +283,8 @@ func TestNextJobV2Handler(t *testing.T) {
 	postAndExpect(t, &url, http.StatusInternalServerError)
 
 	// This one should fail because the fakeJobService returns a duplicate job.
+	postAndExpect(t, &url, http.StatusInternalServerError)
+
+	// Get nil result.
 	postAndExpect(t, &url, http.StatusInternalServerError)
 }


### PR DESCRIPTION
This change fixes a "panic on nil reference" in the job tracker handler.

The `JobService` can a return `nil` value when there are no jobs available to process (such as no historical data or daily only datatypes). The Tracker handler for `NextJob` failed to check for the nil case, which resulted in non-fatal panics. While the parser was resilient to these failures, the gardener should handle this case correctly.

Now, a client will receive an HTTP "Internal Server Error" for Next job requests that return `nil`. The parser remains resilient to this case.

```
2022/10/05 05:42:59 job-service.go:71: 20190110:ndt/ndt7 has no files archive-measurement-lab
2022/10/05 05:42:59 server.go:3197: http: panic serving 10.12.7.2:56470: runtime error: invalid memory address or nil pointer dereference
goroutine 164329685 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1825 +0xbf
panic({0xc0b580, 0x1361540})
        /usr/local/go/src/runtime/panic.go:844 +0x258
github.com/m-lab/etl-gardener/tracker.(*Handler).nextJob(0xc0000b5a28, {0xe613d0, 0xc000bc40e0}, 0xc000580600?)
        /go/src/github.com/m-lab/etl-gardener/tracker/handler.go:118 +0xc0
github.com/m-lab/etl-gardener/tracker.(*Handler).nextJobV2(0x0?, {0xe613d0, 0xc000bc40e0}, 0x4f8da9?)
        /go/src/github.com/m-lab/etl-gardener/tracker/handler.go:137 +0x3b
net/http.HandlerFunc.ServeHTTP(0x7fbc8ba37b18?, {0xe613d0?, 0xc000bc40e0?}, 0x40d5c5?)
        /usr/local/go/src/net/http/server.go:2084 +0x2f
net/http.(*ServeMux).ServeHTTP(0x0?, {0xe613d0, 0xc000bc40e0}, 0xc000616400)
        /usr/local/go/src/net/http/server.go:2462 +0x149
net/http.serverHandler.ServeHTTP({0xc0005034d0?}, {0xe613d0, 0xc000bc40e0}, 0xc000616400)
        /usr/local/go/src/net/http/server.go:2916 +0x43b
net/http.(*conn).serve(0xc0004b86e0, {0xe61d98, 0xc0004c5b60})
        /usr/local/go/src/net/http/server.go:1966 +0x5d7
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:3071 +0x4db
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/411)
<!-- Reviewable:end -->
