### PR TITLE
Enable historical processing for hopannotation2

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -40,7 +40,6 @@ sources:
   target_datasets:
     tmp: tmp_ndt
     raw: raw_ndt
-  daily_only: true
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: scamper1


### PR DESCRIPTION
After concluding the reannotation for hopannotation2 in production, this change will enable historical reprocessing of the complete hopannotation2 dataset.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/426)
<!-- Reviewable:end -->
