### PR TITLE
Restore gardener configuration

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 ---
-start_date: 2022-11-01 # Earliest date for v2 platform datatypes.
+start_date: 2015-11-19 # Earliest date for v2 platform datatypes.
 tracker:
   timeout: 5h
 monitor:
@@ -27,19 +27,15 @@ sources:
   experiment: ndt
   datatype: hopannotation1
   target: tmp_ndt.hopannotation1
-  daily_only: true
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: scamper1
   target: tmp_ndt.scamper1
-  daily_only: true
 - bucket: archive-measurement-lab
   experiment: utilization
   datatype: switch
   target: tmp_utilization.switch
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: tcpinfo
   target: tmp_ndt.tcpinfo
-  daily_only: true


### PR DESCRIPTION
This change restores the standard gardener configuration. This effectively reverts the changes from https://github.com/m-lab/etl-gardener/pull/414 by restoring the start date and removing the daily only configurations for all non-pcap datatypes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/415)
<!-- Reviewable:end -->
