### PR TITLE
Disable pipeline reprocessing

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -13,6 +13,7 @@ sources:
   target_datasets:
     tmp: tmp_ndt
     raw: raw_ndt
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt5
@@ -20,6 +21,7 @@ sources:
     tmp: tmp_ndt
     raw: raw_ndt
     join: ndt
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: ndt7
@@ -27,6 +29,7 @@ sources:
     tmp: tmp_ndt
     raw: raw_ndt
     join: ndt
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: pcap
@@ -40,6 +43,7 @@ sources:
   target_datasets:
     tmp: tmp_ndt
     raw: raw_ndt
+  daily_only: true
 - bucket: archive-measurement-lab
   experiment: ndt
   datatype: scamper1
@@ -47,12 +51,14 @@ sources:
     tmp: tmp_ndt
     raw: raw_ndt
     join: ndt
+  daily_only: true
 - bucket: archive-measurement-lab
   experiment: utilization
   datatype: switch
   target_datasets:
     tmp: tmp_utilization
     raw: raw_utilization
+  daily_only: true
 - bucket: archive-{{NDT_SOURCE_PROJECT}}
   experiment: ndt
   datatype: tcpinfo
@@ -60,6 +66,7 @@ sources:
     tmp: tmp_ndt
     raw: raw_ndt
     join: ndt
+  daily_only: true
 ## WEHE
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: wehe
@@ -90,6 +97,7 @@ sources:
   target_datasets:
     tmp: tmp_msak
     raw: raw_msak
+  daily_only: true
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: msak
   datatype: scamper1
@@ -97,12 +105,14 @@ sources:
     tmp: tmp_msak
     raw: raw_msak
     join: msak
+  daily_only: true
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: msak
   datatype: hopannotation2
   target_datasets:
     tmp: tmp_msak
     raw: raw_msak
+  daily_only: true
 - bucket: archive-{{ANNOTATION_SOURCE_PROJECT}}
   experiment: msak
   datatype: pcap
@@ -117,3 +127,4 @@ sources:
     tmp: tmp_msak
     raw: raw_msak
     join: msak
+  daily_only: true


### PR DESCRIPTION
As discussed at the summit, this PR disables the endless pipeline reprocessing by setting all data to `daily_only`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/etl-gardener/437)
<!-- Reviewable:end -->
