### PR TITLE
Enable historical processing for other sidecar datatypes

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -48,14 +48,12 @@ sources:
     tmp: tmp_ndt
     raw: raw_ndt
     join: ndt
-  daily_only: true
 - bucket: archive-measurement-lab
   experiment: utilization
   datatype: switch
   target_datasets:
     tmp: tmp_utilization
     raw: raw_utilization
-  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: tcpinfo
@@ -63,7 +61,6 @@ sources:
     tmp: tmp_ndt
     raw: raw_ndt
     join: ndt
-  daily_only: true
 ## WEHE
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: wehe


### PR DESCRIPTION
This change enables historical reprocessing for the other ndt sidecar datatypes and the switch utilization data.

The ndt sidecar data will be joined with the newly corrected annotation2 data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/425)
<!-- Reviewable:end -->
