### PR TITLE
Update etl-gardener-universal.yml

### DIFF
--- a/k8s/data-pipeline/deployments/etl-gardener-universal.yml
+++ b/k8s/data-pipeline/deployments/etl-gardener-universal.yml
@@ -93,6 +93,6 @@ spec:
           name: gardener-config
 
       nodeSelector:
-        gardener-node: "true"
+        processor-node: "true"
 
 


### PR DESCRIPTION
This change updates the gardener configuration to use the `processor-node:true` node selector for multiple processor jobs other than just the gardener.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/435)
<!-- Reviewable:end -->
