### PR TITLE
Set batch priority on dedup and join

### DIFF
--- a/cloud/bq/ops.go
+++ b/cloud/bq/ops.go
@@ -115,7 +115,8 @@ func (to TableOps) Dedup(ctx context.Context, dryRun bool) (bqiface.Job, error) 
 	}
 	qc := bqiface.QueryConfig{
 		QueryConfig: bigquery.QueryConfig{
-			Q: qs,
+			Q:      qs,
+			DryRun: dryRun,
 			// Perform Join as a batch job to avoid quota limits for interactive jobs.
 			Priority: bigquery.BatchPriority,
 		},

--- a/cloud/bq/ops.go
+++ b/cloud/bq/ops.go
@@ -113,10 +113,14 @@ func (to TableOps) Dedup(ctx context.Context, dryRun bool) (bqiface.Job, error) 
 	if q == nil {
 		return nil, dataset.ErrNilQuery
 	}
-	if dryRun {
-		qc := bqiface.QueryConfig{QueryConfig: bigquery.QueryConfig{DryRun: dryRun, Q: qs}}
-		q.SetQueryConfig(qc)
+	qc := bqiface.QueryConfig{
+		QueryConfig: bigquery.QueryConfig{
+			Q: qs,
+			// Perform Join as a batch job to avoid quota limits for interactive jobs.
+			Priority: bigquery.BatchPriority,
+		},
 	}
+	q.SetQueryConfig(qc)
 	return q.Run(ctx)
 }
 
@@ -281,6 +285,8 @@ func (to TableOps) Join(ctx context.Context, dryRun bool) (bqiface.Job, error) {
 				Field:                  "date",
 				RequirePartitionFilter: true,
 			},
+			// Perform Join as a batch job to avoid quota limits for interactive jobs.
+			Priority: bigquery.BatchPriority,
 		},
 		Dst: dest,
 	}

--- a/cloud/bq/ops.go
+++ b/cloud/bq/ops.go
@@ -117,7 +117,7 @@ func (to TableOps) Dedup(ctx context.Context, dryRun bool) (bqiface.Job, error) 
 		QueryConfig: bigquery.QueryConfig{
 			Q:      qs,
 			DryRun: dryRun,
-			// Perform Join as a batch job to avoid quota limits for interactive jobs.
+			// Schedule as batch job to avoid quota limits for interactive jobs.
 			Priority: bigquery.BatchPriority,
 		},
 	}
@@ -286,7 +286,7 @@ func (to TableOps) Join(ctx context.Context, dryRun bool) (bqiface.Job, error) {
 				Field:                  "date",
 				RequirePartitionFilter: true,
 			},
-			// Perform Join as a batch job to avoid quota limits for interactive jobs.
+			// Schedule as batch job to avoid quota limits for interactive jobs.
 			Priority: bigquery.BatchPriority,
 		},
 		Dst: dest,

--- a/cloud/bq/ops_test.go
+++ b/cloud/bq/ops_test.go
@@ -116,7 +116,7 @@ func TestValidateQueries(t *testing.T) {
 				t.Fatalf("TestValidateQueries() Join job config failed: %v", err)
 			}
 			if cfg.(*bigquery.QueryConfig).Priority != bigquery.BatchPriority {
-				t.Errorf("TestValidateQueries() Dedup job priority is not Batch: %v", bigquery.BatchPriority)
+				t.Errorf("TestValidateQueries() Join job priority is not Batch: %v", bigquery.BatchPriority)
 			}
 		})
 	}

--- a/cloud/bq/ops_test.go
+++ b/cloud/bq/ops_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/m-lab/etl-gardener/cloud/bq"
 	"github.com/m-lab/etl-gardener/ops"
 	"github.com/m-lab/etl-gardener/tracker"
@@ -90,6 +91,13 @@ func TestValidateQueries(t *testing.T) {
 			if status.Err() != nil {
 				t.Fatal(t.Name(), err, bq.DedupQuery(*qp))
 			}
+			cfg, err := j.Config()
+			if err != nil {
+				t.Fatalf("TestValidateQueries() Dedup job Config failed: %v", err)
+			}
+			if cfg.(*bigquery.QueryConfig).Priority != bigquery.BatchPriority {
+				t.Errorf("TestValidateQueries() Dedup job priority is not Batch: %v", bigquery.BatchPriority)
+			}
 
 			if !ops.JoinableDatatypes[qp.Job.Datatype] {
 				return
@@ -102,6 +110,13 @@ func TestValidateQueries(t *testing.T) {
 			status = j.LastStatus()
 			if status.Err() != nil {
 				t.Fatal(t.Name(), err, bq.JoinQuery(*qp))
+			}
+			cfg, err = j.Config()
+			if err != nil {
+				t.Fatalf("TestValidateQueries() Join job config failed: %v", err)
+			}
+			if cfg.(*bigquery.QueryConfig).Priority != bigquery.BatchPriority {
+				t.Errorf("TestValidateQueries() Dedup job priority is not Batch: %v", bigquery.BatchPriority)
 			}
 		})
 	}


### PR DESCRIPTION
This change adds `QueryConfig.Priority` for Dedup and Join jobs created by gardener using "Batch" priority. This change should avoid quota limits for interactive jobs recently seen in https://github.com/m-lab/etl-gardener/issues/410.

Fixes:
* https://github.com/m-lab/etl-gardener/issues/410

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/412)
<!-- Reviewable:end -->
