### PR TITLE
Reprocess recent data from 2022

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,7 @@
 ---
-start_date: 2015-11-19 # Earliest date for v2 platform datatypes.
+# start_date: 2015-11-19 # Earliest date for v2 platform datatypes.
+# TODO(soltesz): Restore original start_date after reprocessing 2022 is complete.
+start_date: 2022-08-01
 tracker:
   timeout: 5h
 monitor:
@@ -14,6 +16,7 @@ sources:
   experiment: ndt
   datatype: ndt5
   target: tmp_ndt.ndt5
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt7
@@ -27,15 +30,19 @@ sources:
   experiment: ndt
   datatype: hopannotation1
   target: tmp_ndt.hopannotation1
+  daily_only: true
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: scamper1
   target: tmp_ndt.scamper1
+  daily_only: true
 - bucket: archive-measurement-lab
   experiment: utilization
   datatype: switch
   target: tmp_utilization.switch
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: tcpinfo
   target: tmp_ndt.tcpinfo
+  daily_only: true


### PR DESCRIPTION
This change updates the start date for gardener to reprocess recent data starting form 2022-08. All other data types are configured to daily_only so that the ndt7 data can be reprocessed more quickly. This change will be reverted once reprocessing is completed.

Part of:
* https://github.com/m-lab/dev-tracker/issues/750 

FYI: @laiyi-ohlsen

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/416)
<!-- Reviewable:end -->
