### PR TITLE
Revert "Reprocess recent data from 2022"

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,7 +1,5 @@
 ---
-# start_date: 2015-11-19 # Earliest date for v2 platform datatypes.
-# TODO(soltesz): Restore original start_date after reprocessing 2022 is complete.
-start_date: 2022-08-01
+start_date: 2015-11-19 # Earliest date for v2 platform datatypes.
 tracker:
   timeout: 5h
 monitor:
@@ -16,7 +14,6 @@ sources:
   experiment: ndt
   datatype: ndt5
   target: tmp_ndt.ndt5
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt7
@@ -30,19 +27,15 @@ sources:
   experiment: ndt
   datatype: hopannotation1
   target: tmp_ndt.hopannotation1
-  daily_only: true
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: scamper1
   target: tmp_ndt.scamper1
-  daily_only: true
 - bucket: archive-measurement-lab
   experiment: utilization
   datatype: switch
   target: tmp_utilization.switch
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: tcpinfo
   target: tmp_ndt.tcpinfo
-  daily_only: true


### PR DESCRIPTION
Reverts m-lab/etl-gardener#416

This change restores the default configuration for historical processing by Gardener.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/417)
<!-- Reviewable:end -->
