### PR TITLE
Enable historical processing of annotation & ndt data

### DIFF
--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -18,16 +18,14 @@ CLUSTER=${CLOUDSDK_CONTAINER_CLUSTER:?Please provide cluster name: $USAGE}
 DATE_SKIP=${DATE_SKIP:-"0"}  # Number of dates to skip between each processed date (for sandbox).
 TASK_FILE_SKIP=${TASK_FILE_SKIP:-"0"}  # Number of files to skip between each processed file (for sandbox).
 
-# Source sandbox in sandbox.
-# Source annotations from staging in staging.
-# Source ndt from measurement-lab in staging & oti.
-ANNOTATION_SOURCE_PROJECT=${PROJECT_ID/mlab-oti/measurement-lab}
-NDT_SOURCE_PROJECT=${ANNOTATION_SOURCE_PROJECT/mlab-staging/measurement-lab}
+# Use sandbox in sandbox, measurement-lab in staging & oti.
+SOURCE_PROJECT=${PROJECT_ID/mlab-oti/measurement-lab}
+SOURCE_PROJECT=${SOURCE_PROJECT/mlab-staging/measurement-lab}
 sed -i \
-    -e 's/{{ANNOTATION_SOURCE_PROJECT}}/'${ANNOTATION_SOURCE_PROJECT}'/g' \
+    -e 's/{{ANNOTATION_SOURCE_PROJECT}}/'${SOURCE_PROJECT}'/g' \
     config/config.yml
 sed -i \
-    -e 's/{{NDT_SOURCE_PROJECT}}/'${NDT_SOURCE_PROJECT}'/g' \
+    -e 's/{{NDT_SOURCE_PROJECT}}/'${SOURCE_PROJECT}'/g' \
     config/config.yml
 
 # Create the configmap

--- a/apply-cluster.sh
+++ b/apply-cluster.sh
@@ -18,14 +18,16 @@ CLUSTER=${CLOUDSDK_CONTAINER_CLUSTER:?Please provide cluster name: $USAGE}
 DATE_SKIP=${DATE_SKIP:-"0"}  # Number of dates to skip between each processed date (for sandbox).
 TASK_FILE_SKIP=${TASK_FILE_SKIP:-"0"}  # Number of files to skip between each processed file (for sandbox).
 
-# Use sandbox in sandbox, measurement-lab in staging & oti.
-SOURCE_PROJECT=${PROJECT_ID/mlab-oti/measurement-lab}
-SOURCE_PROJECT=${SOURCE_PROJECT/mlab-staging/measurement-lab}
+# Source sandbox in sandbox.
+# Source annotations from staging in staging.
+# Source ndt from measurement-lab in staging & oti.
+ANNOTATION_SOURCE_PROJECT=${PROJECT_ID/mlab-oti/measurement-lab}
+NDT_SOURCE_PROJECT=${ANNOTATION_SOURCE_PROJECT/mlab-staging/measurement-lab}
 sed -i \
-    -e 's/{{ANNOTATION_SOURCE_PROJECT}}/'${SOURCE_PROJECT}'/g' \
+    -e 's/{{ANNOTATION_SOURCE_PROJECT}}/'${ANNOTATION_SOURCE_PROJECT}'/g' \
     config/config.yml
 sed -i \
-    -e 's/{{NDT_SOURCE_PROJECT}}/'${SOURCE_PROJECT}'/g' \
+    -e 's/{{NDT_SOURCE_PROJECT}}/'${NDT_SOURCE_PROJECT}'/g' \
     config/config.yml
 
 # Create the configmap

--- a/config/config.yml
+++ b/config/config.yml
@@ -13,7 +13,6 @@ sources:
   target_datasets:
     tmp: tmp_ndt
     raw: raw_ndt
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt5
@@ -21,7 +20,6 @@ sources:
     tmp: tmp_ndt
     raw: raw_ndt
     join: ndt
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt7
@@ -29,7 +27,6 @@ sources:
     tmp: tmp_ndt
     raw: raw_ndt
     join: ndt
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: pcap


### PR DESCRIPTION
After the successful run of the reannotator and renamer in production, and the transfer from the working bucket to the public archive, the historical processing of the corrected annotation2 data can being.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/423)
<!-- Reviewable:end -->
