### PR TITLE
Add sidecar datatypes parsing to msak experiment

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -90,4 +90,3 @@ sources:
   target_datasets:
     tmp: tmp_msak
     raw: raw_msak
-  daily_only: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -109,7 +109,7 @@ sources:
     tmp: tmp_msak
     raw: raw_msak
   daily_only: true
-- bucket: archive-{{NDT_SOURCE_PROJECT}}
+- bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: msak
   datatype: tcpinfo
   target_datasets:

--- a/config/config.yml
+++ b/config/config.yml
@@ -83,3 +83,11 @@ sources:
     raw: raw_wehe
     join: wehe
   daily_only: true
+## MSAK
+- bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
+  experiment: msak
+  datatype: annotation2
+  target_datasets:
+    tmp: tmp_msak
+    raw: raw_msak
+  daily_only: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -109,3 +109,9 @@ sources:
     tmp: tmp_msak
     raw: raw_msak
   daily_only: true
+- bucket: archive-{{NDT_SOURCE_PROJECT}}
+  experiment: msak
+  datatype: tcpinfo
+  target_datasets:
+    tmp: tmp_msak
+    raw: raw_msak

--- a/config/config.yml
+++ b/config/config.yml
@@ -96,6 +96,7 @@ sources:
   target_datasets:
     tmp: tmp_msak
     raw: raw_msak
+    join: msak
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: msak
   datatype: hopannotation2
@@ -115,3 +116,4 @@ sources:
   target_datasets:
     tmp: tmp_msak
     raw: raw_msak
+    join: msak

--- a/config/config.yml
+++ b/config/config.yml
@@ -90,3 +90,22 @@ sources:
   target_datasets:
     tmp: tmp_msak
     raw: raw_msak
+- bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
+  experiment: msak
+  datatype: scamper1
+  target_datasets:
+    tmp: tmp_msak
+    raw: raw_msak
+- bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
+  experiment: msak
+  datatype: hopannotation2
+  target_datasets:
+    tmp: tmp_msak
+    raw: raw_msak
+- bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
+  experiment: msak
+  datatype: pcap
+  target_datasets:
+    tmp: tmp_msak
+    raw: raw_msak
+  daily_only: true


### PR DESCRIPTION
This PR enables parsing of data produced by msak's sidecar containers:
- scamper
- traceroute-caller
- uuid-annotator
- tcpinfo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/428)
<!-- Reviewable:end -->
