### PR TITLE
Add configuration for parsing Wehe data

### DIFF
--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -18,10 +18,9 @@ CLUSTER=${CLOUDSDK_CONTAINER_CLUSTER:?Please provide cluster name: $USAGE}
 DATE_SKIP=${DATE_SKIP:-"0"}  # Number of dates to skip between each processed date (for sandbox).
 TASK_FILE_SKIP=${TASK_FILE_SKIP:-"0"}  # Number of files to skip between each processed file (for sandbox).
 
-# Use sandbox in sandbox, staging in staging, measurement-lab in oti.
+# Use sandbox in sandbox, measurement-lab in staging & oti.
 SOURCE_PROJECT=${PROJECT_ID/mlab-oti/measurement-lab}
-# TODO(soltesz): restore or remove.
-#SOURCE_PROJECT=${SOURCE_PROJECT/mlab-staging/measurement-lab}
+SOURCE_PROJECT=${SOURCE_PROJECT/mlab-staging/measurement-lab}
 sed -i \
     -e 's/{{ANNOTATION_SOURCE_PROJECT}}/'${SOURCE_PROJECT}'/g' \
     config/config.yml

--- a/config/config.yml
+++ b/config/config.yml
@@ -74,14 +74,14 @@ sources:
   target_datasets:
     tmp: tmp_wehe
     raw: raw_wehe
-  daily_only: true
+#  daily_only: true
 - bucket: archive-mlab-sandbox
   experiment: wehe
   datatype: hopannotation2
   target_datasets:
     tmp: tmp_wehe
     raw: raw_wehe
-  daily_only: true
+#  daily_only: true
 - bucket: archive-mlab-sandbox
   experiment: wehe
   datatype: scamper1
@@ -89,4 +89,4 @@ sources:
     tmp: tmp_wehe
     raw: raw_wehe
     join: wehe
-  daily_only: true
+#  daily_only: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -6,6 +6,7 @@ monitor:
   polling_interval: 1m
 sources:
 # NOTE: It now matters what order these are in.
+## NDT
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: ndt
   datatype: annotation2
@@ -65,4 +66,27 @@ sources:
     tmp: tmp_ndt
     raw: raw_ndt
     join: ndt
+  daily_only: true
+## WEHE
+- bucket: archive-mlab-sandbox
+  experiment: wehe
+  datatype: annotation2
+  target_datasets:
+    tmp: tmp_wehe
+    raw: raw_wehe
+  daily_only: true
+- bucket: archive-mlab-sandbox
+  experiment: wehe
+  datatype: hopannotation2
+  target_datasets:
+    tmp: tmp_wehe
+    raw: raw_wehe
+  daily_only: true
+- bucket: archive-mlab-sandbox
+  experiment: wehe
+  datatype: scamper1
+  target_datasets:
+    tmp: tmp_wehe
+    raw: raw_wehe
+    join: wehe
   daily_only: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -68,25 +68,25 @@ sources:
     join: ndt
   daily_only: true
 ## WEHE
-- bucket: archive-mlab-sandbox
+- bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: wehe
   datatype: annotation2
   target_datasets:
     tmp: tmp_wehe
     raw: raw_wehe
-#  daily_only: true
-- bucket: archive-mlab-sandbox
+  daily_only: true
+- bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: wehe
   datatype: hopannotation2
   target_datasets:
     tmp: tmp_wehe
     raw: raw_wehe
-#  daily_only: true
-- bucket: archive-mlab-sandbox
+  daily_only: true
+- bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: wehe
   datatype: scamper1
   target_datasets:
     tmp: tmp_wehe
     raw: raw_wehe
     join: wehe
-#  daily_only: true
+  daily_only: true


### PR DESCRIPTION
This change adds the scamper1 and annotation datatypes to the daily parsing job for Wehe.

Note: I needed to create the datasets manually, and updated `m-lab/etl/cmd/update-schema` to reference wehe rather than ndt. Ultimately, the update-schema command should be moved to the etl-gardener repo and it's functionality replaced. Similar steps will be necessary in mlab-staging and mlab-oti, performed by the m-lab/etl repo deployment.

```sh
./update-schema -project mlab-sandbox -experiment wehe -datatype scamper1
./update-schema -project mlab-sandbox -experiment wehe -datatype annotation2
./update-schema -project mlab-sandbox -experiment wehe -datatype hopannotation2
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/421)
<!-- Reviewable:end -->
