### PR TITLE
Change datatypes to daily_only to accelerate ndt reprocessing

### DIFF
--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -18,13 +18,12 @@ CLUSTER=${CLOUDSDK_CONTAINER_CLUSTER:?Please provide cluster name: $USAGE}
 DATE_SKIP=${DATE_SKIP:-"0"}  # Number of dates to skip between each processed date (for sandbox).
 TASK_FILE_SKIP=${TASK_FILE_SKIP:-"0"}  # Number of files to skip between each processed file (for sandbox).
 
-# Use sandbox in sandbox, staging in staging, and use measurement-lab in oti.
+# Use sandbox in sandbox, measurement-lab in staging and oti.
 SOURCE_PROJECT=${PROJECT_ID/mlab-oti/measurement-lab}
+SOURCE_PROJECT=${SOURCE_PROJECT/mlab-staging/measurement-lab}
 sed -i \
     -e 's/{{ANNOTATION_SOURCE_PROJECT}}/'${SOURCE_PROJECT}'/g' \
     config/config.yml
-# Use sandbox in sandbox, measurement-lab in staging and oti.
-SOURCE_PROJECT=${SOURCE_PROJECT/mlab-staging/measurement-lab}
 sed -i \
     -e 's/{{NDT_SOURCE_PROJECT}}/'${SOURCE_PROJECT}'/g' \
     config/config.yml

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 ---
-start_date: 2020-11-01 # Earliest date for v2 platform datatypes.
+start_date: 2022-11-01 # Earliest date for v2 platform datatypes.
 tracker:
   timeout: 5h
 monitor:

--- a/config/config.yml
+++ b/config/config.yml
@@ -10,7 +10,6 @@ sources:
   experiment: ndt
   datatype: annotation
   target: tmp_ndt.annotation
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt5

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 ---
-start_date: 2015-11-19 # Earliest date for v2 platform datatypes.
+start_date: 2020-11-01 # Earliest date for v2 platform datatypes.
 tracker:
   timeout: 5h
 monitor:
@@ -10,6 +10,7 @@ sources:
   experiment: ndt
   datatype: annotation
   target: tmp_ndt.annotation
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt5
@@ -27,15 +28,19 @@ sources:
   experiment: ndt
   datatype: hopannotation1
   target: tmp_ndt.hopannotation1
+  daily_only: true
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: scamper1
   target: tmp_ndt.scamper1
+  daily_only: true
 - bucket: archive-measurement-lab
   experiment: utilization
   datatype: switch
   target: tmp_utilization.switch
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: tcpinfo
   target: tmp_ndt.tcpinfo
+  daily_only: true


### PR DESCRIPTION
This change is meant to accelerate the historical reprocessing of the NDT data during the "unsafe" UUID incident period of 11-08 to 11-30. This change updates all other datatypes to "daily_only" meaning that the only historical processing should be for NDT. This also updates the start date to 2022-11-01 which should further accelerate the reprocessing.

This change depends on fixes in:
* https://github.com/m-lab/etl/pull/1107

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/414)
<!-- Reviewable:end -->
